### PR TITLE
Add requests to enable/disable streams communication

### DIFF
--- a/ldms/man/ldmsd_controller.man
+++ b/ldms/man/ldmsd_controller.man
@@ -12,18 +12,9 @@ ldmsd_controller \- a python program to configure an ldms daemon.
 ldmsd_controller> <cmd> [ <attr>=<value> ]
 
 .SH DESCRIPTION
-With LDMS (Lightweight Distributed Metric Service), the ldmsd
-can be configured via the ldmsd_controller.
-
-If ldms is built with --enable-readline, one can invoke the ldmsd_controller
-from the command line and obtain an input interface with feedback. In many
-instances, instances, however, it is prefered to execute scripts and send the
-output commands to an ldmsd instead.
+Configure and query the status of a running LDMSD daemon.
 
 .SH ENVIRONMENT
-Note: python2.6 with the additional installation of the argparse module
-OR python2.7 (which has the argparse module) is required.
-
 .TP
 PYTHONPATH
 <path_to_ovis_install>/lib[64]/pythonX.Y/site-packages/
@@ -402,6 +393,14 @@ attr=<value>
 The producer name. If none is given, the statuses of all producers are
 reported.
 .RE
+
+.SS Disable stream communication
+.BR stream_disable
+.br
+Disable the subscription and publication of data on a stream in this daemon.
+Once stream communication is disabled, all stream requests will result in an
+error of ENOSYS. Stream communication cannot be re-enabled without restarting
+the daemon.
 
 .SS Subscribe for stream data from all matching producers
 .BR prdcr_subsribe

