### PR TITLE
Fix "fill" handling in static decomposition

### DIFF
--- a/ldms/src/decomp/static/decomp_static.c
+++ b/ldms/src/decomp/static/decomp_static.c
@@ -111,8 +111,7 @@ mval_from_json(ldms_mval_t *v,
 	dst.type = mtype;
 	jtype = json_typeof(jent);
 
-	if ((jtype == JSON_STRING && mtype != LDMS_V_CHAR_ARRAY) ||
-			(mtype == LDMS_V_CHAR_ARRAY && jtype != JSON_STRING)) {
+	if ((mtype == LDMS_V_CHAR_ARRAY && jtype != JSON_STRING)) {
 		snprintf(err_buf, err_sz, "string type must have string value");
 		return EINVAL;
 	}
@@ -129,6 +128,13 @@ mval_from_json(ldms_mval_t *v,
 	case JSON_ARRAY:
 		if (!ldms_type_is_array(mtype)) {
 			snprintf(err_buf, err_sz, "array value must have array type");
+			return EINVAL;
+		}
+		break;
+	case JSON_STRING:
+		if (mtype != LDMS_V_CHAR && mtype != LDMS_V_CHAR_ARRAY) {
+			snprintf(err_buf, err_sz,
+				 "string value must have 'char' or 'char_array' type");
 			return EINVAL;
 		}
 		break;
@@ -1194,7 +1200,7 @@ static void assign_value(ldmsd_col_t dst, ldmsd_col_t src)
 	}
 	switch (dst->type) {
 	case LDMS_V_CHAR:
-		dst->mval->v_char = ldms_mval_as_s8(src->mval, src->type, 0);
+		dst->mval->v_char = ldms_mval_as_char(src->mval, src->type, 0);
 		break;
 	case LDMS_V_U8:
 		dst->mval->v_u8 = ldms_mval_as_u8(src->mval, src->type, 0);

--- a/ldms/src/decomp/static/decomp_static.c
+++ b/ldms/src/decomp/static/decomp_static.c
@@ -915,11 +915,12 @@ static int resolve_col(struct resolve_ctxt_s *ctxt,
 	if (mid < 0) {
 		/* This is a fill candidate, must have a type and if
 		 * an array a length */
-		if (cfg_col->type == LDMS_V_NONE) {
+		if (!cfg_col->fill) {
 			ldmsd_log(LDMSD_LERROR,
 				"strgp '%s': col[src] '%s' does not exist in "
-				"the set and the 'type' is not specified.\n",
-				ctxt->strgp->obj.name, cfg_col->src);
+				"the set '%s' and the 'fill' is not specified.\n",
+				ctxt->strgp->obj.name, cfg_col->src,
+				ldms_set_name_get(ctxt->set));
 			rc = EINVAL;
 			goto err;
 		}


### PR DESCRIPTION
This PR addressed #1495 . This PR (with #1498 and #1499) has been tested with these test cases in `ldms-test` repo (branch `b4.4`):
 - updated [ldmsd_decomp_test](https://github.com/ovis-hpc/ldms-test/blob/b4.4/ldmsd_decomp_test) with all "fill" types.
 - existing decomposition-related test cases
   - [ldmsd_decomp_no_fill_test](https://github.com/ovis-hpc/ldms-test/blob/b4.4/ldmsd_decomp_no_fill_test)
   - [ldmsd_decomp_static_omit_test](https://github.com/ovis-hpc/ldms-test/blob/b4.4/ldmsd_decomp_static_omit_test)
   - [ldmsd_flex_decomp_test](https://github.com/ovis-hpc/ldms-test/blob/b4.4/ldmsd_flex_decomp_test)