### PR TITLE
Fix libfabric build option (b4.4 backport)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -131,7 +131,6 @@ OPTION_DEFAULT_ENABLE([ovis_auth], [ENABLE_OVIS_AUTH])
 OPTION_DEFAULT_ENABLE([zap], [ENABLE_ZAP])
 OPTION_DEFAULT_DISABLE([rdma], [ENABLE_RDMA])
 OPTION_DEFAULT_DISABLE([nola], [ENABLE_NOLA])
-OPTION_DEFAULT_DISABLE([fabric], [ENABLE_FABRIC])
 OPTION_DEFAULT_DISABLE([ugni], [ENABLE_UGNI])
 dnl dnl OPTION_DEFAULT_DISABLE([sos], [ENABLE_SOS])
 dnl dnl OPTION_WITH_OR_BUILD([sos],[../sos],[sos/src sos/include ods/src ods/include])
@@ -188,23 +187,8 @@ dnl we need libibverbs-devel and librdmacm-devel to support rdma
 		      AC_MSG_ERROR([pkg-config cray-rca failed])
 		      )
   fi
-  if test "$enable_fabric" = "yes"; then
-    AC_ARG_WITH([libfabric],
-      AC_HELP_STRING([--with-libfabric], [Specify libfabric location]),
-        [AS_IF([test -d "$withval/lib"], [LIB_FABRIC="$withval"],
-          AC_MSG_ERROR([libfabric not found at $withval]))],
-          AC_MSG_ERROR([must specify --with-libfabric]))
-    LDFLAGS="$LDFLAGS -L${LIB_FABRIC}/lib"
-    AC_SUBST([LIBFABRIC_INCDIR], [${LIB_FABRIC}/include])
-    saveCPPFLAGS=$CPPFLAGS
-    CPPFLAGS="$CPPFLAGS -I${LIB_FABRIC}/include"
-    AC_CHECK_LIB([fabric], fi_getinfo, [],
-      AC_MSG_ERROR([fi_getinfo() not found. zap requires fabric.]))
-    AC_CHECK_HEADER([rdma/fabric.h], [],
-      [AC_MSG_ERROR([<rdma/fabric.h> not found. zap requires fabric.])])
-    AC_MSG_RESULT([Using fabric at $LIB_FABRIC])
-    CPPFLAGS=$saveCPPFLAGS
-  fi
+  OPTION_WITH_CHECK([libfabric], [LIBFABRIC], [rdma/fabric.h],
+		    [fabric], [fi_getinfo] )
 fi
 OPTION_WITH([libibverbs], [LIBIBVERBS])
 OPTION_WITH([librdmacm], [LIBRDMACM])

--- a/lib/src/zap/Makefile.am
+++ b/lib/src/zap/Makefile.am
@@ -4,7 +4,7 @@ if ENABLE_RDMA
 SUBDIRS += rdma
 endif
 
-if ENABLE_FABRIC
+if HAVE_LIBFABRIC
 SUBDIRS += fabric
 endif
 

--- a/lib/src/zap/fabric/Makefile.am
+++ b/lib/src/zap/fabric/Makefile.am
@@ -3,5 +3,5 @@ pkglib_LTLIBRARIES = libzap_fabric.la
 AM_CFLAGS = -I$(srcdir)/../.. -I$(srcdir)/.. -I$(top_srcdir) -I../..
 
 libzap_fabric_la_SOURCES = zap_fabric.c zap_fabric.h
-libzap_fabric_la_CFLAGS = -I@LIBFABRIC_INCDIR@ ${AM_CFLAGS}
+libzap_fabric_la_CFLAGS = @LIBFABRIC_INCDIR_FLAG@ $(AM_CFLAGS)
 libzap_fabric_la_LIBADD = -lfabric ../libzap.la


### PR DESCRIPTION
`--with-libfabric` was only looking for the library in `PREFIX/lib`. This patch removed `--enable-fabric` and use `--with-fabric` that check for the library/header by default.

Fixes #1472

Backporting this commit would probably address issue #1472. The only thing to consider though, is whether we want to make which change to the configure command line options in b4.4.