### PR TITLE
Fix `ldms_xprt_connect_by_name()` wrong xprt type handling in sync mode

### DIFF
--- a/ldms/src/core/ldms_rail.c
+++ b/ldms/src/core/ldms_rail.c
@@ -1993,3 +1993,56 @@ void __rail_process_rate_reconfig(ldms_t x, struct ldms_request *req)
 		rep->rate_quota.rate = rate;
 	}
 }
+
+void sync_connect_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
+{
+	ldms_rail_t r = (ldms_rail_t)x;
+	switch (e->type) {
+	case LDMS_XPRT_EVENT_CONNECTED:
+		r->sem_rc = 0;
+		sem_post(&r->sem);
+		break;
+	case LDMS_XPRT_EVENT_REJECTED:
+	case LDMS_XPRT_EVENT_ERROR:
+	case LDMS_XPRT_EVENT_DISCONNECTED:
+		r->sem_rc = ECONNREFUSED;
+		sem_post(&r->sem);
+		break;
+	case LDMS_XPRT_EVENT_RECV:
+		break;
+	case LDMS_XPRT_EVENT_SET_DELETE:
+	case LDMS_XPRT_EVENT_SEND_COMPLETE:
+	case LDMS_XPRT_EVENT_SEND_QUOTA_DEPOSITED:
+		/* Don't post */
+		return;
+	default:
+		RAIL_LOG("sync_connect_cb: unexpected "
+				"ldms_xprt event value %d\n", (int) e->type);
+		assert(0 == "sync_connect_cb: unexpected ldms_xprt event value");
+	}
+}
+
+int ldms_rail_connect_by_name(ldms_t x, const char *host, const char *port,
+			      ldms_event_cb_t cb, void *cb_arg)
+{
+	ldms_rail_t r = (ldms_rail_t)x;
+	struct addrinfo *ai;
+	struct addrinfo hints = {
+		.ai_socktype = SOCK_STREAM
+	};
+	int rc = getaddrinfo(host, port, &hints, &ai);
+	if (rc)
+		return EHOSTUNREACH;
+	if (!cb) {
+		rc = ldms_xprt_connect(x, ai->ai_addr, ai->ai_addrlen, sync_connect_cb, cb_arg);
+		if (rc)
+			goto out;
+		sem_wait(&r->sem);
+		rc = r->sem_rc;
+	} else {
+		rc = ldms_xprt_connect(x, ai->ai_addr, ai->ai_addrlen, cb, cb_arg);
+	}
+out:
+	freeaddrinfo(ai);
+	return rc;
+}


### PR DESCRIPTION
The application-facing xprts are now rails. However `ldms_xprt_connect_by_name()` handled it as xprt and consequently corrupt the rail structure. This patch moves the related code into `ldms_rail.c` and handle it as rail accordingly.