### PR TITLE
Fix wrong reference put in `qgroup_member_add` handler

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -10327,7 +10327,7 @@ static int qgroup_member_add_handler(ldmsd_req_ctxt_t reqc)
 	free(a_port);
 	free(a_xprt);
 	free(a_auth);
-	ldmsd_cfgobj_put(&auth->obj, "init");
+	ldmsd_cfgobj_put(&auth->obj, "find");
 	return rc;
 }
 


### PR DESCRIPTION
The reference of the auth object was obtained by "find".