### PR TITLE
dcgm_sampler: Add documentation about nv-hostengine

### DIFF
--- a/ldms/src/sampler/dcgm_sampler/Plugin_dcgm_sampler.man
+++ b/ldms/src/sampler/dcgm_sampler/Plugin_dcgm_sampler.man
@@ -13,6 +13,8 @@ With LDMS (Lightweight Distributed Metric Service), plugins for the ldmsd (ldms 
 or a configuration file. The dcgm_sampler plugin provides a metric set for each DCGM-compatible Nvidia GPU on the system.
 The schema is named "dcgm" by default.
 
+NOTE: This sampler requires the NVidia DCGM daemon "nv-hostengine" running before it can be configured in ldmsd.
+
 .SH CONFIGURATION ATTRIBUTE SYNTAX
 
 .TP

--- a/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
+++ b/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
@@ -160,7 +160,7 @@ static int dcgm_init()
         if (standalone) {
                 rc = dcgmConnect(host_ip, &dcgm_handle);
                 if (rc != DCGM_ST_OK) {
-                        log_fn(LDMSD_LERROR, SAMP" dcgmConnect() failed: %s(%d)\n",
+                        log_fn(LDMSD_LERROR, SAMP" dcgmConnect() failed: %s(%d) (is DCGM's nv-hostengine daemon running?)\n",
                                errorString(rc), rc);
                         return -1;
                 }


### PR DESCRIPTION
dcgm_sampler: Add documentation about nv-hostengine
    
Update the man page for dcgm_sampler to explain its requirement on the nv-hostengine daemon.
Improve a dcgm_sampler error message to suggest checking for nv-hostengine when dcgmConnect() fails.
    
Fixes #1636
