### PR TITLE
Fix `load` command's error message

### DIFF
--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -303,8 +303,7 @@ class LdmsdCmdParser(cmd.Cmd):
                 plugin = name
             rc, msg = self.comm.plugn_load(name, plugin)
             if rc:
-                print(f'Error loading configuration named {arg["name"]} '
-                      f'with plugin {arg["plugin"]}')
+                print(msg)
 
     def complete_load(self, text, line, begidx, endidx):
         return self.__complete_attr_list('load', text)


### PR DESCRIPTION
When issuing the following command through `ldmsd_controller`

    load name=bogus

the error message returned was

    Error loading configuration named bogus with plugin None

In addition, when issuing the same load command through `ldmsctl`, there was no error message printed at all. This was because the response message from `ldmsd` only contained the error code with empty message.

This patch modified `ldmsd` to also return the error message in the response, and both `ldmsd_controller` and `ldmsctl` can just print the error message from the response. This patch also modified `ldmsd_load_plugn()` and `load_plugin()` to add more details in the error response, e.g.:

    Error 2 configuration named 'bogus' with plugin 'bogus': failed to
    load the plugin, dlerror: /opt/ovis/lib64/ovis-ldms/libbogus.so:
    cannot open shared object file: No such file or directory