### PR TITLE
Add "Interval" and "Offset" back to `plugn_status` command

### DIFF
--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1588,12 +1588,15 @@ class LdmsdCmdParser(cmd.Cmd):
         rc, msg = self.comm.plugn_status(arg['name'])
         if rc == 0:
             plugins = fmt_status(msg)
-            print("Config Name  Plugin                   Type         libpath")
-            print("------------ ------------------------ ------------ ------------")
+            print(f"{'Config Name':12}", f"{'Plugin':24}", f"{'Type':12}",
+                  f"{'Interval':12}", f"{'Offset':12}", f"{'libpath':12}")
+            print('-'*12, '-'*24, '-'*12, '-'*12, '-'*12, '-'*12)
             for plugn in plugins:
-                print("{0:12} {1:24} {2:12} {3}".format(
-                    plugn['name'], plugn['plugin'], plugn['type'],
-                    plugn['libpath']))
+                print(f"{plugn['name']:12}", f"{plugn['plugin']:24}",
+                      f"{plugn['type']:12}",
+                      f"{plugn.get('sample_interval_us', '-'):12}",
+                      f"{plugn.get('sample_offset_us', '-'):12}",
+                      f"{plugn['libpath']}")
 
     def do_plugn_sets(self, arg):
         """

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -5094,10 +5094,14 @@ int __plugn_status_json_obj(ldmsd_req_ctxt_t reqc)
 		count++;
 		rc = linebuf_printf(reqc,
 			       "{\"name\":\"%s\",\"plugin\":\"%s\",\"type\":\"%s\","
+			       "\"sample_interval_us\":%ld,"
+			       "\"sample_offset_us\":%ld,"
 			       "\"libpath\":\"%s\"}",
 			       samp->cfg.name,
 			       samp->api->base.name,
 			       plugn_state_str(samp->api->base.type),
+			       samp->sample_interval_us,
+			       samp->sample_offset_us,
 			       samp->api->base.libpath);
 		if (rc) {
 			ldmsd_cfg_unlock(LDMSD_CFGOBJ_SAMPLER);


### PR DESCRIPTION
The "Interval" and "Offset" sampling information has been (accidentally?) removed from the `plugn_status` command. This patch added them back. For storage plugin, the values of "Interval" and "Offset" are "-".

NOTE: Currently there is no other command to obtain the sampling interval.