### PR TITLE
Fix ovis_event thrstat calculation

### DIFF
--- a/lib/src/ovis_event/ovis_event.c
+++ b/lib/src/ovis_event/ovis_event.c
@@ -664,7 +664,7 @@ static void __thrstat_wait_start(ovis_event_thrstat_t stats)
 
 	clock_gettime(CLOCK_REALTIME, &now);
 	stats->wait_start = now;
-	stats->wait_tot += __timespec_diff_us(&stats->wait_end, &now);
+	stats->proc_tot += __timespec_diff_us(&stats->wait_end, &now);
 	stats->waiting = 1;
 }
 
@@ -673,7 +673,7 @@ static void __thrstat_wait_end(ovis_event_thrstat_t stats)
 	struct timespec now;
 	clock_gettime(CLOCK_REALTIME, &now);
 	stats->wait_end = now;
-	stats->proc_tot += __timespec_diff_us(&stats->wait_start, &now);
+	stats->wait_tot += __timespec_diff_us(&stats->wait_start, &now);
 	stats->waiting = 0;
 }
 


### PR DESCRIPTION
When `__thrstat_wait_start()` was called, the caller was going into INACTIVE state from ACTIVE state. Hence, the duration from `wait_end` to `now` was the active time and should be added to `proc_tot`.

Likewise, when `__thrstat_wait_end()` was called, the caller just woke up. Hence, the duration from `wait_start` to `now` was an INACTIVE time and should be added to `wait_tot`.