### PR TITLE
issue1489: for ldmsd_process_config_request, if hostname does not res…

### DIFF
--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -756,6 +756,13 @@ parse:
 			rc = xprt.rsp_err;
 		ldmsd_log(LDMSD_LERROR, "Configuration error at line %d (%s)\n",
 				lineno, path);
+            /* If hostname doesn't resolve skip, non-fatal */
+            if (rc == 97) {
+                ldmsd_log(LDMSD_LERROR,
+                     "Hostname not resolved at "
+                     "line %d (%s), skipping\n", lineno, path);
+                goto next_req;
+            }
 		goto cleanup;
 	}
 next_req:


### PR DESCRIPTION
issue1489: for ldmsd_process_config_request, if hostname does not resolve skip host, non-fatal

ldmsd should not fail if a hostname is not resolved.