### PR TITLE
Fix __APPEND macro to prevent infinite loop of reallocation

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -6662,7 +6662,10 @@ struct op_summary {
 	int len = snprintf(s, sz, __VA_ARGS__);			\
 	if (len >= sz) {					\
 		uint64_t off = (uint64_t)s - (uint64_t)buff;	\
-		sz += LDMS_ROUNDUP(len-sz, __APPEND_SZ);	\
+		uint64_t bump = LDMS_ROUNDUP(len-sz, __APPEND_SZ);  \
+		if (bump == 0)					\
+			bump = __APPEND_SZ;			\
+		sz += bump;					\
 		s = realloc(buff, off + sz);			\
 		if (!s) {					\
 			goto __APPEND_ERR;			\


### PR DESCRIPTION
The macro was causing an indefinite loop when the length of the string to be appended equaled the size of the remaining buffer. In this case, LDMS_ROUNDUP(len-sz, __APPEND_SZ) evaluted to zero, resulting in reallocation with the same buffer size repeatedly.

This patch ensures that the buffer is always reallocated with a larger size when len == sz, preventing the infinite loop condition.