### PR TITLE
Prevent use-after-free in stream publisher RBN key

### DIFF
--- a/ldms/src/ldmsd/ldmsd_stream.c
+++ b/ldms/src/ldmsd/ldmsd_stream.c
@@ -121,7 +121,7 @@ static struct ldmsd_stream_publisher_s *__new_publisher(const char *name)
 	p->p_name = strdup(name);
 	if (!p->p_name)
 		goto err;
-	rbn_init(&p->p_ent, (char*)name);
+	rbn_init(&p->p_ent, (char*)p->p_name);
 	return p;
 err:
 	__free_publisher(p);


### PR DESCRIPTION
Initialize publisher's RBN key (p_ent.key) with its own copy of name (p_name) rather than externally managed memory. This prevents potential use-after-free when the external memory is freed while the publisher entry remains in the RBN tree.

Fixes #1177