### PR TITLE
Perform validity checks on set name

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -1573,6 +1573,27 @@ ldms_set_t ldms_set_create(const char *instance_name,
 	int set_array_card;
 	struct ldms_set *set;
 
+	/*
+	 * Ensure the instance_name does not contain characters
+	 * that can't be encoded in a quoted string
+	 */
+	const char *s = instance_name;
+	while (*s != '\0') {
+		if (iscntrl(*s)) {
+			errno = EINVAL;
+			return NULL;
+		}
+		if (*s == '"') {
+			errno = EINVAL;
+			return NULL;
+		}
+		if (*s == '\'') {
+			errno = EINVAL;
+			return NULL;
+		}
+		s++;
+	}
+
 	if (delete_thread_init_once())
 		return NULL;
 


### PR DESCRIPTION
The set name provided to ldms_set_create cannot contain characters that cannot be encoded in a quoted string. Prior to this patch it was possible to create a set that would crash ldms_set_dir because the result is encoded as a JSON object and the instance name as a JSON string.