### PR TITLE
Fix double free bug in ldms

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2673,6 +2673,8 @@ static void __ldms_xprt_release_sets(ldms_t x, struct rbt *set_coll)
 
 	rbn = rbt_min(set_coll);
 	while (rbn) {
+		lp = NULL;
+		pp = NULL;
 		rbt_del(set_coll, rbn);
 		ent = container_of(rbn, struct xprt_set_coll_entry, rbn);
 		pthread_mutex_lock(&ent->set->lock);


### PR DESCRIPTION
The `lp` and `pp` pointers in `__ldms_xprt_release_sets()` were not
reset to `NULL` and then got reused in the next iteration, causing a
double-free issue.