### PR TITLE
Fix incorrect cast in ovis_json

### DIFF
--- a/lib/src/ovis_json/ovis_json.c
+++ b/lib/src/ovis_json/ovis_json.c
@@ -738,7 +738,7 @@ json_entity_t __attr_value_new(int type, va_list *ap)
 		v = json_entity_new(type, va_arg(*ap, double));
 		break;
 	case JSON_INT_VALUE:
-		v = json_entity_new(type, va_arg(*ap, uint64_t));
+		v = json_entity_new(type, va_arg(*ap, int));
 		break;
 	case JSON_STRING_VALUE:
 		v = json_entity_new(type, va_arg(*ap, char *));


### PR DESCRIPTION
The symptom here was a garbage value for the sample count.

The JSON_INT is passed as an int, however, the ovis_json logic was using uint64_t to pull the value from the stack. This resulted in garbage values on some platforms.