### PR TITLE
Document LDMS_DELET_TIMEOUT environment variable

### DIFF
--- a/ldms/man/ldmsd.man
+++ b/ldms/man/ldmsd.man
@@ -50,6 +50,12 @@ The size of memory reserved for metric sets. Set this variable or specify "-m"
 to ldmsd. See the -m option for further details. If both are specified, the -m
 option takes precedence over this environment variable.
 .TP
+LDMS_DELETE_TIMEOUT
+The timeout period (in seconds) before ldmsd forcibly frees memory of deleted metric sets when network problems prevent normal cleanup.
+Under normal conditions, metric set memory is freed automatically and this timeout is not used. If network issues prevent proper cleanup,
+deleted sets will remain in memory and can be observbed using the "set_stats" command. Consider increasing this value if network problems
+are temporary and you want to allow more time for normal cleanup to complete. If not set, defaults to 60 seconds.
+.TP
 LDMSD_UPDTR_OFFSET_INCR
 The increment to the offset hint in microseconds. This is only for updaters that
 determine the update interval and offset automatically. For example, the offset


### PR DESCRIPTION
Add documentation for the LDMS_DELETE_TIMEOUT environment variable to explain its purpose and usage in the ldmsd man page.

Resolves #1216