### PR TITLE
Add C and Python API for LDMS Schema info access

### DIFF
--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -585,6 +585,16 @@ cdef py_ldms_metric_get_record_type(Set s, int m_idx):
 cdef py_ldms_metric_get_record_array(Set s, int m_idx):
     return RecordArray(s, m_idx)
 
+cdef char * CSTR(object obj):
+    if obj is None:
+        return NULL
+    return obj
+
+cdef bytes CBYTES(const char *s):
+    if s == NULL:
+        return None
+    return bytes(s)
+
 METRIC_GETTER_TBL = {
         LDMS_V_CHAR : py_ldms_metric_get_char,
         LDMS_V_U8   : py_ldms_metric_get_u8,
@@ -1327,6 +1337,8 @@ cdef ldms_value_type LDMS_VALUE_TYPE(t):
 cdef bytes BYTES(o):
     """Convert Python object `s` to `bytes` (c-string compatible)"""
     # a wrapper to solve the annoying bytes vs str in python3
+    if o is None:
+        return None
     if type(o) == bytes:
         return o
     return str(o).encode()
@@ -1707,7 +1719,8 @@ cdef class RecordDef(object):
         t = LDMS_VALUE_TYPE(metric_type)
         if t < LDMS_V_CHAR or LDMS_V_D64_ARRAY < t:
             raise TypeError("{} is not supported in a record".format(metric_type))
-        idx = ldms_record_metric_add(self._rec_def, BYTES(name), BYTES(units),
+        idx = ldms_record_metric_add(self._rec_def, CSTR(BYTES(name)),
+                                     CSTR(BYTES(units)),
                                      t, count)
         if idx < 0:
             raise RuntimeError("ldms_record_metric_add() error: {}" \
@@ -1876,9 +1889,8 @@ cdef class Schema(object):
         NOTE: If metric_type is LDMS_V_LIST, the count is the heap size in bytes.
         """
         cdef int idx
-        cdef char *u = NULL
-        cdef bytes b
         cdef RecordDef _rec_def
+
 
         if type(metric_type) == RecordDef:
             self.add_record(metric_type)
@@ -1890,25 +1902,26 @@ cdef class Schema(object):
             if type(rec_def) != RecordDef:
                 raise TypeError("Expecting RecordRef `rec_def`")
             _rec_def = <RecordDef>rec_def
-            idx = ldms_schema_record_array_add(self._schema, BYTES(name),
-                    _rec_def._rec_def, count)
+            idx = ldms_schema_record_array_add(self._schema,
+                                CSTR(BYTES(name)), _rec_def._rec_def, count)
         elif t == LDMS_V_LIST:
-            if units is not None:
-                b = BYTES(units)
-                u = b
-            idx = ldms_schema_metric_list_add(self._schema, BYTES(name), u, count)
+            idx = ldms_schema_metric_list_add(self._schema,
+                                              CSTR(BYTES(name)),
+                                              CSTR(BYTES(units)), count)
         elif ldms_type_is_array(t):
             if meta:
-                idx = ldms_schema_meta_array_add(self._schema, BYTES(name), t,
-                                                 count)
+                idx = ldms_schema_meta_array_add_with_unit( self._schema,
+                                CSTR(BYTES(name)), CSTR(BYTES(units)), t, count)
             else:
-                idx = ldms_schema_metric_array_add(self._schema, BYTES(name), t,
-                                                   count)
+                idx = ldms_schema_metric_array_add_with_unit(self._schema,
+                                CSTR(BYTES(name)), CSTR(BYTES(units)), t, count)
         else:
             if meta:
-                idx = ldms_schema_meta_add(self._schema, BYTES(name), t)
+                idx = ldms_schema_meta_add_with_unit(self._schema,
+                                CSTR(BYTES(name)), CSTR(BYTES(units)), t)
             else:
-                idx = ldms_schema_metric_add(self._schema, BYTES(name), t)
+                idx = ldms_schema_metric_add_with_unit(self._schema,
+                                CSTR(BYTES(name)), CSTR(BYTES(units)), t)
         if idx < 0:
             # error = -idx
             raise OSError(-idx, "Adding metric to schema failed: {}" \
@@ -2482,20 +2495,20 @@ cdef class RecordInstance(MVal):
         """Get metric name of the i_th member of the record"""
         cdef const char *c_str
         c_str = ldms_record_metric_name_get(self.rec_inst, i)
-        return STR(c_str)
+        return STR(CBYTES(c_str))
 
     def get_metric_unit(self, i):
         """Get metric unit of the i_th member of the record"""
         cdef const char *c_str
         c_str = ldms_record_metric_unit_get(self.rec_inst, i)
-        return STR(c_str)
+        return STR(CBYTES(c_str))
 
     def keys(self):
         """Generator yielding the names of the metrics in the record"""
         cdef const char *c_str
         for i in range(len(self)):
             c_str = ldms_record_metric_name_get(self.rec_inst, i)
-            s = STR(c_str)
+            s = STR(CBYTES(c_str))
             yield s
 
     def items(self):
@@ -3162,15 +3175,15 @@ cdef class Xprt(object):
                 raise TypeError("auth_opts must be a dictionary")
             avl = av_new(len(auth_opts))
             for k, v in auth_opts.items():
-                rc = av_add(avl, BYTES(k), BYTES(v))
+                rc = av_add(avl, CSTR(BYTES(k)), CSTR(BYTES(v)))
                 if rc:
                     av_free(avl)
                     raise OSError(rc, "av_add() error: {}"\
                                   .format(ERRNO_SYM(rc)))
         self.rail_eps = rail_eps
-        self.xprt = ldms_xprt_rail_new(BYTES(name), rail_eps,
+        self.xprt = ldms_xprt_rail_new(CSTR(BYTES(name)), rail_eps,
                                         rail_recv_limit, rail_rate_limit,
-                                        BYTES(auth), avl)
+                                        CSTR(BYTES(auth)), avl)
         av_free(avl)
         if not self.xprt:
             raise ConnectionError(errno, "Error creating transport, errno: {}"\
@@ -4054,7 +4067,7 @@ cdef class StreamClient(object):
             desc = ""
         self.c = ldms_stream_subscribe(BYTES(match), is_regex,
                                        __stream_client_cb, <void*>self,
-                                       BYTES(desc))
+                                       CSTR(BYTES(desc)))
         if not self.c:
             raise RuntimeError(f"ldms_stream_subscribe() error, errno: {errno}")
 
@@ -4168,4 +4181,4 @@ def ovis_log_set_level_by_name(str subsys_name, level):
     """ovis_log_set_level_by_name(str subsys_name, level)"""
     if type(level) is str:
         level = LOG_LEVEL_MAP[level.upper()]
-    ldms.ovis_log_set_level_by_name(BYTES(subsys_name), level)
+    ldms.ovis_log_set_level_by_name(CSTR(BYTES(subsys_name)), level)

--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -4966,8 +4966,6 @@ int ldms_schema_metric_add_template(ldms_schema_t s,
 	for (i=0, ent=tmp; ent->name || ent->rec_def; i++,ent++) {
 		switch (ent->type) {
 		case LDMS_V_RECORD_TYPE:
-			if (ent->flags & LDMS_MDESC_F_META)
-				return -EINVAL;
 			ret = ldms_schema_record_add(s, ent->rec_def);
 			break;
 		case LDMS_V_RECORD_ARRAY:

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -1934,6 +1934,45 @@ extern void ldms_schema_delete(ldms_schema_t schema);
 extern int ldms_schema_metric_count_get(ldms_schema_t schema);
 
 /**
+ * \brief Populate \c out with information of metric \c mid in \c schema.
+ *
+ * Please note that the pointer members in \c out (e.g. \c out->name) point to
+ * memory that is owned by \c schema. So, please do *NOT* modify or free the
+ * members of \c out. The \c out itself can be freed.
+ *
+ * \param [in]  schema The schema handle.
+ * \param [in]  mid    The metric ID.
+ * \param [out] out    The metric template structure output.
+ *
+ * \retval 0      If succeeded, or
+ * \retval ENOENT if \c mid does not exist.
+ */
+extern int ldms_schema_metric_template_get(ldms_schema_t schema, int mid,
+				struct ldms_metric_template_s *out);
+
+/**
+ * \brief Like \c ldms_schema_metric_template_get(), but in bulk.
+ *
+ * This function copies metric template information from \c schema into \c out
+ * template array up to \c len metrics. The pointers in the template structure
+ * are owned by \c schema, please do not modify or free them. The \c out array,
+ * however, can be freed. Similar to \c snprintf(), this function returns a
+ * number less than or equal to \c len if succeeded, or a number greater than
+ * \c len to indicate the required array length. In the latter case, the
+ * template array \c out contains \c len metric templates.
+ *
+ * \param [in]  schema The schema handle.
+ * \param [in]  len    The length of the \c out array buffer.
+ * \param [out] out    The output template array.
+ *
+ * \retval N<=len If succeeded, or
+ * \retval N>len  if the output array is not long enough
+ *
+ */
+extern int ldms_schema_bulk_template_get(ldms_schema_t schema, int len,
+				struct ldms_metric_template_s out[]);
+
+/**
  * \brief Set the cardinality of the set array created by this schema.
  *
  * \param schema The schema handle.
@@ -1985,6 +2024,18 @@ void ldms_record_delete(ldms_record_t rec_def);
 int ldms_record_metric_add(ldms_record_t rec_def, const char *name,
 			   const char *unit, enum ldms_value_type type,
 			   size_t array_len);
+
+/**
+ * Get the number of metrics in record definition \c rec_def.
+ *
+ * \note \c ldms_record_card() does the same thing on \c mavl (\c record_inst or
+ * \c record_type) from an LDMS set.
+ *
+ * \param rec_def  The record definition handle (from \c ldms_record_alloc()).
+ *
+ * \retval N The number of metrics in the record.
+ */
+int ldms_record_metric_card(ldms_record_t rec_def);
 
 
 /**
@@ -2047,6 +2098,47 @@ size_t ldms_record_heap_size_get(ldms_record_t rec_def);
  * \retval bytes The size of the heap memory
  */
 size_t ldms_record_value_size_get(ldms_record_t rec_def);
+
+/**
+ * \brief Populate \c out with information of metric \c mid in \c record.
+ *
+ * Please note that the pointer members in \c out (e.g. \c out->name) point to
+ * memory that is owned by \c record. So, please do *NOT* modify or free the
+ * members of \c out. The \c out itself can be freed.
+ *
+ * \param [in]  record The record handle.
+ * \param [in]  mid    The metric ID.
+ * \param [out] out    The metric template structure output.
+ *
+ * \retval 0      If succeeded, or
+ * \retval ENOENT if \c mid does not exist.
+ */
+extern int ldms_record_metric_template_get(ldms_record_t record, int mid,
+				struct ldms_metric_template_s *out);
+
+/**
+ * \brief Like \c ldms_record_metric_template_get(), but in bulk.
+ *
+ * This function copies metric template information from \c record into \c out
+ * template array up to \c len metrics. The pointers in the template structure
+ * are owned by \c record, please do not modify or free them. The \c out array,
+ * however, can be freed. Similar to \c snprintf(), this function returns a
+ * number less than or equal to \c len if succeeded, or a number greater than
+ * \c len to indicate the required array length. In the latter case, the
+ * template array \c out contains \c len metric templates.
+ *
+ * \param [in]  record The record handle.
+ * \param [in]  len    The length of the \c out array buffer.
+ * \param [out] out    The output template array.
+ *
+ * \retval N<=len If succeeded, or
+ * \retval N>len  if the output array is not long enough
+ *
+ */
+extern int ldms_record_bulk_template_get(ldms_record_t record, int len,
+				struct ldms_metric_template_s out[]);
+
+extern const char *ldms_record_name_get(ldms_record_t record);
 
 void _ldms_set_ref_get(ldms_set_t s, const char *reason, const char *func, int line);
 int _ldms_set_ref_put(ldms_set_t s, const char *reason, const char *func, int line);


### PR DESCRIPTION
This is to support information access to LDMS Schema and Record
Definition objects without the LDMS sets. The schema registry needs
these APIs to access metric information inside the Schema and Record
Definition to construct their representation in the Schema Registry
database.

This pull request also includes bug fixes found along the way.