### PR TITLE
Make ldmsd continue startup on producer's hostname resolution failure

### DIFF
--- a/ldms/man/ldmsd_controller.man
+++ b/ldms/man/ldmsd_controller.man
@@ -300,6 +300,10 @@ Instruct \fBldmsd\fR to use \fIAUTH_REF\fR (a name reference to \fBauth\fR
 object created by \fBauth_add\fR command) with the connections to this
 producer. If not given, the default authentication method specified on
 the CLI options (see \fBldmsd\fR(8) option \fB-a\fR) is used.
+.TP
+.BI [cache_ip " cache_ip"]
+.br
+Controls how \fBldmsd\fR handles hostname resolution for producer IP addresses. When set to \fBtrue\fR (default), \fBldmsd\fR resolves the hostname once during \fBprdcr_add\fR and caches the result. If the initial resolution fails and the producer is started (via \fBprdcr_start\R or \fBprdcr_start_regex\fR), \fBldmsd\fR will retry resolution at connection time and each resonnection attempt until successful. When set to \fBfalse\fR, \fBldmsd\fR performs hostname resolution at \fBprdcr_add\fR time and repeats the resolution at every connection and reconnection attempt if the producer is started.
 .RE
 
 .SS Delete a producer from the aggregator

--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -2030,10 +2030,12 @@ class Communicator(object):
             attrs.append(LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.AUTH, value=kwargs['auth']))
         if 'perm' in kwargs.keys() and kwargs['perm']:
             attrs.append(LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.PERM, value=str(kwargs['perm'])))
+        if 'cache_ip' in kwargs.keys() and kwargs['cache_ip']:
+            attrs.append(LDMSD_Req_Attr(attr_id = LDMSD_Req_Attr.IP, value = str(kwargs['cache_ip'])))
 
         return attrs
 
-    def prdcr_add(self, name, ptype, xprt, host, port, reconnect, auth=None, perm=None):
+    def prdcr_add(self, name, ptype, xprt, host, port, reconnect, auth=None, perm=None, cache_ip=None):
         """
         Add a producer. A producer is a peer to the LDMSD being configured.
         Once started, the LDSMD will attempt to connect to this peer
@@ -2051,8 +2053,11 @@ class Communicator(object):
         - The reconnect interval in microseconds
 
         Keyword Parameters:
+        auth - The authentication domain
         perm - The configuration client permission required to
                modify the producer configuration. Default is None.
+        cache_ip - True: Cache hostname after first successfull resolution;
+                   False: Resolve hostname on every connection
 
         Returns:
         A tuple of status, data
@@ -2060,7 +2065,7 @@ class Communicator(object):
         - data is an error message if status != 0 or None
         """
         args_d = {'name': name, 'ptype': ptype, 'xprt': xprt, 'host': host, 'port': port,
-                  'reconnect': reconnect, 'auth': auth, 'perm': perm}
+                  'reconnect': reconnect, 'auth': auth, 'perm': perm, 'cache_ip': cache_ip}
         attrs = self._prdcr_add_attr_prep(**args_d)
         req = LDMSD_Request( command_id = LDMSD_Request.PRDCR_ADD, attrs = attrs)
         try:

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -370,6 +370,8 @@ class LdmsdCmdParser(cmd.Cmd):
         interval= The connection retry interval (us) (Deprecated, please use 'reconnect'.)
         auth=     The authentication method
         [perm=]   The permission to modify the producer in the future.
