### PR TITLE
Add ldms-containers dispatcher on release

### DIFF
--- a/.github/data/dispatch.yaml
+++ b/.github/data/dispatch.yaml
@@ -1,0 +1,16 @@
+ref: dispatch
+inputs:
+  TAG: LDMS_TAG
+  # vars is a long string, alternating ATTR VALUE ...
+  vars: LDMS_REPO LDMS_REPO_URL
+        LDMS_BRANCH LDMS_TAG
+        SOS_REPO https://github.com/ovis-hpc/sos
+        SOS_BRANCH SOS-6
+        MAESTRO_REPO https://github.com/ovis-hpc/maestro
+        MAESTRO_BRANCH master
+        NUMSOS_REPO https://github.com/narategithub/numsos
+        NUMSOS_BRANCH compMinMeanMax-fix
+        SOSDBUI_REPO https://github.com/nick-enoent/sosdb-ui
+        SOSDBUI_BRANCH 500069d5388fc8d68fe9ae0d6b847c8ce1da95c0
+        SOSDBGRAFANA_REPO https://github.com/nick-enoent/sosdb-grafana
+        SOSDBGRAFANA_BRANCH e5eb5347f3864e2e3447e996cdbe28b8e74b2bb6

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -37,3 +37,20 @@ jobs:
       with:
         files: |
           ./${{ env.TARBALL_NAME }}
+  dispatch-container-bake:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: dispatch ldms-containers bake
+        run: |
+          set -e
+          sed -i "s|LDMS_TAG|${{github.ref_name}}|" .github/data/dispatch.yaml
+          sed -i "s|LDMS_REPO_URL|${{github.server_url}}/${{github.repository}}|" .github/data/dispatch.yaml
+          python3 -c 'import sys,yaml,json; print(json.dumps(yaml.load(sys.stdin, yaml.SafeLoader)))' < .github/data/dispatch.yaml > dispatch.json
+          curl -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{secrets.NARATEGITHUB_LDMS_CONTAINERS_TOKEN}}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d "@dispatch.json" \
+            "https://api.github.com/repos/narategithub/ldms-containers/actions/workflows/on_ldms_release.yaml/dispatches"


### PR DESCRIPTION
This patch adds another job in the `create-release.yaml` that dispatches `docker buildx bake` jobs in `ldms-containers` after the `build` job in `create-release.yaml` succeeded.