### PR TITLE
added use of base, when configured, in dcgm sampling.

### DIFF
--- a/ldms/scripts/examples/dcgm1.1
+++ b/ldms/scripts/examples/dcgm1.1
@@ -1,3 +1,3 @@
 load name=dcgm_sampler
-config name=dcgm_sampler producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} interval=1000000 perm=757 uid=3556 gid=3556 job_set=instance=localhost${i}/job_info use_base=1
+config name=dcgm_sampler producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} interval=1000000 perm=757 uid=3556 gid=3556 job_set=localhost${i}/jobid use_base=1
 start name=dcgm_sampler interval=1000000 offset=0

--- a/ldms/scripts/examples/dcgm1.2
+++ b/ldms/scripts/examples/dcgm1.2
@@ -13,3 +13,7 @@ updtr_start name=allhosts
 strgp_add name=store_${testname} plugin=store_csv schema=${testname} container=node
 strgp_prdcr_add name=store_${testname} regex=.*
 strgp_start name=store_${testname}
+
+strgp_add name=jobid.csv plugin=store_csv schema=jobid container=node
+strgp_prdcr_add name=jobid.csv regex=.*
+strgp_start name=jobid.csv


### PR DESCRIPTION
before jobid data didn't get set if use_base was set.