### PR TITLE
fix errno report in  blobwriter, stop warning about repeat subscribe

### DIFF
--- a/ldms/src/ldmsd/ldmsd_stream.c
+++ b/ldms/src/ldmsd/ldmsd_stream.c
@@ -346,8 +346,11 @@ ldmsd_stream_subscribe(const char *stream_name,
 	}
 	LIST_FOREACH(cc, &s->s_c_list, c_ent) {
 		if (cc->c_cb_fn == cb_fn && cc->c_ctxt == ctxt) {
+#if 0
+			/* this is a high frequency common case */
 			msglog("The client %p is already subscribed to "
 			       "stream %s\n", cc, stream_name);
+#endif
 			errno = EEXIST;
 			pthread_mutex_unlock(&s->s_lock);
 			goto err_1;

--- a/ldms/src/sampler/blob_stream/blob_stream_writer.c
+++ b/ldms/src/sampler/blob_stream/blob_stream_writer.c
@@ -246,6 +246,7 @@ static void fclose_and_spool(FILE* *f, char* *fname, int final)
 			sprintf(rbuf, "%s/spool/%s", dirn, base);
 			err = rename(*fname, rbuf);
 			if (err) {
+				err = errno;
 				msglog(LDMSD_LERROR, PNAME
 					": rename_output: failed rename(%s, %s):"
 					" %s\n", *fname, rbuf, STRERROR(err));


### PR DESCRIPTION
fix errno misreported in blobwriter, and stop warning about repeat subscribe, which happens a lot (50000 out of 55000 log lines in a recent case)