### PR TITLE
ldmsd_controller age for stream_status v4.4.x

### DIFF
--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -60,6 +60,7 @@ import os
 import traceback
 import json
 import re
+import time
 from datetime import datetime
 
 from ldmsd import ldmsd_util
@@ -2097,23 +2098,32 @@ class LdmsdCmdParser(cmd.Cmd):
             print(f'Error {rc}: {msg}')
             return
         streams = fmt_status(msg)
-        print(f'{"name":30} {"bytes/sec":12} {"msg/sec":12} {"total bytes":12} {"msg count":12} {"first msg":12} {"last msg":12}')
-        print("-" * 30, "-" * 12, "-" * 12, "-" * 12, "-" * 12, "-" * 12, "-" * 12)
-        # print("--------------- -------------- --------------- ----- ----------------- -----------\n")
+        print(f'{"name":30} {"bytes/sec":12} {"msg/sec":12} {"total bytes":12} {"msg count":12} {"first msg":12} {"last msg":12} {"last_age_sec":12}')
+        print("-" * 30, "-" * 12, "-" * 12, "-" * 12, "-" * 12, "-" * 12, "-" * 12, "-" * 12)
+        # print("--------------- -------------- --------------- ----- ----------------- ----------- -----------\n")
+        now = time.time()
         for name,s in streams.items():
             if name == "_OVERALL_":
                 s['mode'] = ""
                 print(f"{name}")
             else:
                 print(f"{name} ({s['mode']})")
-
-            print(f"{'   published':<30} {rate(s['pub']):>12} {freq(s['pub']):>12} {total_bytes(s['pub']):>12} {count(s['pub']):>12} {first(s['pub']):>12} {last(s['pub']):>12}")
-            print(f"{'   received':<30} {rate(s['recv']):>12} {freq(s['recv']):>12} {total_bytes(s['recv']):>12} {count(s['recv']):>12} {first(s['recv']):>12} {last(s['recv']):>12}")
+                if last(s['pub']) == "-":
+                    age = "-"
+                else:
+                    age = int(now - last(s['pub']))
+                print(f"{'   published':<30} {rate(s['pub']):>12} {freq(s['pub']):>12} {total_bytes(s['pub']):>12} {count(s['pub']):>12} {first(s['pub']):>12} {last(s['pub']):>12} {age:>12}")
+                if last(s['recv']) == "-":
+                    age = "-"
+                else:
+                    age = int(now - last(s['recv']))
+                print(f"{'   received':<30} {rate(s['recv']):>12} {freq(s['recv']):>12} {total_bytes(s['recv']):>12} {count(s['recv']):>12} {first(s['recv']):>12} {last(s['recv']):>12} {age:>12}")
             if 'publishers' not in s.keys() or len(s['publishers']) == 0:
                 continue
             print("      Producers")
             for name,p in s['publishers'].items():
-                print(f"{' '*14} {name:15} {rate(p['recv']):>12} {freq(p['recv']):>12} {total_bytes(p['recv']):>12} {count(p['recv']):>12} {first(p['recv']):>12} {last(p['recv']):>12}")
+                    age = int(now - last(p['recv']))
+                    print(f"{' '*14} {name:15} {rate(p['recv']):>12} {freq(p['recv']):>12} {total_bytes(p['recv']):>12} {count(p['recv']):>12} {first(p['recv']):>12} {last(p['recv']):>12} {age:>12}")
 
     def complete_stream_status(self, text, line, begidx, endidx):
         return self.__complete_attr_list('stream_status', text)


### PR DESCRIPTION
This expands the stream_status output format with last_age_sec (now - last msg):
```
name                           bytes/sec    msg/sec      total bytes  msg count    first msg    last msg     last_age_sec
------------------------------ ------------ ------------ ------------ ------------ ------------ ------------ ------------
darshanConnector (subscribed)
   published                              -            -            -            -            -            -            -
   received                               -            -            -            -            -            -            -
slurm (subscribed)
   published                   40658.053212    93.509272    151288616       347948   1738602030   1738605751            0
   received                    40949.431556     94.08465    152864228       351218   1738602018   1738605751            0
      Producers
               amber1             17.031963     0.100188        63410          373   1738602019   1738605742            9
```
This is very helpful in finding nodes with an unexpectedly old last stream message. 