### PR TITLE
Fix test_sampler `default` schema

### DIFF
--- a/ldms/src/sampler/examples/test_sampler/test_sampler.c
+++ b/ldms/src/sampler/examples/test_sampler/test_sampler.c
@@ -327,6 +327,7 @@ static int create_metric_set(const char *schema_name, int push)
 			snprintf(metric_name, 127, "metric_%d", i);
 			metric = malloc(sizeof(*metric));
 			metric->name = strdup(metric_name);
+			metric->vtype = LDMS_V_U64;
 			metric->idx = ldms_schema_metric_add(schema, metric_name, LDMS_V_U64);
 			if (metric->idx < 0) {
 				rc = ENOMEM;


### PR DESCRIPTION
`test_sampler` default schema did not specify the metric type in its own
metric records. As a result, the type could be any number and the
`sample()` which should increment the value of the metric failed to do
so because of the invalid type. This patch specified the metric type and
the issue went away.