+        [cache_ip=]   True to cache the IP address after first successful resolution (default).
+                      False to resolve the hostname at prdcr_add and at every connection attempt.
         """
         arg = self.handle_args('prdcr_add', arg)
         if arg is None:
@@ -390,7 +392,8 @@ class LdmsdCmdParser(cmd.Cmd):
                                           arg['port'],
                                           arg['reconnect'],
                                           arg['auth'],
-                                          arg['perm'])
+                                          arg['perm'],
+                                          arg['cache_ip'])
             if rc:
                 print(f'Error adding prdcr {arg["name"]}: {msg}')
 

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -201,6 +201,11 @@ typedef struct ldmsd_prdcr_stream_s {
 typedef struct ldmsd_prdcr {
 	struct ldmsd_cfgobj obj;
 
+	/* Controls hostname resolution caching behavior (user configurable)
+	 * 1 = (default) Cache hostname after first successfull resolution
+	 * 0 = Resolve hostname on every connection
+	 */
+	uint8_t cache_ip;
 	struct sockaddr_storage ss;	/* Host address */
 	socklen_t ss_len;
 	char *host_name;	/* Host name */
@@ -1156,7 +1161,8 @@ ldmsd_prdcr_new_with_auth(const char *name, const char *xprt_name,
 		const char *host_name, const unsigned short port_no,
 		enum ldmsd_prdcr_type type,
 		int conn_intrvl_us,
-		const char *auth, uid_t uid, gid_t gid, int perm);
+		const char *auth, uid_t uid, gid_t gid, int perm,
+		int cache_ip);
 int ldmsd_prdcr_del(const char *prdcr_name, ldmsd_sec_ctxt_t ctxt);
 ldmsd_prdcr_t ldmsd_prdcr_first();
 ldmsd_prdcr_t ldmsd_prdcr_next(struct ldmsd_prdcr *prdcr);

--- a/ldms/src/ldmsd/ldmsd_failover.c
+++ b/ldms/src/ldmsd/ldmsd_failover.c
@@ -440,6 +440,12 @@ int __failover_send_prdcr(ldmsd_failover_t f, ldms_t x, ldmsd_prdcr_t p)
 	if (rc)
 		goto cleanup;
 
+	/* Cache_ip */
+	snprintf(buff, sizeof(buff), "%d", p->cache_ip);
+	rc = ldmsd_req_cmd_attr_append_str(rcmd, LDMSD_ATTR_IP, buff);
+	if (rc)
+		goto cleanup;
+
 	/* Terminate the message */
 	rc = ldmsd_req_cmd_attr_term(rcmd);
 	if (rc)
@@ -2025,6 +2031,7 @@ int failover_cfgprdcr_handler(ldmsd_req_ctxt_t req)
 	char *perm = __req_attr_gets(req, LDMSD_ATTR_PERM);
 	char *auth = __req_attr_gets(req, LDMSD_ATTR_AUTH);
 	char *stream = __req_attr_gets(req, LDMSD_ATTR_STREAM);
+	char *cache_ip = __req_attr_gets(req, LDMSD_ATTR_IP);
 
 	uid_t _uid;
 	gid_t _gid;
@@ -2079,7 +2086,7 @@ int failover_cfgprdcr_handler(ldmsd_req_ctxt_t req)
 	}
 
 	p = ldmsd_prdcr_new_with_auth(name, xprt, host, atoi(port), ptype,
-			atoi(interval), auth, _uid, _gid, _perm);
+			atoi(interval), auth, _uid, _gid, _perm, atoi(cache_ip));
 	if (!p) {
 		rc = errno;
 		str_rbn_free(srbn);

--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -849,9 +849,9 @@ static void prdcr_connect(ldmsd_prdcr_t prdcr)
 {
 	int ret;
 
-	if (0 == prdcr->ss.ss_family) {
-		if (prdcr_resolve(prdcr->host_name, prdcr->port_no, &prdcr->ss,
-								&prdcr->ss_len)) {
+	if ((0 == prdcr->ss.ss_family) || (!prdcr->cache_ip)) {
+		if (prdcr_resolve(prdcr->host_name, prdcr->port_no,
+					&prdcr->ss, &prdcr->ss_len)) {
 			ldmsd_log(LDMSD_LERROR, "Producer '%s' connection failed. " \
 						"Hostname '%s:%u' not resolved.\n",
 						prdcr->obj.name, prdcr->host_name,
@@ -988,7 +988,8 @@ ldmsd_prdcr_t
 ldmsd_prdcr_new_with_auth(const char *name, const char *xprt_name,
 		const char *host_name, const unsigned short port_no,
 		enum ldmsd_prdcr_type type, int conn_intrvl_us,
-		const char *auth, uid_t uid, gid_t gid, int perm)
+		const char *auth, uid_t uid, gid_t gid, int perm,
+		int cache_ip)
 {
 	extern struct rbt *cfgobj_trees[];
 	struct ldmsd_prdcr *prdcr;
@@ -1007,6 +1008,7 @@ ldmsd_prdcr_new_with_auth(const char *name, const char *xprt_name,
 	prdcr->conn_intrvl_us = conn_intrvl_us;
 	prdcr->port_no = port_no;
 	prdcr->conn_state = LDMSD_PRDCR_STATE_STOPPED;
+	prdcr->cache_ip = cache_ip;
 	rbt_init(&prdcr->set_tree, set_cmp);
 	rbt_init(&prdcr->hint_set_tree, ldmsd_updtr_schedule_cmp);
 	prdcr->host_name = strdup(host_name);
@@ -1063,7 +1065,7 @@ ldmsd_prdcr_new(const char *name, const char *xprt_name,
 {
 	return ldmsd_prdcr_new_with_auth(name, xprt_name, host_name,
 			port_no, type, conn_intrvl_us,
-			DEFAULT_AUTH, getuid(), getgid(), 0777);
+			DEFAULT_AUTH, getuid(), getgid(), 0777, 1);
 }
 
 extern struct rbt *cfgobj_trees[];

--- a/ldms/src/ldmsd/ldmsd_request_util.c
+++ b/ldms/src/ldmsd/ldmsd_request_util.c
@@ -158,6 +158,7 @@ const struct req_str_id attr_str_id_table[] = {
 	{  "auto_interval",     LDMSD_ATTR_AUTO_INTERVAL  },
 	{  "auto_switch",       LDMSD_ATTR_AUTO_SWITCH  },
 	{  "base",              LDMSD_ATTR_BASE  },
+	{  "cache_ip",          LDMSD_ATTR_IP  },
 	{  "container",         LDMSD_ATTR_CONTAINER  },
 	{  "decomposition",     LDMSD_ATTR_DECOMP  },
 	{  "disable_start",     LDMSD_ATTR_AUTO_INTERVAL  },


### PR DESCRIPTION
Change producer's hostname resolution failure at config time from an error to a warning, allowing ldmsd to continue starting up. The hostname will be resolved again before establishing the connection and retired at the reconnect interval if the resolution fails.

Resolves #1489 