### PR TITLE
Fix Sampler Advertisement bugs

### DIFF
--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -384,6 +384,7 @@ class LDMSD_Req_Attr(object):
                    'summary' : SUMMARY,
                    'size' : SIZE,
                    'IP' : IP,
+                   'ip' : IP,
                    'ask_interval': ASK_INTERVAL,
                    'ask_mark': ASK_MARK,
                    'ask_amount': ASK_AMOUNT,


### PR DESCRIPTION
The patch fixes the following bugs:
 - prdcr_listen_status when there are multiple prdcr_listen objects
 - 'ip' attribute name isn't recognized by ldmsd_communicator.py
 - Remove prdcr_listen when an error at prdcr_listen_add