### PR TITLE
Fix ldms_ls SIGSEGV at exit with OFED librdmacm

### DIFF
--- a/ldms/src/ldmsd/ldms_ls.c
+++ b/ldms/src/ldmsd/ldms_ls.c
@@ -1075,5 +1075,6 @@ done:
 	_t.tv_sec += 2;
 	sem_timedwait(&conn_sem, &_t);
 
+	ldms_xprt_term(1);
 	exit(0);
 }


### PR DESCRIPTION
`rdma_cma_fini()` is in `atexit` list in OFED librdmacm. At the end of
`ldms_ls`, `exit()` is called and subsequently `rdma_cma_fini()` and
`ibv_close_device()`. This raced with the zap_rdma thread as it was
also tearing down the endpoint used by `ldms_ls`.

To avoid the race, this patch adds a call to `ldms_xprt_term()` to
terminate all zap threads before `exit()` at the end of `ldms_ls`.