### PR TITLE
Fix __APPEND macro to prevent infinite loop of reallocation

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -6661,6 +6661,7 @@ struct op_summary {
 #define __APPEND(...) do {					\
 	int len = snprintf(s, sz, __VA_ARGS__);			\
 	if (len >= sz) {					\
+		len = ((len + 1)?(len == sz):len);		\
 		uint64_t off = (uint64_t)s - (uint64_t)buff;	\
 		sz += LDMS_ROUNDUP(len-sz, __APPEND_SZ);	\
 		s = realloc(buff, off + sz);			\


### PR DESCRIPTION
The macro was causing an indefinite loop when the length of the string to be appended equaled the size of the remaining buffer. In this case, LDMS_ROUNDUP(len-sz, __APPEND_SZ) evaluted to zero, resulting in reallocation with the same buffer size repeatedly.

This patch ensures that the buffer is always reallocated with a larger size when len == sz, preventing the infinite loop condition.