### PR TITLE
Fix SIGSEGV due to NULL prdcr_set in ldmsd

### DIFF
--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -517,6 +517,8 @@ static void __prdcr_remote_set_delete(ldmsd_prdcr_t prdcr, const char *name)
 	const char *state_str = "bad_state";
 	ldmsd_prdcr_set_t prdcr_set;
 	prdcr_set = ldmsd_prdcr_set_find(prdcr, name);
+	if (!prdcr_set)
+		return;
 	pthread_mutex_lock(&prdcr_set->lock);
 	assert(prdcr_set->ref_count);
 	switch (prdcr_set->state) {


### PR DESCRIPTION
The producer set may not yet be created when the ldmsd receive
DIR_DELETE from the peer. For example, an L2 aggregator issued a dir
request to an L1 aggregator. The L1 aggregator send DIR_LIST to the L2
aggregator in chunks. In the mean time, a sampler (a peer of L1) may die
and causing the L1 to issue a DIR_DELETE message to the L2 aggregator
that the DIR_LIST chunk of that set may not yet arrived. In this case,
`ldmsd_prdcr_set_find()` will return NULL and cause a segmentation
fault. This patch NULL-check the returned prdcr set before using it in
the DIR_DELETE path.