### PR TITLE
[b4.4] Fix value increment in test_sampler

### DIFF
--- a/ldms/src/sampler/examples/test_sampler/test_sampler.c
+++ b/ldms/src/sampler/examples/test_sampler/test_sampler.c
@@ -1754,7 +1754,7 @@ static int __sample_classic(struct test_sampler_set *ts_set)
 				type = ldms_record_metric_type_get(lent, 0, &cnt);
 				lent = ldms_record_metric_get(lent, 0);
 			}
-			v = lent->v_u64 + 1;
+			v = ldms_mval_as_u64(lent, type, 0) + 1;
 			ldms_list_purge(ts_set->set, mval);
 			for (j = 0; j < len; j++) {
 				if (LDMS_V_RECORD_INST == list->type) {

--- a/ldms/src/sampler/examples/test_sampler/test_sampler.c
+++ b/ldms/src/sampler/examples/test_sampler/test_sampler.c
@@ -1008,7 +1008,8 @@ static int __init_set(struct test_sampler_set *ts_set)
 				} else {
 					lent = ldms_list_append_item(ts_set->set, lh, list->type, list->cnt);
 					cnt = 1;
-					__metric_set(lent, type, cnt, list->init_value.v_u64);
+					__metric_set(lent, list->type, list->cnt,
+						     ldms_mval_as_u64(&list->init_value, list->type, 1));
 				}
 
 			}

--- a/ldms/src/sampler/examples/test_sampler/test_sampler.c
+++ b/ldms/src/sampler/examples/test_sampler/test_sampler.c
@@ -1775,7 +1775,7 @@ static int __sample_classic(struct test_sampler_set *ts_set)
 				__metric_set(lent, list->type, cnt, v);
 			}
 		} else {
-			v = mval->v_u64 + 1;
+			v = ldms_mval_as_u64(mval, type, 0) + 1;
 			if (ldms_metric_is_array(ts_set->set, i))
 				len = ldms_metric_array_get_len(ts_set->set, i);
 			else


### PR DESCRIPTION
Test sampler access raw metric value with `mval->v_u64` and increment that value by 1. This works for integer values. When `mval` contains float or double, `mval->v_u64` became big number due to IEEE 754 binary32 or binary64 format. As such, `test_sampler` should use `ldms_mval_as_u64()` to coerce the `mval` to u64 properly.