--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -134,6 +134,8 @@ LDMSD_CTRL_CMD_MAP = {'usage': {'req_attr': [], 'opt_attr': ['name']},
                       'subscribe': {'req_attr': ['name'], 'opt_attr': []},
                       'stream_client_dump': {'req_attr': [], 'opt_attr': []},
                       'stream_status' : {'req_attr': [], 'opt_attr': []},
+                      'stream_disable' : {'req_attr': [], 'opt_attr':[]},
+
                       ##### Daemon #####
                       'daemon_status': {'req_attr': [], 'opt_attr': ['thread_stats']},
                       ##### Misc. #####
@@ -582,6 +584,8 @@ class LDMSD_Request(object):
     STREAM_CLIENT_DUMP = STREAM_PUBLISH + 3
     STREAM_NEW = STREAM_PUBLISH + 4
     STREAM_STATUS = STREAM_PUBLISH + 5
+    STREAM_ENABLE = STREAM_PUBLISH + 6
+    STREAM_DISABLE = STREAM_PUBLISH + 7
 
     AUTH_ADD = 0xa00
 
@@ -681,6 +685,7 @@ class LDMSD_Request(object):
 
             'stream_client_dump'   :  {'id' : STREAM_CLIENT_DUMP },
             'stream_status'    :  {'id' : STREAM_STATUS },
+            'stream_disable'   :  {'id' : STREAM_DISABLE },
 
             'listen'        :  {'id' : LISTEN },
             'auth_add'      :  {'id' : AUTH_ADD },
@@ -1412,6 +1417,20 @@ class Communicator(object):
         No parameters
         """
         req = LDMSD_Request(command_id=LDMSD_Request.STREAM_STATUS)
+        try:
+            req.send(self)
+            resp = req.receive(self)
+            return resp['errcode'], resp['msg']
+        except Exception as e:
+            return errno.ENOTCONN, str(e)
+
+    def stream_disable(self):
+        """
+        Disable stream communication in the daemon
+
+        No parameters
+        """
+        req = LDMSD_Request(command_id=LDMSD_Request.STREAM_DISABLE)
         try:
             req.send(self)
             resp = req.receive(self)

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -522,7 +522,8 @@ class LdmsdCmdParser(cmd.Cmd):
 
     def do_prdcr_stream_status(self, arg):
         """
-        Get stream_status of the matched prdcr. The connected LDMSD acts as a proxy.
+        Report the stream status of each producer matched by the regular expression.
+
         Parameters:
         regex=     A regular expression matching producer names
         """
@@ -2031,7 +2032,7 @@ class LdmsdCmdParser(cmd.Cmd):
 
     def do_stream_status(self, arg):
         """
-        Dump the stream information
+        Report stream status information for each stream known to the daemon
 
         No Parameters
         """
@@ -2098,6 +2099,22 @@ class LdmsdCmdParser(cmd.Cmd):
 
     def complete_stream_status(self, text, line, begidx, endidx):
         return self.__complete_attr_list('stream_status', text)
+
+    def do_stream_disable(self, arg):
+        """
+        Disable stream communication in the daemon
+
+        No Parameters
+        """
+        rc, msg = self.comm.stream_disable()
+        if rc != 0:
+            print(f'Error {rc}: {msg}')
+        else:
+            print('Streams communication is DISABLED in the daemon')
+        return
+
+    def complete_stream_disable(self, text, line, begidx, endidx):
+        return self.__complete_attr_list('stream_disable', text)
 
     def do_listen(self, arg):
         """

--- a/ldms/src/ldmsd/ldmsd_request.h
+++ b/ldms/src/ldmsd/ldmsd_request.h
@@ -182,12 +182,13 @@ enum ldmsd_request {
 	LDMSD_SETGROUP_RM_REQ, /* Remove a set from a group */
 
 	/* Publish/Subscribe Requests */
-	LDMSD_STREAM_PUBLISH_REQ = 0x900, /* Publish data to a stream */
-	LDMSD_STREAM_SUBSCRIBE_REQ,	  /* Subscribe to a stream */
-	LDMSD_STREAM_UNSUBSCRIBE_REQ,	  /* Unsubscribe to a stream */
-	LDMSD_STREAM_CLIENT_DUMP_REQ,	  /* Dump stream client info */
-	LDMSD_STREAM_NEW_REQ,	/* Create a stream */
+	LDMSD_STREAM_PUBLISH_REQ = 0x900,/* Publish data to a stream */
+	LDMSD_STREAM_SUBSCRIBE_REQ,	/* Subscribe to a stream */
+	LDMSD_STREAM_UNSUBSCRIBE_REQ,	/* Unsubscribe to a stream */
+	LDMSD_STREAM_CLIENT_DUMP_REQ,	/* Dump stream client info */
+	LDMSD_STREAM_NEW_REQ,		/* Create a stream */
 	LDMSD_STREAM_STATUS_REQ,	/* Query stream information */
+	LDMSD_STREAM_DISABLE_REQ,	/* Disable streams in this daemon */
 
 	/* Auth */
 	LDMSD_AUTH_ADD_REQ = 0xa00, /* Add auth domain */

--- a/ldms/src/ldmsd/ldmsd_request_util.c
+++ b/ldms/src/ldmsd/ldmsd_request_util.c
@@ -120,7 +120,8 @@ const struct req_str_id req_str_id_table[] = {
 	{  "start",              LDMSD_PLUGN_START_REQ  },
 	{  "stop",               LDMSD_PLUGN_STOP_REQ  },
 	{  "stream_client_dump", LDMSD_STREAM_CLIENT_DUMP_REQ  },
-	{  "stream_status",         LDMSD_STREAM_STATUS_REQ  },
+	{  "stream_disable",     LDMSD_STREAM_DISABLE_REQ  },
+	{  "stream_status",      LDMSD_STREAM_STATUS_REQ  },
 	{  "strgp_add",          LDMSD_STRGP_ADD_REQ  },
 	{  "strgp_del",          LDMSD_STRGP_DEL_REQ  },
 	{  "strgp_metric_add",   LDMSD_STRGP_METRIC_ADD_REQ  },
@@ -327,6 +328,7 @@ const char *ldmsd_req_id2str(enum ldmsd_request req_id)
 	case LDMSD_STREAM_PUBLISH_REQ : return "STREAM_PUBLISH_REQ";
 	case LDMSD_STREAM_NEW_REQ : return "STREAM_NEW_REQ";
 	case LDMSD_STREAM_STATUS_REQ : return "STREAM_DIR_REQ";
+	case LDMSD_STREAM_DISABLE_REQ : return "STREAM_DISABLE_REQ";
 	default: return "UNKNOWN_REQ";
 	}
 }


### PR DESCRIPTION
This change adds a command to disable stream support in the ldmsd daemon. When streams communication is disabled, stream data cannot be published to or subscribed from the daemon.

The current default of enabled is maintained.