### PR TITLE
Add call to slurm_init() required for Slurm 20.11

### DIFF
--- a/ldms/src/sampler/spank/slurm_notifier.c
+++ b/ldms/src/sampler/spank/slurm_notifier.c
@@ -64,6 +64,7 @@
 #include <netinet/in.h>
 #include <semaphore.h>
 #include <pthread.h>
+#include <slurm/slurm.h>
 #include <slurm/spank.h>
 #include "ldms.h"
 #include <ovis_json/ovis_json.h>
@@ -842,6 +843,13 @@ static int _step_is_valid(spank_t sh, const char *func, int line)
 int slurm_spank_init(spank_t sh, int argc, char *argv[])
 {
 	jbuf_t jb;
+
+#if SLURM_VERSION_NUMBER >= SLURM_VERSION_NUM(20,11,0)
+        /* as of Slurm 20.11.1 slurm_init is required before a call to
+         * libslurm, e.g. slurm_debug2 */
+	slurm_init(NULL);
+#endif
+
 	if (spank_context() != S_CTX_REMOTE)
 		return ESPANK_SUCCESS;
 	if (!step_is_valid(sh))


### PR DESCRIPTION
Slurm 20.11 requires slurm_init() to be called before calling libslurm.  The `slurm_notifier` plugin uses a debug call from libslurm.  This caused us some issues with the notifier.  This patch adds the required call wrapped with an ifdef to ensure that it is called in versions 20.11 and later. It has been tested on a system here and works as intended.  Addresses #782 