### PR TITLE
add man page for ldmsd_stream_publish and -r/-i options

### DIFF
--- a/ldms/src/ldmsd/test/Makefile.am
+++ b/ldms/src/ldmsd/test/Makefile.am
@@ -1,5 +1,6 @@
 sbin_PROGRAMS =
 pkglib_LTLIBRARIES =
+dist_man7_MANS=
 
 AM_LDFLAGS = @OVIS_LIB_ABS@
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
@@ -14,6 +15,7 @@ COMMON_LD_ADD = ../../core/libldms.la \
 sbin_PROGRAMS += ldmsd_stream_publish
 ldmsd_stream_publish_SOURCES = ldmsd_stream_publish.c
 ldmsd_stream_publish_LDADD = $(COMMON_LD_ADD)
+dist_man7_MANS += ldmsd_stream_publish.man
 
 sbin_PROGRAMS += ldmsd_stream_subscribe
 ldmsd_stream_subscribe_SOURCES = ldmsd_stream_subscribe.c

--- a/ldms/src/ldmsd/test/ldmsd_stream_publish.man
+++ b/ldms/src/ldmsd/test/ldmsd_stream_publish.man
@@ -1,0 +1,111 @@
+.\" Manpage for ldmsd_stream_publish
+.\" Contact ovis-help@ca.sandia.gov to correct errors or typos.
+.TH man 7 "21 Aug 2021" "v4" "LDMS executable utility ldmsd_streams_publish man page"
+
+.SH NAME
+ldmsd_stream_publish - man page for the LDMS ldmsd_stream_publish executable utility
+
+.SH SYNOPSIS
+At the command line:
+ldmsd_stream_publish [args]
+
+.SH DESCRIPTION
+The ldmsd_stream_publish executable publishes to the ldmsd_streams interface of a running ldms daemon.
+The hello_publisher takes a file as input and publishes it either in bulk or line by line.
+It reuses the connection for all the messages
+
+.SH COMMAND LINE SYNTAX
+
+.TP
+ldmsd_sstream_publish -x <xprt> -h <host> -p <port> -s <stream-name> -a <auth> -A <auth-opt> -t <data-format>  -f <file> [-l]
+.br
+.RS
+.TP
+-x <xprt>
+.br
+transport of the ldmsd to which to connect.
+.TP
+-p <port>
+.br
+port of the ldmsd to which to connect.
+.TP
+-a <auth>
+.br
+auth to connect to the ldmsd
+.TP
+-A <auth-opt>
+.br
+auth-opts to connect to the ldmsd
+.TP
+-s <stream-name>
+.br
+Name of the stream (this will be used for subscribing)
+.TP
+-t <data-format>
+.br
+Optional data-format. Either 'string' or 'json'. Default is string.
+.TP
+-l
+.br
+Optional line mode. Publishes file one line at a time as separate publish calls
+.TP
+-f <file>
+.br
+File that is published. If not specified, input is copied from STDIN.
+.TP
+-r N
+.br
+Repeat the publication of the file N times, with a delay interval specifed by -i.
+Repeating is not supported unless the input is
+a file. If the -l option is given, the file and connection are opened once and
+the lines are replayed to individual ldmsd_stream_publish calls. If -l is not given,
+the ldmsd_stream_publish_file call is used, resulting in multiple connection openings.
+-i interval_in_microseconds
+.br
+Change the default delay (usleep(interval_in_microseconds)) used if repeat is specified.
+.RE
+
+.SH BUGS
+No known bugs.
+
+.SH NOTES
+.PP
+This executable is in development and may change at any time.
+.PP The difference in repeat behavior if -l is present allows for testing two scenarios: repeating many messages to a single connection and repeating connection attempts to a daemon that may come and go during publication attempts.
+Environment variables LDMSD_STREAM_CONN_TIMEOUT and LDMSD_STREAM_ACK_TIMEOUT will affect the timing of the repeat loop when -l is not given.
+
+
+
+.SH EXAMPLES
+.PP
+Within ldmsd_controller or a configuration file:
+.nf
+load name=hello_sampler
+config name=hello_sampler producer=host1 instance=host1/hello_sampler stream=foo component_id=1
+start name=hello_sampler interval=1000000 offset=0
+.fi
+
+.PP
+.nf
+> cat testdata.10.out
+{ "seq": 0, "job-id" : 10364, "rank" : 1, "kokkos-perf-data" : [ {"name" : "SPARTAFOO0", "count": 0, "time": 0.0000},{"name" : "SPARTAFOO1", "count": 1, "time": 0.0001},{"name" : "SPARTAFOO2", "count": 2, "time": 0.0002},{"name" : "SPARTAFOO3", "count": 3, "time": 0.0003},{"name" : "SPARTAFOO4", "count": 4, "time": 0.0004},{"name" : "SPARTAFOO5", "count": 5, "time": 0.0005},{"name" : "SPARTAFOO6", "count": 6, "time": 0.0006},{"name" : "SPARTAFOO7", "count": 7, "time": 0.0007},{"name" : "SPARTAFOO8", "count": 8, "time": 0.0008},{"name" : "SPARTAFOO9", "count": 9, "time": 0.0009}] }
+.fi
+
+.PP
+.nf
+> ldmsd_stream_publish -x sock -h localhost -p 52001 -s foo -t json -f ./testdata.10.out -a none
+.ni
+
+.PP
+In the log file of the ldmsd:
+.nf
+> cat log.txt
+Sat Aug 21 18:15:27 2021: CRITICAL  : stream_type: JSON, msg: "{ "seq": 0, "job-id" : 10364, "rank" : 1, "kokkos-perf-data" : [ {"name" : "SPARTAFOO0", "count": 0, "time": 0.0000},{"name" : "SPARTAFOO1", "count": 1, "time": 0.0001},{"name" : "SPARTAFOO2", "count": 2, "time": 0.0002},{"name" : "SPARTAFOO3", "count": 3, "time": 0.0003},{"name" : "SPARTAFOO4", "count": 4, "time": 0.0004},{"name" : "SPARTAFOO5", "count": 5, "time": 0.0005},{"name" : "SPARTAFOO6", "count": 6, "time": 0.0006},{"name" : "SPARTAFOO7", "count": 7, "time": 0.0007},{"name" : "SPARTAFOO8", "count": 8, "time": 0.0008},{"name" : "SPARTAFOO9", "count": 9, "time": 0.0009},{"name" : "SPARTAFOO10", "count": 10, "time": 0.00010}] }", msg_len: 589, entity: 0x2aaab8004680
+.ni
+
+Note that the hello_streams sampler does not do a sample, instead it subscribes to the stream with a callback and prints out what it got off the stream.
+.fi
+
+
+.SH SEE ALSO
+ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), ldms_sampler_base(7), Plugin_hello_sampler(7), Plugin_stream_csv_store(7)


### PR DESCRIPTION
Options -r count -i delay allow the publisher to repeat file input
to the publishing target count times with a delay between repeats.