### PR TITLE
 ldmsd hanging on delete_thread fix

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -3876,6 +3876,7 @@ static void *delete_proc(void *arg)
 					pthread_mutex_unlock(&set->lock);
 					goto next;
 				}
+				xrbn = rbn_succ(xrbn);
 			}
 			pthread_mutex_unlock(&set->lock);
 


### PR DESCRIPTION
The ldmsd aggregators on one of our production clusters would enter into a deadlock state waiting on `delete_thread` indefinitely, where the aggregator daemon continued to run, would use 100% cpu, and in gdb session with a debug-symbol supported aggregator daemon instance, we discovered the issue manifests in `ldms/src/core/ldms.c` where an if statement lacked a test to confirm success of red/black node relationship, (?).

I'm proposing adding in this code-fix for this issue we continue to encounter on Sandia systems after debug session on tag release v4.4.3 with @tom95858, on aggregators without the patch.

@bschwal