### PR TITLE
Fix Sampler Advertisement bugs

### DIFF
--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -341,6 +341,7 @@ class LDMSD_Req_Attr(object):
                    'reconnect' : INTERVAL,
                    'size' : SIZE,
                    'IP' : IP,
+                   'ip' : IP,
                    'TERMINATING': LAST
         }
 


### PR DESCRIPTION
The patch fixes the following bugs:
 - prdcr_listen_status when there are multiple prdcr_listen objects
 - 'ip' attribute name isn't recognized by ldmsd_communicator.py
 - Remove prdcr_listen when an error at prdcr_listen_add