### PR TITLE
Fix SIGSEGV in case of invalid log level

### DIFF
--- a/lib/src/ovis_log/ovis_log.c
+++ b/lib/src/ovis_log/ovis_log.c
@@ -290,11 +290,11 @@ int ovis_log_str_to_level(const char *level_s)
 	/*
 	 * A single log level name is given.
 	 */
-	for (i = 0; strcasecmp(level_tbl[i].name, level_s); i++);
+	for (i = 0; level_tbl[i].name && strcasecmp(level_tbl[i].name, level_s); i++);
 	if (!i)
 		return OVIS_LQUIET;
 	if (!level_tbl[i].value)
-		return ENOENT;	/* level_s not found */
+		return -EINVAL;	/* level_s not found */
 	for (rc = 0; level_tbl[i].value; i++)
 		rc |= level_tbl[i].value;
 	return rc;


### PR DESCRIPTION
In the case of single log level, the function find the matching level from the `level_bl`, but it forgot to check the breeaking `NULL` entry and causing segmentation fault. In addition, the return code of the single-level case is also changed to `-EINVAL` to match that of the multi-level case (which matched the test cases).