### PR TITLE
[main] rdc_sampler fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -150,6 +150,8 @@ AC_LIB_HAVE_LINKFLAGS([rdc_bootstrap], [], [
 ])
 AM_CONDITIONAL([HAVE_LIBRDC_BOOTSTRAP], [test "x$HAVE_LIBRDC_BOOTSTRAP" = xyes])
 
+AC_LIB_HAVE_LINKFLAGS([rdc_ras], [], [])
+
 AC_ARG_ENABLE([rdc],
 	[AS_HELP_STRING([--enable-rdc], [Include components that depend upon AMD rdc tooling. @<:@default=no@:>@ for GPUs.])],
 	[],

--- a/configure.ac
+++ b/configure.ac
@@ -145,7 +145,10 @@ m4_ifndef([PKG_CHECK_MODULES],
       [m4_fatal([pkg.m4 not found. Please install pkg-config (Ubuntu) or pkgconfig (RHEL) package])])
 PKG_PROG_PKG_CONFIG
 
+# <rdc/rdc.h> fails to include <assert.h> in at least rocm 6.2.1, hence the
+# include of assert.h here.
 AC_LIB_HAVE_LINKFLAGS([rdc_bootstrap], [], [
+#include <assert.h>
 #include <rdc/rdc.h>
 ])
 AM_CONDITIONAL([HAVE_LIBRDC_BOOTSTRAP], [test "x$HAVE_LIBRDC_BOOTSTRAP" = xyes])

--- a/ldms/src/sampler/rdc_sampler/Makefile.am
+++ b/ldms/src/sampler/rdc_sampler/Makefile.am
@@ -9,6 +9,7 @@ librdc_sampler_la_CFLAGS  = $(AM_CFLAGS)
 librdc_sampler_la_LDFLAGS = $(AM_LDFLAGS)
 librdc_sampler_la_LIBADD  = \
 	$(LTLIBRDC_BOOTSTRAP) \
+	$(LTLIBRDC_RAS) \
 	$(top_builddir)/ldms/src/sampler/libsampler_base.la \
 	$(top_builddir)/ldms/src/ldmsd/libldmsd_plugattr.la \
 	$(top_builddir)/ldms/src/core/libldms.la \
@@ -23,6 +24,7 @@ ldms_rdc_schema_name_CFLAGS = $(AM_CFLAGS) -DMAIN
 ldms_rdc_schema_name_LDFLAGS = $(AM_LDFLAG)
 ldms_rdc_schema_name_LDADD = \
 	$(LIBRDC_BOOTSTRAP) \
+	$(LIBRDC_RAS) \
 	$(top_builddir)/ldms/src/ldmsd/libldmsd_plugattr.la \
 	$(top_builddir)/ldms/src/core/libldms.la \
 	$(top_builddir)/lib/src/ovis_util/libovis_util.la \

--- a/ldms/src/sampler/rdc_sampler/rdcinfo.h
+++ b/ldms/src/sampler/rdc_sampler/rdcinfo.h
@@ -55,6 +55,9 @@
 #include "ldmsd.h"
 #include "ovis_json/ovis_json.h"
 #include "sampler_base.h"
+/* rdc/rdc.h in at least ROCm 6.2.1 forget to include <assert.h>, so we
+ * include it here for them before including <rdc/rdc.h> */
+#include <assert.h>
 #include <rdc/rdc.h>
 
 #define SAMP "rdc_sampler"


### PR DESCRIPTION
Some fixes to allow compiling rdc_sampler with ROCm 6.2.1.