### PR TITLE
[b4.4] static decomposition: yield a config error for "op" without "group"

### DIFF
--- a/ldms/src/decomp/static/decomp_static.c
+++ b/ldms/src/decomp/static/decomp_static.c
@@ -830,6 +830,14 @@ decomp_static_config(ldmsd_strgp_t strgp, json_t *jcfg,
 			rc = handle_group(strgp, jgroup, cfg_row, row_no, reqc);
 			if (rc)
 				goto err_0;
+		} else if (cfg_row->op_present) {
+			/* has "op", but has no "group" */
+			errno = EINVAL;
+			THISLOG(reqc, errno,
+				"%s: schema \"%s\" requires \"group\" due to"
+				" the presence of \"op\".\n",
+				strgp->obj.name, cfg_row->schema_name);
+			goto err_0;
 		}
 
 		dcfg->row_count++;


### PR DESCRIPTION
When "op" was present in the static decomposition configuration but "group" was not defined, the static decomposition skipped row cache creation and continue working with `row_cache` being `NULL`. Consequently, when `decompose()` was later called, `ldmsd` terminated with SIGSEGV.

This patch add a sanity check in `config()` so that the static decomposition yields an error when "group" is missing in the presence of "op".