### PR TITLE
LDMS Variorum Sampler Plugin updated to support Variorum v0.8.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -376,6 +376,11 @@ AC_ARG_ENABLE([variorum],
     [],
     [enable_variorum="check"])
 AS_IF([test "x$enable_variorum" != xno],[
+    PKG_CHECK_MODULES([variorum], [variorum >= 0.8], [variorum_version_check=yes], [variorum_version_check=no])
+    AS_IF([test "x$enable_variorum" != xcheck],[
+        AS_IF([test "x$variorum_version_check" = xno],
+            [AC_MSG_ERROR([variorum pkgconfig file not found, or variorum version is not >= 0.8])])
+    ])
     AC_LIB_HAVE_LINKFLAGS([variorum], [], [#include <variorum.h>
                            #include <variorum_topology.h>])
     AS_IF([test "x$enable_variorum" != xcheck],[
@@ -387,7 +392,7 @@ AS_IF([test "x$enable_variorum" != xno],[
             [AC_MSG_ERROR([libjansson or headers not found])])
     ])
 ])
-AM_CONDITIONAL([ENABLE_VARIORUM_SAMPLER], [test "x$enable_variorum" != no -a "x$HAVE_LIBVARIORUM" = xyes -a "x$HAVE_LIBJANSSON" = xyes])
+AM_CONDITIONAL([ENABLE_VARIORUM_SAMPLER], [test "x$enable_variorum" != no -a "x$HAVE_LIBVARIORUM" = xyes -a "x$variorum_version_check" = xyes -a "x$HAVE_LIBJANSSON" = xyes])
 
 dnl check for libcurl if influx is configured
 OPTION_DEFAULT_DISABLE([influx], [ENABLE_INFLUX])

--- a/ldms/src/contrib/sampler/variorum_sampler/Plugin_variorum_sampler.man
+++ b/ldms/src/contrib/sampler/variorum_sampler/Plugin_variorum_sampler.man
@@ -19,7 +19,7 @@ GPU power consumption in Watts (aggregated across all GPUs on the socket, and
 reported as -1 on unsupported platforms); and memory power consumption in Watts.
 
 .PP
-The variorum sampler depends on Variorum 0.6.0 or higher and Jansson. The sampler cannot be built without these libraries. If either library is installed in a non-standard location, paths to the respective install directories should be provided to Autoconf using
+The variorum sampler depends on Variorum 0.8.0 or higher and Jansson. The sampler cannot be built without these libraries. If either library is installed in a non-standard location, paths to the respective install directories should be provided to Autoconf using
 the --with-libjansson-prefix and/or --with-libvariorum-prefix flag.
 
 .SH CONFIGURATION ATTRIBUTE SYNTAX

--- a/ldms/src/contrib/sampler/variorum_sampler/README.md
+++ b/ldms/src/contrib/sampler/variorum_sampler/README.md
@@ -9,7 +9,7 @@ architecture and implementation.
 Build Requirements
 ------------------
 
-The Variorum LDMS sampler currently requires version 0.6.0 or higher
+The Variorum LDMS sampler currently requires version 0.8.0 or higher
 of the Variorum library (``libvariorum.so``). This library must be built
 from source. The sampler also requires jansson, which is a Variorum
 dependency. If both libraries are installed in standard locations,
@@ -52,7 +52,7 @@ Using the Variorum LDMS Sampler
 
 The sampler, when configured, automatically detects the number of sockets
 on the host machine and then provides, for each socket, an LDMS record
-containing power data. The sampler calls ``variorum_get_node_power_json``
+containing power data. The sampler calls ``variorum_get_power_json``
 internally, for which documentation can be found here:
 [Variorum JSON-Support Functions](https://variorum.readthedocs.io/en/latest/api/json_support_functions.html)
 


### PR DESCRIPTION
Fixes #1431. 
Supersedes #1447.  

This PR updates the JSON API and the parsing of power data based on Variorum 0.8.

ToDo:

- [x] Cleanup comments
- [x] Squash commits
- [x] Test on alehouse after applying Chris' `configure.ac` patch (needed to export `LD_LIBRARY_PATH` as the pkg-config on alehouse is broken)
- [x] Test on Mutt once with setting `PKG_CONFIG_PATH` instead of `LD_LIBRARY_PATH` @slabasan @kshoga1 