### PR TITLE
Fix dump_cfg ldmsd command

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -5326,7 +5326,7 @@ static int plugn_config_handler(ldmsd_req_ctxt_t reqc)
 	free(cfg->avl_str);
 	free(cfg->kvl_str);
 	cfg->avl_str = av_to_string(av_list, 0);
-	cfg->kvl_str = av_to_string(kw_list, 0);
+	cfg->kvl_str = (kw_list->count)?av_to_string(kw_list, 0):"";
 
 	exclusive_thread = av_value(av_list, "exclusive_thread");
 	if (exclusive_thread && sampler)
@@ -6449,9 +6449,10 @@ static int dump_cfg_handler(ldmsd_req_ctxt_t reqc)
 	ldmsd_cfg_lock(LDMSD_CFGOBJ_STORE);
 	for (store = ldmsd_store_first(LDMSD_CFGOBJ_STORE); store;
 			store = ldmsd_store_next(store)) {
-		fprintf(fp, "load name=%s as=%s\n", store->api->base.name, store->api->base.cfg_name);
+		fprintf(fp, "load name=%s plugin=%s\n", store->api->base.cfg_name, store->api->base.name);
 		if (store->cfg.avl_str || store->cfg.kvl_str)
-			fprintf(fp, "config name=%s %s\n",
+			fprintf(fp, "config name=%s %s %s\n",
+				store->api->base.cfg_name,
 				store->cfg.avl_str ? store->cfg.avl_str : "",
 				store->cfg.kvl_str ? store->cfg.kvl_str : "");
 	}
@@ -6460,9 +6461,10 @@ static int dump_cfg_handler(ldmsd_req_ctxt_t reqc)
 	ldmsd_cfgobj_sampler_t samp;
 	for (samp = ldmsd_sampler_first(); samp;
 			samp = ldmsd_sampler_next(samp)) {
-		fprintf(fp, "load name=%s as=%s\n", samp->api->base.name, samp->api->base.cfg_name);
+		fprintf(fp, "load name=%s plugin=%s\n", samp->api->base.cfg_name, samp->api->base.name);
 		if (samp->cfg.avl_str || samp->cfg.kvl_str)
-			fprintf(fp, "config name=%s %s\n",
+			fprintf(fp, "config name=%s %s %s\n",
+				samp->api->base.cfg_name,
 				samp->cfg.avl_str ? samp->cfg.avl_str : "",
 				samp->cfg.kvl_str ? samp->cfg.kvl_str : "");
 		if (samp->thread_id >= 0) {


### PR DESCRIPTION
- Fix incorrect `config` output, missing the value of `name` attribute.

- The `config` line produced by `dump_cfg` has "(empty)" appended at the end. This caused by `av_to_string()` produced literal "(empty)" when the keyword list has no entry (the keyword list usually has no entry). The memorized keyword list is now checked if it is empty first and uses "" instead of calling `av_to_string()` if it is an empty list. The attribute-value list does not have this issue because all plugins has at least "name" attribute in its config line.

- Fix the `load name=PLUGIN as=INST` output to `load name=INST plugin=PLUGIN`.