### PR TITLE
Limit the number of zap threads with nprocs

### DIFF
--- a/lib/src/zap/zap_priv.h
+++ b/lib/src/zap/zap_priv.h
@@ -337,6 +337,9 @@ struct zap {
 	/** Mutex for _io_threads. */
 	pthread_mutex_t _io_mutex;
 
+	/** Number of threads */
+	int _n_threads;
+
 };
 
 static inline zap_err_t


### PR DESCRIPTION
A new zap thread was created if the existing ones were too busy.
However, ldmsd could end up spwaning too many threads without any
limitation. This patch limits the number of zap threads with the number
of processors in the system.