### PR TITLE
Refactor ldms_xprt to use ovis_ref and fix rail & xprt references

### DIFF
--- a/ldms/python/ldms.pxd
+++ b/ldms/python/ldms.pxd
@@ -352,7 +352,7 @@ cdef extern from "ldms.h" nogil:
 			  int n, int64_t recv_quota, int32_t rate_limit,
 			  const char *auth_name,
 			  attr_value_list *auth_av_list)
-    void ldms_xprt_put(ldms_t x)
+    void ldms_xprt_put(ldms_t x, const char *name)
     void ldms_xprt_close(ldms_t x)
     int ldms_xprt_connect_by_name(ldms_t x, const char *host, const char *port,
                                   ldms_event_cb_t cb, void *cb_arg)

--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -1512,7 +1512,7 @@ cdef void xprt_cb(ldms_t _x, ldms_xprt_event *e, void *arg) with gil:
             if x.xprt:
                 _xprt = x.xprt
                 x.xprt = NULL
-                ldms_xprt_put(_xprt)
+                ldms_xprt_put(_xprt, "rail_ref")
     if x._conn_cb:
         # Call the callback
         x._conn_cb(x, XprtEvent(PTR(e)), x._conn_cb_arg)
@@ -1570,7 +1570,7 @@ cdef void passive_xprt_cb(ldms_t _x, ldms_xprt_event *e, void *arg) with gil:
         if x.xprt:
             _xprt = x.xprt
             x.xprt = NULL
-            ldms_xprt_put(_xprt)
+            ldms_xprt_put(_xprt, "rail_ref")
     if x._conn_cb:
         # Call the callback
         x._conn_cb(x, XprtEvent(PTR(e)), x._conn_cb_arg)
@@ -3534,7 +3534,7 @@ cdef class Xprt(object):
 
     def __del__(self):
         if self.xprt:
-            ldms_xprt_put(self.xprt)
+            ldms_xprt_put(self.xprt, "rail_ref")
 
     def connect(self, host, port=411, cb=None, cb_arg=None, timeout=None):
         """X.connect(host, port=411, cb=None, cb_arg=None, timeout=None)
@@ -3573,7 +3573,7 @@ cdef class Xprt(object):
                                        xprt_cb, <void*>self)
         if rc:
             # synchronously failed, self.xprt is no good. Need to "put" it down.
-            ldms_xprt_put(self.xprt)
+            ldms_xprt_put(self.xprt, "rail_ref")
             self.xprt = NULL
             raise ConnectionError(rc, "ldms_xprt_connect_by_name() error: {}" \
                                       .format(ERRNO_SYM(rc)))
@@ -3626,7 +3626,7 @@ cdef class Xprt(object):
                                       passive_xprt_cb, <void*>self)
         if rc:
             # synchronously failed, self.xprt is no good. Need to "put" it down.
-            ldms_xprt_put(self.xprt)
+            ldms_xprt_put(self.xprt, "rail_ref")
             self.xprt = NULL
             raise ConnectionError(rc, "ldms_xprt_listen_by_name() error: {}" \
                                       .format(ERRNO_SYM(rc)))
@@ -3650,7 +3650,7 @@ cdef class Xprt(object):
         cdef timespec ts
         if self.xprt:
             ldms_xprt_close(self.xprt)
-            ldms_xprt_put(self.xprt)
+            ldms_xprt_put(self.xprt, "rail_ref")
             self.xprt = NULL
             if self._conn_cb: # has `cb` ==> asynchronous/non-blocking mode
                 return

--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -816,7 +816,7 @@ static void sync_update_cb(ldms_t x, ldms_set_t s, int status, void *arg)
 int __ldms_xprt_update(ldms_t x, struct ldms_set *set, ldms_update_cb_t cb,
                                    void *arg, struct ldms_op_ctxt *op_ctxt)
 {
-	ldms_t xprt = ldms_xprt_get(x);
+	ldms_t xprt = ldms_xprt_get(x, "update");
 	int rc;
 
 	assert(set);
@@ -835,7 +835,7 @@ int __ldms_xprt_update(ldms_t x, struct ldms_set *set, ldms_update_cb_t cb,
 		rc = __ldms_remote_update(xprt, set, sync_update_cb, arg);
 		pthread_mutex_unlock(&xprt->lock);
 		if (rc) {
-			ldms_xprt_put(xprt);
+			ldms_xprt_put(xprt, "update");
 			return rc;
 		}
 		sem_wait(&xprt->sem);
@@ -844,7 +844,7 @@ int __ldms_xprt_update(ldms_t x, struct ldms_set *set, ldms_update_cb_t cb,
 		rc = __ldms_remote_update(xprt, set, cb, arg);
 		pthread_mutex_unlock(&xprt->lock);
 	}
-	ldms_xprt_put(xprt);
+	ldms_xprt_put(xprt, "update");
 	return rc;
 }
 
@@ -902,11 +902,11 @@ void __ldms_set_on_xprt_term(ldms_set_t set, ldms_t xprt)
 	}
 	pthread_mutex_unlock(&set->lock);
 	if (pp) {
-		ldms_xprt_put(pp->xprt);
+		ldms_xprt_put(pp->xprt, "push_peer");
 		free(pp);
 	}
 	if (np) {
-		ldms_xprt_put(np->xprt);
+		ldms_xprt_put(np->xprt, "notify_peer");
 		free(np);
 	}
 }
@@ -1010,7 +1010,7 @@ void __ldms_set_delete(ldms_set_t s, int notify)
 	s->xprt = NULL;
 	pthread_mutex_unlock(&s->lock);
 	if (x)
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "lu_set");
 
 	/* Add the set to the delete tree with the current timestamp */
 	s->del_time = time(NULL);
@@ -4064,7 +4064,7 @@ static void *delete_proc(void *arg)
 					}
 				}
 				pthread_mutex_unlock(&x->lock);
-				ldms_xprt_put(x);
+				ldms_xprt_put(x, "push_peer");
 			free_pp:
 				free(pp);
 			}
@@ -4104,7 +4104,7 @@ static void *delete_proc(void *arg)
 					}
 				}
 				pthread_mutex_unlock(&x->lock);
-				ldms_xprt_put(x);
+				ldms_xprt_put(x, "lookup_peer");
 			free_lp:
 				free(lp);
 			}

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -461,8 +461,10 @@ int ldms_init(size_t max_size);
  * \param name  Reference name
  * \returns	The transport handle
  */
-ldms_t ldms_xprt_get(ldms_t x, const char *name);
-void ldms_xprt_put(ldms_t x, const char *name);
+#define ldms_xprt_get(_x_, _n_) _ldms_xprt_get((_x_), (_n_), __func__, __LINE__)
+#define ldms_xprt_put(_x_, _n_) _ldms_xprt_put((_x_), (_n_), __func__, __LINE__)
+ldms_t _ldms_xprt_get(ldms_t x, const char *name, const char *func, int line);
+void _ldms_xprt_put(ldms_t x, const char *name, const char *func, int line);
 
 /**
  * \brief Terminate underlying LDMS Transport threads

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -458,10 +458,11 @@ int ldms_init(size_t max_size);
  * \brief Take a reference on a transport
  *
  * \param x	The transport handle
+ * \param name  Reference name
  * \returns	The transport handle
  */
-ldms_t ldms_xprt_get(ldms_t x);
-void ldms_xprt_put(ldms_t x);
+ldms_t ldms_xprt_get(ldms_t x, const char *name);
+void ldms_xprt_put(ldms_t x, const char *name);
 
 /**
  * \brief Terminate underlying LDMS Transport threads

--- a/ldms/src/core/ldms_qgroup.c
+++ b/ldms/src/core/ldms_qgroup.c
@@ -673,7 +673,7 @@ static void __qgroup_member_do_connect(ldms_qgroup_member_t m)
 {
 	int rc;
 	if (m->x) {
-		ldms_xprt_put((ldms_t)m->x);
+		ldms_xprt_put((ldms_t)m->x, "init");
 		m->x = NULL;
 	}
 	m->x = (ldms_rail_t)ldms_xprt_new_with_auth(m->c_xprt, m->c_auth, m->c_auth_av_list);
@@ -685,7 +685,7 @@ static void __qgroup_member_do_connect(ldms_qgroup_member_t m)
 	rc = ldms_xprt_connect_by_name((ldms_t)m->x, m->c_host, m->c_port,
 						__qgroup_member_xprt_cb, m);
 	if (rc) {
-		ldms_xprt_put((ldms_t)m->x);
+		ldms_xprt_put((ldms_t)m->x, "init");
 		m->x = NULL;
 		m->state = LDMS_QGROUP_MEMBER_STATE_DISCONNECTED;
 	} else {

--- a/ldms/src/core/ldms_rail.c
+++ b/ldms/src/core/ldms_rail.c
@@ -180,8 +180,11 @@ static void __rail_ref_free(void *arg)
 
 	for (i = 0; i < r->n_eps; i++) {
 		rep = &r->eps[i];
-		if (rep->ep)
+		if (rep->ep) {
+			ldms_xprt_ctxt_set(rep->ep, NULL, NULL);
 			ldms_xprt_put(rep->ep, "init");
+		}
+
 	}
 
 	while ((dc = TAILQ_FIRST(&r->dir_notify_tq))) {

--- a/ldms/src/core/ldms_rail.c
+++ b/ldms/src/core/ldms_rail.c
@@ -98,8 +98,8 @@ static int __rail_lookup(ldms_t _r, const char *name, enum ldms_lookup_flags fla
 	       ldms_lookup_cb_t cb, void *cb_arg, struct ldms_op_ctxt *op_ctxt);
 static int __rail_stats(ldms_t _r, ldms_xprt_stats_t stats, int mask, int is_reset);
 
-static ldms_t __rail_get(ldms_t _r); /* ref get */
-static void __rail_put(ldms_t _r); /* ref put */
+static ldms_t __rail_get(ldms_t _r, const char *name); /* ref get */
+static void __rail_put(ldms_t _r, const char *name); /* ref put */
 static void __rail_ctxt_set(ldms_t _r, void *ctxt, app_ctxt_free_fn fn);
 static void *__rail_ctxt_get(ldms_t _r);
 static uint64_t __rail_conn_id(ldms_t _r);
@@ -179,7 +179,7 @@ static void __rail_ref_free(void *arg)
 	for (i = 0; i < r->n_eps; i++) {
 		rep = &r->eps[i];
 		if (rep->ep)
-			ldms_xprt_put(rep->ep);
+			ldms_xprt_put(rep->ep, "init");
 	}
 
 	while ((dc = TAILQ_FIRST(&r->dir_notify_tq))) {
@@ -209,8 +209,8 @@ ldms_rail_t rail_first()
 	r = LIST_FIRST(&rail_list);
 	if (!r)
 		goto out;
-	__rail_get((ldms_t)r); /* next reference */
-	r = (ldms_rail_t)__rail_get((ldms_t)r); /* caller reference */
+	__rail_get((ldms_t)r, "iter_next"); /* next reference */
+	r = (ldms_rail_t)__rail_get((ldms_t)r, "inter_caller"); /* caller reference */
 out:
 	pthread_mutex_unlock(&rail_list_lock);
 	return r;
@@ -223,11 +223,11 @@ ldms_rail_t rail_next(ldms_rail_t r)
 	r = LIST_NEXT(r, rail_link);
 	if (!r)
 		goto out;
-	__rail_get((ldms_t)r);	/* next reference */
-	r = (ldms_rail_t)__rail_get((ldms_t)r);	/* caller reference */
+	__rail_get((ldms_t)r, "iter_next");	/* next reference */
+	r = (ldms_rail_t)__rail_get((ldms_t)r, "iter_caller");	/* caller reference */
  out:
 	pthread_mutex_unlock(&rail_list_lock);
-	__rail_put((ldms_t)prev_r);	/* next reference */
+	__rail_put((ldms_t)prev_r, "iter_next"); /* next reference */
 	return r;
 }
 
@@ -488,14 +488,14 @@ void __rail_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 		 */
 		if (e->type != LDMS_XPRT_EVENT_CONNECTED) {
 			/* bad passive legacy xprt does not notify the app */
-			ldms_xprt_put(x);
+			ldms_xprt_put(x, "init");
 			return;
 
 		}
 		/* Wrap it in new rail transport and continue */
 		r = __rail_passive_legacy_wrap(x, r->event_cb, r->event_cb_arg);
 		if (!r) {
-			ldms_xprt_put(x);
+			ldms_xprt_put(x, "init");
 			return;
 		}
 		rep = &r->eps[0];
@@ -825,7 +825,7 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 	ldms_xprt_ctxt_set(_x, &r->eps[m->idx], NULL);
 	pthread_mutex_unlock(&r->mutex);
 
-	ldms_xprt_get(_x);
+	ldms_xprt_get(_x, "zap_uctxt");
 	zap_set_ucontext(zep, _x);
 
 	auth = ldms_auth_clone(lx->auth);
@@ -840,7 +840,7 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 	__ldms_rail_conn_msg_init(r, m->idx, &msg);
 
 	/* Take a 'connect' reference. Dropped in ldms_xprt_close() */
-	ldms_xprt_get(_x);
+	ldms_xprt_get(_x, "connected");
 
 	ref_get(&r->ref, "ldms_accepting");
 	zerr = zap_accept2(zep, ldms_zap_auto_cb, (void*)&msg, sizeof(msg), m->idx);
@@ -852,7 +852,7 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 	return;
  err_3:
 	ref_put(&r->ref, "ldms_accepting");
-	ldms_xprt_put(_x); /* drop 'connect' reference */
+	ldms_xprt_put(_x, "connect"); /* drop 'connect' reference */
  err_2:
 	ldms_auth_free(auth);
  err_1:
@@ -862,7 +862,7 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 	r->eps[m->idx].state = LDMS_RAIL_EP_ERROR;
 	pthread_mutex_unlock(&r->mutex);
 	zap_set_ucontext(_x->zap_ep, NULL);
-	ldms_xprt_put(_x);	/* context reference */
+	ldms_xprt_put(_x, "zap_uctxt");	/* context reference */
  err_0:
 	zap_reject(zep, rej_msg, strlen(rej_msg)+1);
 }
@@ -893,7 +893,7 @@ static int __rail_ep_connect(ldms_t x, struct sockaddr *sa, socklen_t sa_len,
 
 	x->event_cb = cb;
 	x->event_cb_arg = cb_arg;
-	ldms_xprt_get(x);
+	ldms_xprt_get(x, "connect");
 	rc = zap_connect2(x->zap_ep, sa, sa_len, (void*)&msg, sizeof(msg), rep->idx);
 	return rc;
 }
@@ -981,7 +981,7 @@ static int __rail_listen(ldms_t _r, struct sockaddr *sa, socklen_t sa_len,
 	if (rc) {
 		r->eps[0].ep = NULL;
 		r->eps[0].state = LDMS_RAIL_EP_ERROR;
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "init");
 		return rc;
 	}
 	return 0;
@@ -1369,19 +1369,21 @@ err:
 	return rc;
 }
 
-static ldms_t __rail_get(ldms_t _r)
+static ldms_t __rail_get(ldms_t _r, const char *name)
 {
 	assert(XTYPE_IS_RAIL(_r->xtype));
 	ldms_rail_t r = (ldms_rail_t)_r;
-	ref_get(&r->ref, "rail_ref");
+	// ref_get(&r->ref, "rail_ref");
+	ref_get(&r->ref, name);
 	return (ldms_t)r;
 }
 
-static void __rail_put(ldms_t _r)
+static void __rail_put(ldms_t _r, const char *name)
 {
 	assert(XTYPE_IS_RAIL(_r->xtype));
 	ldms_rail_t r = (ldms_rail_t)_r;
-	ref_put(&r->ref, "rail_ref");
+	// ref_put(&r->ref, "rail_ref");
+	ref_put(&r->ref, name);
 }
 
 static void __rail_ctxt_set(ldms_t _r, void *ctxt, app_ctxt_free_fn fn)

--- a/ldms/src/core/ldms_rail.c
+++ b/ldms/src/core/ldms_rail.c
@@ -98,8 +98,10 @@ static int __rail_lookup(ldms_t _r, const char *name, enum ldms_lookup_flags fla
 	       ldms_lookup_cb_t cb, void *cb_arg, struct ldms_op_ctxt *op_ctxt);
 static int __rail_stats(ldms_t _r, ldms_xprt_stats_t stats, int mask, int is_reset);
 
-static ldms_t __rail_get(ldms_t _r, const char *name); /* ref get */
-static void __rail_put(ldms_t _r, const char *name); /* ref put */
+#define __rail_get(_r_, _n_) ___rail_get((_r_), (_n_), __func__, __LINE__)
+#define __rail_put(_r_, _n_) ___rail_put((_r_), (_n_), __func__, __LINE__)
+static ldms_t ___rail_get(ldms_t _r, const char *name, const char *func, int line); /* ref get */
+static void ___rail_put(ldms_t _r, const char *name, const char *func, int line); /* ref put */
 static void __rail_ctxt_set(ldms_t _r, void *ctxt, app_ctxt_free_fn fn);
 static void *__rail_ctxt_get(ldms_t _r);
 static uint64_t __rail_conn_id(ldms_t _r);
@@ -126,8 +128,8 @@ static struct ldms_xprt_ops_s __rail_ops = {
 	.lookup       = __rail_lookup,
 	.stats        = __rail_stats,
 
-	.get          = __rail_get,
-	.put          = __rail_put,
+	.get          = ___rail_get,
+	.put          = ___rail_put,
 	.ctxt_set     = __rail_ctxt_set,
 	.ctxt_get     = __rail_ctxt_get,
 	.conn_id      = __rail_conn_id,
@@ -840,7 +842,7 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 	__ldms_rail_conn_msg_init(r, m->idx, &msg);
 
 	/* Take a 'connect' reference. Dropped in ldms_xprt_close() */
-	ldms_xprt_get(_x, "connected");
+	ldms_xprt_get(_x, "connect");
 
 	ref_get(&r->ref, "ldms_accepting");
 	zerr = zap_accept2(zep, ldms_zap_auto_cb, (void*)&msg, sizeof(msg), m->idx);
@@ -1369,21 +1371,19 @@ err:
 	return rc;
 }
 
-static ldms_t __rail_get(ldms_t _r, const char *name)
+static ldms_t ___rail_get(ldms_t _r, const char *name, const char *func, int line)
 {
 	assert(XTYPE_IS_RAIL(_r->xtype));
 	ldms_rail_t r = (ldms_rail_t)_r;
-	// ref_get(&r->ref, "rail_ref");
-	ref_get(&r->ref, name);
+	_ref_get(&r->ref, name, func, line);
 	return (ldms_t)r;
 }
 
-static void __rail_put(ldms_t _r, const char *name)
+static void ___rail_put(ldms_t _r, const char *name, const char *func, int line)
 {
 	assert(XTYPE_IS_RAIL(_r->xtype));
 	ldms_rail_t r = (ldms_rail_t)_r;
-	// ref_put(&r->ref, "rail_ref");
-	ref_put(&r->ref, name);
+	_ref_put(&r->ref, name, func, line);
 }
 
 static void __rail_ctxt_set(ldms_t _r, void *ctxt, app_ctxt_free_fn fn)

--- a/ldms/src/core/ldms_rail.h
+++ b/ldms/src/core/ldms_rail.h
@@ -163,12 +163,11 @@ struct ldms_rail_s {
 	int sem_rc;
 
 	char name[LDMS_MAX_TRANSPORT_NAME_LEN];
+	struct ref_s ref;
 	char auth_name[LDMS_AUTH_NAME_MAX + 1];
 	struct attr_value_list *auth_av_list;
 	ldms_log_fn_t log;
 	LIST_ENTRY(ldms_rail_s) rail_link;
-
-	struct ref_s ref;
 
 	/* These are informational. The actual quotas are in eps[idx]. */
 	uint64_t recv_quota;      /* 0xffffffffffffffff is unlimited */

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -127,17 +127,17 @@ const char *ldms_xprt_event_type_to_str(enum ldms_xprt_event_type t)
 	return xprt_event_type_names[t];
 }
 
-static inline ldms_t __ldms_xprt_get(ldms_t x, const char *name)
+static inline ldms_t __ldms_xprt_get(ldms_t x, const char *name, const char *func, int line)
 {
 	if (x) {
-		ref_get(&x->ref, name);
+		_ref_get(&x->ref, name, func, line);
 	}
 	return x;
 }
 
-ldms_t ldms_xprt_get(ldms_t x, const char *name)
+ldms_t _ldms_xprt_get(ldms_t x, const char *name, const char *func, int line)
 {
-	return x->ops.get(x, name);
+	return x->ops.get(x, name, func, line);
 }
 
 static int __ldms_xprt_is_connected(struct ldms_xprt *x)
@@ -731,14 +731,14 @@ static void __xprt_ref_free(void *arg)
 	free(x);
 }
 
-static inline void __ldms_xprt_put(ldms_t x, const char *name)
+static inline void __ldms_xprt_put(ldms_t x, const char *name, const char *func, int line)
 {
-	ref_put(&x->ref, name);
+	_ref_put(&x->ref, name, func, line);
 }
 
-void ldms_xprt_put(ldms_t x, const char *name)
+void _ldms_xprt_put(ldms_t x, const char *name, const char *func, int line)
 {
-	x->ops.put(x, name);
+	x->ops.put(x, name, func, line);
 }
 
 /* The implementations are in ldms_rail.c. */
@@ -3403,8 +3403,8 @@ static int __ldms_xprt_lookup(ldms_t x, const char *path, enum ldms_lookup_flags
 static int __ldms_xprt_stats(ldms_t x, ldms_xprt_stats_t stats, int mask, int is_reset);
 static int __ldms_xprt_dir_cancel(ldms_t x);
 
-static ldms_t __ldms_xprt_get(ldms_t x, const char *name); /* ref get */
-static void __ldms_xprt_put(ldms_t x, const char *name); /* ref put */
+static ldms_t __ldms_xprt_get(ldms_t x, const char *name, const char *func, int line); /* ref get */
+static void __ldms_xprt_put(ldms_t x, const char *name, const char *func, int line); /* ref put */
 static void __ldms_xprt_ctxt_set(ldms_t x, void *ctxt, app_ctxt_free_fn fn);
 static void *__ldms_xprt_ctxt_get(ldms_t x);
 static uint64_t __ldms_xprt_conn_id(ldms_t x);

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -127,25 +127,22 @@ const char *ldms_xprt_event_type_to_str(enum ldms_xprt_event_type t)
 	return xprt_event_type_names[t];
 }
 
-static ldms_t __ldms_xprt_get(ldms_t x)
+static inline ldms_t __ldms_xprt_get(ldms_t x, const char *name)
 {
-	int a;
 	if (x) {
-		assert(x->ref_count > 0);
-		a = __sync_add_and_fetch(&x->ref_count, 1);
-		assert(a > 1); /* we are not getting a reference after it has reached 0. */
+		ref_get(&x->ref, name);
 	}
 	return x;
 }
 
-ldms_t ldms_xprt_get(ldms_t x)
+ldms_t ldms_xprt_get(ldms_t x, const char *name)
 {
-	return x->ops.get(x);
+	return x->ops.get(x, name);
 }
 
 static int __ldms_xprt_is_connected(struct ldms_xprt *x)
 {
-	assert(x && x->ref_count);
+	assert(x && x->ref.ref_count);
 	return (x->disconnected == 0 && x->zap_ep && zap_ep_connected(x->zap_ep));
 }
 
@@ -162,8 +159,8 @@ ldms_t ldms_xprt_first()
 	x = LIST_FIRST(&xprt_list);
 	if (!x)
 		goto out;
-	ldms_xprt_get(x);	/* next reference */
-	x = ldms_xprt_get(x);	/* caller reference */
+	ldms_xprt_get(x, "iter_next");	/* next reference */
+	x = ldms_xprt_get(x, "iter_caller");	/* caller reference */
  out:
 	pthread_mutex_unlock(&xprt_list_lock);
 	return x;
@@ -176,11 +173,11 @@ ldms_t ldms_xprt_next(ldms_t x)
 	x = LIST_NEXT(x, xprt_link);
 	if (!x)
 		goto out;
-	ldms_xprt_get(x);	/* next reference */
-	x = ldms_xprt_get(x);	/* caller reference */
+	ldms_xprt_get(x, "iter_next");	/* next reference */
+	x = ldms_xprt_get(x, "iter_caller");	/* caller reference */
  out:
 	pthread_mutex_unlock(&xprt_list_lock);
-	ldms_xprt_put(prev_x);	/* next reference */
+	ldms_xprt_put(prev_x, "iter_next");	/* next reference */
 	return x;
 }
 
@@ -304,21 +301,21 @@ ldms_t ldms_xprt_by_remote_sin(struct sockaddr *sa)
 			 * Put the next ref back (taken in ldms_xprt_first()
 			 * or ldms_xprt_next()).
 			 */
-			ldms_xprt_put(l);
+			ldms_xprt_put(l, "iter_next");
 			r = __ldms_xprt_to_rail(l);
-			ldms_xprt_get(r);
+			ldms_xprt_get(r, "iter_caller");
 			/*
 			 * Put back the caller reference taken in
 			 * ldms_xprt_first() or ldms_xprt_next().
 			 *
 			 * The rail hold a reference on the ldms_xprt object already.
 			 */
-			ldms_xprt_put(l);
+			ldms_xprt_put(l, "iter_caller");
 			return r;
 		}
 next:
 		next_l = ldms_xprt_next(l);
-		ldms_xprt_put(l);
+		ldms_xprt_put(l, "iter_next");
 		l = next_l;
 	}
 	return NULL;
@@ -336,7 +333,7 @@ struct ldms_context *__ldms_alloc_ctxt(struct ldms_xprt *x, size_t sz,
 		XPRT_LOG(x, OVIS_LCRITICAL, "%s(): Out of memory\n", __func__);
 		return ctxt;
 	}
-	ctxt->x = ldms_xprt_get(x);
+	ctxt->x = ldms_xprt_get(x, "alloc_ctxt");
 	(void)clock_gettime(CLOCK_REALTIME, &ctxt->start);
 #ifdef CTXT_DEBUG
 	XPRT_LOG(x, OVIS_LALWAYS, "%s(): x %p: alloc ctxt %p: type %d\n",
@@ -448,7 +445,7 @@ void __ldms_free_ctxt(struct ldms_xprt *x, struct ldms_context *ctxt)
 		e->count += 1;
 		e->mean_us /= e->count;
 	}
-	ldms_xprt_put(ctxt->x);
+	ldms_xprt_put(ctxt->x, "alloc_ctxt");
 	free(ctxt);
 }
 
@@ -717,27 +714,16 @@ void __ldms_xprt_resource_free(struct ldms_xprt *x)
 	}
 	pthread_mutex_unlock(&x->lock);
 	if (drop_ep_ref)
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "zap_uctxt");
 }
 
-static void __ldms_xprt_put(ldms_t x)
+static void __xprt_ref_free(void *arg)
 {
-	int remove = 0;
-	assert(x->ref_count);
-	if (0 == __sync_sub_and_fetch(&x->ref_count, 1)) {
-		remove = 1;
-		pthread_mutex_lock(&xprt_list_lock);
-		LIST_REMOVE(x, xprt_link);
-		pthread_mutex_unlock(&xprt_list_lock);
-#ifdef DEBUG
-		x->xprt_link.le_next = 0;
-		x->xprt_link.le_prev = 0;
-#endif /* DEBUG */
-	}
+	ldms_t x = (ldms_t)arg;
 
-	if (!remove)
-		return;
-
+	pthread_mutex_lock(&xprt_list_lock);
+	LIST_REMOVE(x, xprt_link);
+	pthread_mutex_unlock(&xprt_list_lock);
 	__ldms_xprt_resource_free(x);
 	sem_destroy(&x->sem);
 	if (x->app_ctxt && x->app_ctxt_free_fn)
@@ -745,9 +731,14 @@ static void __ldms_xprt_put(ldms_t x)
 	free(x);
 }
 
-void ldms_xprt_put(ldms_t x)
+static inline void __ldms_xprt_put(ldms_t x, const char *name)
 {
-	x->ops.put(x);
+	ref_put(&x->ref, name);
+}
+
+void ldms_xprt_put(ldms_t x, const char *name)
+{
+	x->ops.put(x, name);
 }
 
 /* The implementations are in ldms_rail.c. */
@@ -1085,7 +1076,7 @@ process_req_notify_request(struct ldms_xprt *x, struct ldms_request *req)
 		return;
 	}
 	rbn_init(&np->rbn, x);
-	np->xprt = ldms_xprt_get(x);
+	np->xprt = ldms_xprt_get(x, "notify_peer");
 	rbt_ins(&set->lookup_coll, &np->rbn);
 	np->remote_notify_xid = req->hdr.xid;
 	np->notify_flags = ntohl(req->req_notify.flags);
@@ -1129,7 +1120,7 @@ process_cancel_notify_request(struct ldms_xprt *x, struct ldms_request *req)
 	}
 	pthread_mutex_unlock(&set->lock);
 	if (np) {
-		ldms_xprt_put(np->xprt);
+		ldms_xprt_put(np->xprt, "notify_peer");
 		free(np);
 	}
 }
@@ -1167,7 +1158,7 @@ process_cancel_push_request(struct ldms_xprt *x, struct ldms_request *req)
 	reply.push.flags = htonl(LDMS_UPD_F_PUSH | LDMS_UPD_F_PUSH_LAST);
 	(void)zap_send(x->zap_ep, &reply, len);
 
-	ldms_xprt_put(pp->xprt);
+	ldms_xprt_put(pp->xprt, "push_set");
 	free(pp);
 
 	return;
@@ -1284,7 +1275,7 @@ static int __add_lookup_peer(struct ldms_xprt *x, struct ldms_set *set)
 				__FILE__, __func__, __LINE__);
 		return ENOMEM;
 	}
-	lp->xprt = ldms_xprt_get(x);
+	lp->xprt = ldms_xprt_get(x, "lookup_peer");
 	rbn_init(&lp->rbn, x);
 	rbt_ins(&set->lookup_coll, &lp->rbn);
 	pthread_mutex_unlock(&set->lock);
@@ -1323,7 +1314,7 @@ remove_peer:
 	pthread_mutex_lock(&set->lock);
 	rbt_del(&set->lookup_coll, &lp->rbn);
 	pthread_mutex_unlock(&set->lock);
-	ldms_xprt_put(lp->xprt);
+	ldms_xprt_put(lp->xprt, "lookup_peer");
 	free(lp);
 	return rc;
 }
@@ -2338,7 +2329,7 @@ void __ldms_passive_connect_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 	case LDMS_XPRT_EVENT_DISCONNECTED:
 		(void)clock_gettime(CLOCK_REALTIME, &x->stats.disconnected);
  		__ldms_xprt_resource_free(x);
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "connect");
 		break;
 	case LDMS_XPRT_EVENT_RECV:
 		/* Do nothing */
@@ -2434,7 +2425,7 @@ static void ldms_zap_handle_conn_req(zap_ep_t zep)
 	_x->event_cb_arg = x->event_cb_arg;
 	if (!_x->event_cb)
 		_x->event_cb = __ldms_passive_connect_cb;
-	ldms_xprt_get(_x);
+	ldms_xprt_get(_x, "zap_uctxt");
 	zap_set_ucontext(zep, _x);
 
 	auth = ldms_auth_clone(x->auth);
@@ -2450,7 +2441,7 @@ static void ldms_zap_handle_conn_req(zap_ep_t zep)
 	__ldms_xprt_conn_msg_init(x, &msg);
 
 	/* Take a 'connect' reference. Dropped in ldms_xprt_close() */
-	ldms_xprt_get(_x);
+	ldms_xprt_get(_x, "connect");
 
 	zerr = zap_accept(zep, ldms_zap_auto_cb, (void*)&msg, sizeof(msg));
 	if (zerr) {
@@ -2461,12 +2452,12 @@ static void ldms_zap_handle_conn_req(zap_ep_t zep)
 
 	return;
 err2:
-	ldms_xprt_put(_x);	/* drop 'connect' reference */
+	ldms_xprt_put(_x, "connect");	/* drop 'connect' reference */
 err1:
 	ldms_auth_free(auth);
 err0:
 	zap_set_ucontext(_x->zap_ep, NULL);
-	ldms_xprt_put(_x);	/* context reference */
+	ldms_xprt_put(_x, "zap_uctxt");	/* context reference */
 	zap_reject(zep, rej_msg, strlen(rej_msg)+1);
 }
 
@@ -2828,7 +2819,7 @@ static void handle_rendezvous_lookup(zap_ep_t zep, zap_event_t ev,
 		rc = errno;
 		goto callback;
 	}
-	lset->xprt = ldms_xprt_get(x);
+	lset->xprt = ldms_xprt_get(x, "lu_set");
 	lset->rmap = ev->map; /* lset now owns ev->map */
 	lset->remote_set_id = lm->lookup.set_id;
 
@@ -2951,7 +2942,7 @@ static void handle_rendezvous_push(zap_ep_t zep, zap_event_t ev,
 		return;
 	}
 	rbn_init(&pp->rbn, x);
-	pp->xprt = ldms_xprt_get(x);
+	pp->xprt = ldms_xprt_get(x, "push_set");
 	pp->push_flags = ntohl(push->flags);
 	pp->remote_set_id = push->push_set_id;
 	rbt_ins(&set->push_coll, &pp->rbn);
@@ -3062,11 +3053,11 @@ static void __ldms_xprt_release_sets(ldms_t x, struct rbt *set_coll)
 		}
 		pthread_mutex_unlock(&ent->set->lock);
 		if (lp) {
-			ldms_xprt_put(lp->xprt);
+			ldms_xprt_put(lp->xprt, "lookup_peer");
 			free(lp);
 		}
 		if (pp) {
-			ldms_xprt_put(pp->xprt);
+			ldms_xprt_put(pp->xprt, "push_peer");
 			free(pp);
 		}
 		ref_put(&ent->set->ref, "xprt_set_coll");
@@ -3108,7 +3099,7 @@ static void ldms_zap_cb(zap_ep_t zep, zap_event_t ev)
 		return;
 #ifdef DEBUG
 	XPRT_LOG(x, OVIS_LDEBUG, "ldms_zap_cb: receive %s. %p: ref_count %d\n",
-			zap_event_str(ev->type), x, x->ref_count);
+			zap_event_str(ev->type), x, x->ref.ref_count);
 #endif /* DEBUG */
 
 	errno = 0;
@@ -3169,7 +3160,7 @@ static void ldms_zap_cb(zap_ep_t zep, zap_event_t ev)
 			x->event_cb(x, &event, x->event_cb_arg);
 		__ldms_xprt_resource_free(x);
 		/* Put the reference taken in ldms_xprt_connect() */
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "connect");
 		break;
 	case ZAP_EVENT_CONNECTED:
 		thrstat->last_op = LDMS_THRSTAT_OP_CONNECT_SETUP;
@@ -3197,7 +3188,7 @@ static void ldms_zap_cb(zap_ep_t zep, zap_event_t ev)
 			x->event_cb(x, &event, x->event_cb_arg);
 		__ldms_xprt_resource_free(x);
 		/* Put the reference taken in ldms_xprt_connect() */
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "connect");
 		break;
 	case ZAP_EVENT_DISCONNECTED:
 		thrstat->last_op = LDMS_THRSTAT_OP_DISCONNECTED;
@@ -3240,21 +3231,21 @@ static void ldms_zap_cb(zap_ep_t zep, zap_event_t ev)
 		} else if (XTYPE_IS_PASSIVE(x->xtype) &&
 				event.type != LDMS_XPRT_EVENT_DISCONNECTED) {
 			/* don't call event_cb(), the application does not
-			 * know about thix transport yet, simply put the
+			 * know about this transport yet, simply put the
 			 * transport reference.*/
-			ldms_xprt_put(x);
+			ldms_xprt_put(x, "init"); /* TODO: verify the ref name */
 		} else {
 			if (x->event_cb)
 				x->event_cb(x, &event, x->event_cb_arg);
 		}
 		#ifdef DEBUG
 		XPRT_LOG(x, OVIS_LDEBUG, "ldms_zap_cb: DISCONNECTED %p: ref_count %d. "
-						"after callback\n", x, x->ref_count);
+						"after callback\n", x, x->ref.ref_count);
 		#endif /* DEBUG */
 		__ldms_xprt_release_sets(x, &set_coll);
 		__ldms_xprt_resource_free(x);
 		/* Put the reference taken in ldms_xprt_connect() or accept() */
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "connect");
 		break;
 	case ZAP_EVENT_SEND_COMPLETE:
 		thrstat->last_op = LDMS_THRSTAT_OP_SEND_MSG;
@@ -3376,7 +3367,7 @@ int __ldms_xprt_zap_new(struct ldms_xprt *x, const char *name)
 		goto err0;
 	}
 	x->max_msg = zap_max_msg(x->zap);
-	ldms_xprt_get(x);
+	ldms_xprt_get(x, "zap_uctxt");
 	zap_set_ucontext(x->zap_ep, x);
 	return 0;
 err0:
@@ -3412,8 +3403,8 @@ static int __ldms_xprt_lookup(ldms_t x, const char *path, enum ldms_lookup_flags
 static int __ldms_xprt_stats(ldms_t x, ldms_xprt_stats_t stats, int mask, int is_reset);
 static int __ldms_xprt_dir_cancel(ldms_t x);
 
-static ldms_t __ldms_xprt_get(ldms_t x); /* ref get */
-static void __ldms_xprt_put(ldms_t x); /* ref put */
+static ldms_t __ldms_xprt_get(ldms_t x, const char *name); /* ref get */
+static void __ldms_xprt_put(ldms_t x, const char *name); /* ref put */
 static void __ldms_xprt_ctxt_set(ldms_t x, void *ctxt, app_ctxt_free_fn fn);
 static void *__ldms_xprt_ctxt_get(ldms_t x);
 static uint64_t __ldms_xprt_conn_id(ldms_t x);
@@ -3463,7 +3454,7 @@ void __ldms_xprt_init(struct ldms_xprt *x, const char *name, int is_active)
 	x->conn_id = __sync_add_and_fetch(&__ldms_conn_id, 1);
 	x->name[LDMS_MAX_TRANSPORT_NAME_LEN - 1] = 0;
 	memccpy(x->name, name, 0, LDMS_MAX_TRANSPORT_NAME_LEN - 1);
-	x->ref_count = 1;
+	ref_init(&x->ref, "init", __xprt_ref_free, x);
 	x->remote_dir_xid = x->local_dir_xid = 0;
 
 	x->luid = -1;
@@ -3573,7 +3564,7 @@ ldms_t __ldms_xprt_new_with_auth(const char *xprt_name, const char *auth_name,
 err2:
 	ldms_auth_free(auth);
 err1:
-	ldms_xprt_put(x);
+	ldms_xprt_put(x, "init");
 err0:
 	errno = ret;
 	return NULL;
@@ -3690,7 +3681,7 @@ static int __ldms_xprt_send(ldms_t _x, char *msg_buf, size_t msg_len,
 	if (LDMS_XPRT_AUTH_GUARD(x))
 		return EPERM;
 
-	ldms_xprt_get(x);
+	ldms_xprt_get(x, "send");
 	pthread_mutex_lock(&x->lock);
 	size_t sz = sizeof(struct ldms_request) + sizeof(struct ldms_context) + msg_len;
 	ctxt = __ldms_alloc_ctxt(x, sz, LDMS_CONTEXT_SEND);
@@ -3720,7 +3711,7 @@ static int __ldms_xprt_send(ldms_t _x, char *msg_buf, size_t msg_len,
 	__ldms_free_ctxt(x, ctxt);
  err_0:
 	pthread_mutex_unlock(&x->lock);
-	ldms_xprt_put(x);
+	ldms_xprt_put(x, "send");
 	return rc;
 }
 
@@ -3771,13 +3762,13 @@ int __ldms_remote_dir(ldms_t _x, ldms_dir_cb_t cb, void *cb_arg, uint32_t flags)
 		return EBUSY;
 
 	/* Prevent x being destroyed if DISCONNECTED is delivered in another thread */
-	ldms_xprt_get(x);
+	ldms_xprt_get(x, "dir");
 	pthread_mutex_lock(&x->lock);
 	ctxt = __ldms_alloc_ctxt(x, sizeof(*ctxt) + sizeof(*req),
 					LDMS_CONTEXT_DIR, cb, cb_arg);
 	if (!ctxt) {
 		pthread_mutex_unlock(&x->lock);
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "dir");
 		return ENOMEM;
 	}
 	req = (struct ldms_request *)(ctxt + 1);
@@ -3804,7 +3795,7 @@ int __ldms_remote_dir(ldms_t _x, ldms_dir_cb_t cb, void *cb_arg, uint32_t flags)
 #endif /* DEBUG */
 		pthread_mutex_unlock(&x->lock);
 	}
-	ldms_xprt_put(x);
+	ldms_xprt_put(x, "dir");
 	return zap_zerr2errno(zerr);
 }
 
@@ -3833,12 +3824,12 @@ int __ldms_remote_dir_cancel(ldms_t _x)
 		return EPERM;
 
 	/* Prevent x being destroyed if DISCONNECTED is delivered in another thread */
-	ldms_xprt_get(x);
+	ldms_xprt_get(x, "dir_cancel");
 	pthread_mutex_lock(&x->lock);
 	ctxt = __ldms_alloc_ctxt(x, sizeof(*req) + sizeof(*ctxt), LDMS_CONTEXT_DIR_CANCEL);
 	if (!ctxt) {
 		pthread_mutex_unlock(&x->lock);
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "dir_cancel");
 		return ENOMEM;
 	}
 	req = (struct ldms_request *)(ctxt + 1);
@@ -3861,7 +3852,7 @@ int __ldms_remote_dir_cancel(ldms_t _x)
 	pthread_mutex_lock(&x->lock);
 	__ldms_free_ctxt(x, ctxt);
 	pthread_mutex_unlock(&x->lock);
-	ldms_xprt_put(x);
+	ldms_xprt_put(x, "dir_cancel");
 	return zap_zerr2errno(zerr);
 }
 
@@ -3903,7 +3894,7 @@ int __ldms_remote_lookup(ldms_t _x, const char *path,
 		return ENOMEM;
 
 	/* Prevent x being destroyed if DISCONNECTED is delivered in another thread */
-	ldms_xprt_get(x);
+	ldms_xprt_get(x, "lookup");
 	pthread_mutex_lock(&x->lock);
 	ctxt = __ldms_alloc_ctxt(x,
 				sizeof(struct ldms_request) + sizeof(*ctxt),
@@ -3912,7 +3903,7 @@ int __ldms_remote_lookup(ldms_t _x, const char *path,
 	if (!ctxt) {
 		free(lu_path);
 		pthread_mutex_unlock(&x->lock);
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "lookup");
 		return ENOMEM;
 	}
 	req = (struct ldms_request *)(ctxt + 1);
@@ -3945,7 +3936,7 @@ int __ldms_remote_lookup(ldms_t _x, const char *path,
 		       path);
 #endif /* DEBUG */
 	}
-	ldms_xprt_put(x);
+	ldms_xprt_put(x, "lookup");
 	return zap_zerr2errno(zerr);
 }
 
@@ -4190,14 +4181,14 @@ static int send_req_notify(ldms_t _x, ldms_set_t s, uint32_t flags,
 	if (!ldms_xprt_connected(x))
 		return ENOTCONN;
 
-	ldms_xprt_get(x);
+	ldms_xprt_get(x, "send_notify");
 	pthread_mutex_lock(&x->lock);
 	ctxt = __ldms_alloc_ctxt(x, sizeof(*req) + sizeof(*ctxt),
 					LDMS_CONTEXT_REQ_NOTIFY,
 					s, cb_fn, cb_arg);
 	pthread_mutex_unlock(&x->lock);
 	if (!ctxt) {
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "send_notify");
 		return ENOMEM;
 	}
 	req = (struct ldms_request *)(ctxt + 1);
@@ -4218,7 +4209,7 @@ static int send_req_notify(ldms_t _x, ldms_set_t s, uint32_t flags,
 		XPRT_LOG(x, OVIS_LERROR, "%s(): x %p: error %s sending REQ_NOTIFY\n",
 		       __func__, x, zap_err_str(zerr));
 	}
-	ldms_xprt_put(x);
+	ldms_xprt_put(x, "send_notify");
 	return zap_zerr2errno(zerr);
 }
 
@@ -4290,7 +4281,7 @@ static int send_req_register_push(ldms_set_t s, uint32_t push_change)
 	if (!ldms_xprt_connected(x))
 		return ENOTCONN;
 
-	ldms_xprt_get(x);
+	ldms_xprt_get(x, "register_push");
 	rc = __xprt_set_access_check(x, s, LDMS_ACCESS_WRITE);
 	/* check if the remote can write to us */
 	if (rc)
@@ -4311,7 +4302,7 @@ static int send_req_register_push(ldms_set_t s, uint32_t push_change)
 		rc = zap_zerr2errno(zerr);
 	}
  out:
-	ldms_xprt_put(x);
+	ldms_xprt_put(x, "register_push");
 	return rc;
 }
 
@@ -4335,7 +4326,7 @@ static int send_req_cancel_push(ldms_set_t s)
 	if (!ldms_xprt_connected(x))
 		return ENOTCONN;
 
-	x = ldms_xprt_get(s->xprt);
+	x = ldms_xprt_get(s->xprt, "cancel_push");
 	len = sizeof(struct ldms_request_hdr)
 		+ sizeof(struct ldms_cancel_push_cmd_param);
 	req.hdr.xid = 0;
@@ -4347,7 +4338,7 @@ static int send_req_cancel_push(ldms_set_t s)
 		rc = zap_zerr2errno(zerr);
 		x->zerrno = zerr;
 	}
-	ldms_xprt_put(x);
+	ldms_xprt_put(x, "cancel_push");
 	return rc;
 }
 
@@ -4460,12 +4451,12 @@ static int __ldms_xprt_connect(ldms_t x, struct sockaddr *sa, socklen_t sa_len,
 	__ldms_xprt_conn_msg_init(x, &msg);
 	_x->event_cb = cb;
 	_x->event_cb_arg = cb_arg;
-	ldms_xprt_get(x);
+	ldms_xprt_get(x, "connect");
 	rc = zap_connect(_x->zap_ep, sa, sa_len,
 			 (void*)&msg, sizeof(msg.ver) + strlen(msg.auth_name) + 1);
 	if (rc) {
 		__ldms_xprt_resource_free(x);
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "connect");
 	}
 	return rc;
 }

--- a/ldms/src/core/ldms_xprt.h
+++ b/ldms/src/core/ldms_xprt.h
@@ -465,8 +465,8 @@ struct ldms_xprt_ops_s {
 		       ldms_lookup_cb_t cb, void *cb_arg, struct ldms_op_ctxt *op_ctxt);
 	int (*stats)(ldms_t x, ldms_xprt_stats_t stats, int mask, int is_reset);
 
-	ldms_t (*get)(ldms_t x, const char *name); /* ref get */
-	void (*put)(ldms_t x, const char *name); /* ref put */
+	ldms_t (*get)(ldms_t x, const char *name, const char *func, int line); /* ref get */
+	void (*put)(ldms_t x, const char *name, const char *func, int line); /* ref put */
 	void (*ctxt_set)(ldms_t x, void *ctxt, app_ctxt_free_fn fn);
 	void *(*ctxt_get)(ldms_t x);
 	uint64_t (*conn_id)(ldms_t x);

--- a/ldms/src/core/ldms_xprt.h
+++ b/ldms/src/core/ldms_xprt.h
@@ -465,8 +465,8 @@ struct ldms_xprt_ops_s {
 		       ldms_lookup_cb_t cb, void *cb_arg, struct ldms_op_ctxt *op_ctxt);
 	int (*stats)(ldms_t x, ldms_xprt_stats_t stats, int mask, int is_reset);
 
-	ldms_t (*get)(ldms_t x); /* ref get */
-	void (*put)(ldms_t x); /* ref put */
+	ldms_t (*get)(ldms_t x, const char *name); /* ref get */
+	void (*put)(ldms_t x, const char *name); /* ref put */
 	void (*ctxt_set)(ldms_t x, void *ctxt, app_ctxt_free_fn fn);
 	void *(*ctxt_get)(ldms_t x);
 	uint64_t (*conn_id)(ldms_t x);
@@ -502,7 +502,8 @@ struct ldms_xprt {
 	int sem_rc;
 
 	char name[LDMS_MAX_TRANSPORT_NAME_LEN];
-	uint32_t ref_count;
+	struct ref_s ref;
+
 	pthread_mutex_t lock;
 	zap_err_t zerrno;
 	struct xprt_stats_s stats;

--- a/ldms/src/core/ldms_xprt_auth.c
+++ b/ldms/src/core/ldms_xprt_auth.c
@@ -91,7 +91,7 @@ int ldms_xprt_auth_send(ldms_t _x, const char *msg_buf, size_t msg_len)
 	if (x->auth_flag != LDMS_XPRT_AUTH_BUSY)
 		return EINVAL;
 
-	ldms_xprt_get(x);
+	ldms_xprt_get(x, "auth_send");
 	pthread_mutex_lock(&x->lock);
 	size_t sz = sizeof(struct ldms_request) + sizeof(struct ldms_context) + msg_len;
 	ctxt = __ldms_alloc_ctxt(x, sz, LDMS_CONTEXT_SEND);
@@ -115,7 +115,7 @@ int ldms_xprt_auth_send(ldms_t _x, const char *msg_buf, size_t msg_len)
 	__ldms_free_ctxt(x, ctxt);
  err_0:
 	pthread_mutex_unlock(&x->lock);
-	ldms_xprt_put(x);
+	ldms_xprt_put(x, "auth_send");
 	return rc;
 }
 

--- a/ldms/src/ldmsd/ldmsctl.c
+++ b/ldms/src/ldmsd/ldmsctl.c
@@ -2667,10 +2667,10 @@ void __ldms_event_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 		break;
 	case LDMS_XPRT_EVENT_REJECTED:
 		printf("The connected request is rejected.\n");
-		ldms_xprt_put(ctrl->ldms_xprt.x);
+		ldms_xprt_put(ctrl->ldms_xprt.x, "rail_ref");
 		exit(0);
 	case LDMS_XPRT_EVENT_DISCONNECTED:
-		ldms_xprt_put(ctrl->ldms_xprt.x);
+		ldms_xprt_put(ctrl->ldms_xprt.x, "rail_ref");
 		printf("The connection is disconnected.\n");
 		exit(0);
 	case LDMS_XPRT_EVENT_ERROR:
@@ -2716,7 +2716,7 @@ struct ldmsctl_ctrl *__ldms_xprt_ctrl(const char *host, const char *port,
 	rc = ldms_xprt_connect_by_name(ctrl->ldms_xprt.x, host, port,
 						__ldms_event_cb, ctrl);
 	if (rc) {
-		ldms_xprt_put(ctrl->ldms_xprt.x);
+		ldms_xprt_put(ctrl->ldms_xprt.x, "rail_ref");
 		sem_destroy(&ctrl->ldms_xprt.connected_sem);
 		sem_destroy(&ctrl->ldms_xprt.recv_sem);
 		free(ctrl);

--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -261,7 +261,7 @@ void cleanup(int x, const char *reason)
 
 	if (ldms) {
 		/* No need to close the xprt. It has never been connected. */
-		ldms_xprt_put(ldms);
+		ldms_xprt_put(ldms, "rail_ref");
 		ldms = NULL;
 	}
 
@@ -1375,7 +1375,7 @@ void ldmsd_listen___del(ldmsd_cfgobj_t obj)
 {
 	ldmsd_listen_t listen = (ldmsd_listen_t)obj;
 	if (listen->x)
-		ldms_xprt_put(listen->x);
+		ldms_xprt_put(listen->x, "rail_ref");
 	if (listen->xprt)
 		free(listen->xprt);
 	if (listen->host)

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -1296,7 +1296,7 @@ static void __listen_connect_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 		ldmsd_xprt_term(x);
 	case LDMS_XPRT_EVENT_REJECTED:
 	case LDMS_XPRT_EVENT_ERROR:
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "rail_ref");
 		break;
 	case LDMS_XPRT_EVENT_RECV:
 		ldmsd_recv_msg(x, e->data, e->data_len);
@@ -1335,7 +1335,7 @@ int listen_on_ldms_xprt(ldmsd_listen_t listen)
 
 void ldmsd_cfg_ldms_init(ldmsd_cfg_xprt_t xprt, ldms_t ldms)
 {
-	xprt->ldms.ldms = ldms_xprt_get(ldms);
+	xprt->ldms.ldms = ldms_xprt_get(ldms, "cfg_xprt");
 	xprt->send_fn = send_ldms_fn;
 	xprt->max_msg = ldms_xprt_msg_max(ldms);
 	xprt->cleanup_fn = ldmsd_cfg_ldms_xprt_cleanup;

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -1035,6 +1035,7 @@ int __req_deferred_advertiser_start(ldmsd_req_ctxt_t reqc)
 	int rc = 0;
 	ldmsd_prdcr_t prdcr;
 	char *name;
+	int drop_find_ref = 1;
 
 	name = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_NAME);
 	if (!name) {
@@ -1044,6 +1045,7 @@ int __req_deferred_advertiser_start(ldmsd_req_ctxt_t reqc)
 
 	prdcr = ldmsd_prdcr_find(name);
 	if (!prdcr) {
+		drop_find_ref = 0;
 		prdcr = __prdcr_add_handler(reqc, "advertiser_start", "advertiser");
 		if (!prdcr) {
 			ovis_log(config_log, OVIS_LERROR, "%s", reqc->line_buf);
@@ -1054,7 +1056,8 @@ int __req_deferred_advertiser_start(ldmsd_req_ctxt_t reqc)
 
 	prdcr->obj.perm |= LDMSD_PERM_DSTART;
 out:
-	ldmsd_prdcr_put(prdcr, "find");
+	if (drop_find_ref)
+		ldmsd_prdcr_put(prdcr, "find");
 	free(name);
 	return rc;
 }

--- a/ldms/src/ldmsd/ldmsd_failover.c
+++ b/ldms/src/ldmsd/ldmsd_failover.c
@@ -1052,7 +1052,7 @@ void __failover_xprt_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 		f->task_interval = f->ping_interval;
 		__failover_task_resched(f);
 		f->conn_state = FAILOVER_CONN_STATE_DISCONNECTED;
-		ldms_xprt_put(f->ax);
+		ldms_xprt_put(f->ax, "rail_ref");
 		f->ax = NULL;
 		need_start = !__F_GET(f, __FAILOVER_OURCFG_ACTIVATED);
 		__F_ON(f, __FAILOVER_OURCFG_ACTIVATED);
@@ -1098,7 +1098,7 @@ int __failover_active_connect(ldmsd_failover_t f)
 	f->conn_state = FAILOVER_CONN_STATE_CONNECTING;
 	goto out;
 err1:
-	ldms_xprt_put(f->ax);
+	ldms_xprt_put(f->ax, "rail_ref");
 	f->ax = NULL;
 	f->conn_state = FAILOVER_CONN_STATE_DISCONNECTED;
 out:

--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -850,10 +850,10 @@ reset_prdcr:
 		if ((prdcr->type == LDMSD_PRDCR_TYPE_PASSIVE) ||
 				(prdcr->type == LDMSD_PRDCR_TYPE_ADVERTISED_PASSIVE)) {
 			/* Put back the ldms_xprt_by_remote_sin() reference. */
-			ldms_xprt_put(prdcr->xprt);
+			ldms_xprt_put(prdcr->xprt, "prdcr");
 		}
 		ldmsd_xprt_term(prdcr->xprt);
-		ldms_xprt_put(prdcr->xprt);
+		ldms_xprt_put(prdcr->xprt, "rail_ref");
 		prdcr->xprt = NULL;
 	}
 	ovis_log(prdcr_log, OVIS_LINFO, "%s:%d Producer (after reset) %s (%s %s:%d)"
@@ -900,7 +900,7 @@ static void prdcr_connect(ldmsd_prdcr_t prdcr)
 						 prdcr->ss_len,
 						 prdcr_connect_cb, prdcr);
 			if (ret) {
-				ldms_xprt_put(prdcr->xprt);
+				ldms_xprt_put(prdcr->xprt, "rail_ref");
 				prdcr->xprt = NULL;
 				prdcr->conn_state = LDMSD_PRDCR_STATE_DISCONNECTED;
 			}

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -879,7 +879,7 @@ void req_ctxt_tree_unlock()
 
 static void free_cfg_xprt_ldms(ldmsd_cfg_xprt_t xprt)
 {
-	ldms_xprt_put(xprt->ldms.ldms);
+	ldms_xprt_put(xprt->ldms.ldms, "cfg_xprt");
 	free(xprt);
 }
 
@@ -9882,7 +9882,7 @@ ldmsd_prdcr_t __advertised_prdcr_new(ldmsd_req_ctxt_t reqc, ldmsd_prdcr_listen_t
 
 	advtr_name = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_NAME);
 
-	x = ldms_xprt_get(reqc->xprt->ldms.ldms);
+	x = ldms_xprt_get(reqc->xprt->ldms.ldms, "advertised_prdcr");
 	xprt_s = (char *)ldms_xprt_type_name(x);
 
 	attr_name = "hostname";
@@ -9932,7 +9932,7 @@ ldmsd_prdcr_t __advertised_prdcr_new(ldmsd_req_ctxt_t reqc, ldmsd_prdcr_listen_t
 	if (pl->rx_rate) {
 		ldms_xprt_rail_recv_rate_limit_set(x, pl->rx_rate);
 	}
-	ldms_xprt_put(x); /* Put back the reference at the beginning of the funciton */
+	ldms_xprt_put(x, "advertised_prdcr"); /* Put back the reference at the beginning of the funciton */
 	return prdcr;
 
 einval:
@@ -9977,7 +9977,7 @@ static int __process_advertisement(ldmsd_req_ctxt_t reqc, ldmsd_prdcr_listen_t p
 	gid_t gid;
 	int is_new_prdcr = 0;
 	struct ldms_xprt_event conn_ev;
-	ldms_t x = ldms_xprt_get(reqc->xprt->ldms.ldms);
+	ldms_t x = ldms_xprt_get(reqc->xprt->ldms.ldms, "process_advertisement");
 
 	xprt_s = adv_hostname = adv_port = NULL;
 
@@ -10034,12 +10034,12 @@ static int __process_advertisement(ldmsd_req_ctxt_t reqc, ldmsd_prdcr_listen_t p
 				ldmsd_prdcr_unlock(prdcr);
 				goto out;
 			case LDMSD_PRDCR_STATE_STOPPED:
-				prdcr->xprt = ldms_xprt_get(x);
+				prdcr->xprt = ldms_xprt_get(x, "prdcr");
 				ldms_xprt_event_cb_set(prdcr->xprt, prdcr_connect_cb, prdcr);
 				prdcr->conn_state = LDMSD_PRDCR_STATE_STANDBY;
 				break;
 			case LDMSD_PRDCR_STATE_DISCONNECTED:
-				prdcr->xprt = ldms_xprt_get(reqc->xprt->ldms.ldms);
+				prdcr->xprt = ldms_xprt_get(reqc->xprt->ldms.ldms, "prdcr");
 				ldms_xprt_event_cb_set(prdcr->xprt, prdcr_connect_cb, prdcr);
 				/* Move the producer state to CONNECTED here */
 				conn_ev.type = LDMS_XPRT_EVENT_CONNECTED;
@@ -10125,7 +10125,7 @@ static int __process_advertisement(ldmsd_req_ctxt_t reqc, ldmsd_prdcr_listen_t p
 
 	if (pl->auto_start && is_new_prdcr) {
 		if (prdcr->type == LDMSD_PRDCR_TYPE_ADVERTISED_PASSIVE) {
-			prdcr->xprt = ldms_xprt_get(x);
+			prdcr->xprt = ldms_xprt_get(x, "prdcr");
 			ldms_xprt_event_cb_set(prdcr->xprt, prdcr_connect_cb, prdcr);
 			prdcr->conn_state = LDMSD_PRDCR_STATE_STANDBY;
 		}

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -10139,6 +10139,7 @@ static int __process_advertisement(ldmsd_req_ctxt_t reqc, ldmsd_prdcr_listen_t p
 out:
 	free(adv_hostname);
 	free(adv_port);
+	ldms_xprt_put(x, "process_advertisement");
 	return rc;
 einval:
 	ovis_log(NULL, OVIS_LERROR,

--- a/ldms/src/ldmsd/ldmsd_stream.c
+++ b/ldms/src/ldmsd/ldmsd_stream.c
@@ -528,11 +528,11 @@ static void event_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 		conn_status = 0;
 		break;
 	case LDMS_XPRT_EVENT_REJECTED:
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "rail_ref");
 		conn_status = ECONNREFUSED;
 		break;
 	case LDMS_XPRT_EVENT_DISCONNECTED:
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "rail_ref");
 		conn_status = ENOTCONN;
 		break;
 	case LDMS_XPRT_EVENT_ERROR:
@@ -547,7 +547,7 @@ static void event_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 			return;
 		break;
 	default:
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "rail_ref");
 		conn_status = ECONNABORTED;
 		msglog("Received invalid event type %d\n", e->type);
 	}
@@ -624,14 +624,14 @@ int ldmsd_stream_publish_file(const char *stream, const char *type,
 	buf = ldmsd_msg_buf_new(max_msg_len);
 	if (!buf) {
 		msglog("Out of memory\n");
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "rail_ref");
 		return ENOMEM;
 	}
 
 	buffer = malloc(max_msg_len);
 	if (!buffer) {
 		msglog("Out of memory\n");
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "rail_ref");
 		rc = ENOMEM;
 		goto err;
 	}

--- a/ldms/src/ldmsd/ldmsd_upload.c
+++ b/ldms/src/ldmsd/ldmsd_upload.c
@@ -54,12 +54,12 @@ static void event_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 		printf("%s:%d\n", __func__, __LINE__);
 		break;
 	case LDMS_XPRT_EVENT_REJECTED:
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "rail_ref");
 		conn_status = ECONNREFUSED;
 		printf("%s:%d\n", __func__, __LINE__);
 		break;
 	case LDMS_XPRT_EVENT_DISCONNECTED:
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "rail_ref");
 		conn_status = ENOTCONN;
 		printf("%s:%d\n", __func__, __LINE__);
 		break;

--- a/ldms/src/sampler/netlink/simple_lps.c
+++ b/ldms/src/sampler/netlink/simple_lps.c
@@ -682,7 +682,7 @@ static void target_reset(struct slps_target *target)
 			"port=%s auth=%s reconnect=%d\n", target->xprt,
 			target->host, target->port, target->auth,
 			target->reconnect);
-		ldms_xprt_put(target->ldms);
+		ldms_xprt_put(target->ldms, "init");
 		target->ldms = NULL;
 	}
 	target_state_set(IDLE, target);

--- a/ldms/src/test/test_ldms_notify.c
+++ b/ldms/src/test/test_ldms_notify.c
@@ -466,11 +466,11 @@ static void client_connect_cb(ldms_t x, ldms_xprt_event_t e, void *arg)
 		break;
 	case LDMS_XPRT_EVENT_ERROR:
 		printf("%d: conn_error\n", port);
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "init");
 		break;
 	case LDMS_XPRT_EVENT_DISCONNECTED:
 		printf("%d: disconnected\n", port);
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "init");
 		sem_post(&exit_sem);
 		break;
 	case LDMS_XPRT_EVENT_SEND_COMPLETE:

--- a/ldms/src/test/test_ldms_push.c
+++ b/ldms/src/test/test_ldms_push.c
@@ -684,12 +684,12 @@ static void client_connect_cb(ldms_t x, ldms_xprt_event_t e, void *arg)
 		break;
 	case LDMS_XPRT_EVENT_ERROR:
 		printf("%s: conn_error\n", port);
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "init");
 		break;
 	case LDMS_XPRT_EVENT_DISCONNECTED:
 		is_closed = 1;
 		printf("%s: disconnected\n", port);
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "init");
 		sem_post(&exit_sem);
 		break;
 	case LDMS_XPRT_EVENT_SEND_COMPLETE:

--- a/ldms/src/test/test_ldms_set_info.c
+++ b/ldms/src/test/test_ldms_set_info.c
@@ -606,12 +606,12 @@ static void client_event_cb(ldms_t x, ldms_xprt_event_t e, void *arg)
 		break;
 	case LDMS_XPRT_EVENT_ERROR:
 		printf("%d: conn_error\n", port);
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "init");
 		sem_post(&clnt->lookup_sem);
 		break;
 	case LDMS_XPRT_EVENT_DISCONNECTED:
 		printf("%d: disconnected\n", port);
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "init");
 		sem_post(&clnt->lookup_sem);
 		break;
 	case LDMS_XPRT_EVENT_RECV:

--- a/ldms/src/test/test_ldms_xprt_reconnect.c
+++ b/ldms/src/test/test_ldms_xprt_reconnect.c
@@ -245,7 +245,7 @@ static void client_connect_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 	case LDMS_XPRT_EVENT_ERROR:
 		conn->state = DISCONNECTED;
 		printf("%s: conn_error\n", conn->port);
-		ldms_xprt_put(ldms);
+		ldms_xprt_put(ldms, "init");
 		conn->ldms = NULL;
 		break;
 	case LDMS_XPRT_EVENT_DISCONNECTED:
@@ -255,7 +255,7 @@ static void client_connect_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 			ldms_set_delete(conn->set);
 			conn->set = NULL;
 		}
-		ldms_xprt_put(ldms);
+		ldms_xprt_put(ldms, "init");
 		conn->ldms = NULL;
 		break;
 	case LDMS_XPRT_EVENT_SEND_COMPLETE:

--- a/ldms/src/test/test_ldms_xprt_send_recv.c
+++ b/ldms/src/test/test_ldms_xprt_send_recv.c
@@ -212,7 +212,7 @@ static void server_listen_connect_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg
 	case LDMS_XPRT_EVENT_DISCONNECTED:
 		printf("The connection is disconnected.\n");
 		free(recv_arg);
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "init");
 		break;
 	case LDMS_XPRT_EVENT_RECV:
 		server_recv_cb(x, e->data, e->data_len, recv_arg);
@@ -283,11 +283,11 @@ static void client_connect_cb(ldms_t x, ldms_xprt_event_t e, void *arg)
 		break;
 	case LDMS_XPRT_EVENT_ERROR:
 		printf("con_error\n");
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "init");
 		break;
 	case LDMS_XPRT_EVENT_DISCONNECTED:
 		printf("disconnected\n");
-		ldms_xprt_put(x);
+		ldms_xprt_put(x, "init");
 		sem_post(&exit_sem);
 		break;
 	case LDMS_XPRT_EVENT_RECV:

--- a/lib/src/ovis_ref/ref.h
+++ b/lib/src/ovis_ref/ref.h
@@ -58,6 +58,7 @@ static inline int _ref_put(ref_t r, const char *name, const char *func, int line
 	fprintf(stderr,
 		"name %s ref_count %d func %s line %d put but not taken\n",
 		name, r->ref_count, func, line);
+	pthread_mutex_unlock(&r->lock);
 	assert(0);
  out:
 	if (!count)


### PR DESCRIPTION
The pull request is a set of patches:

- Refactor ldms_xprt to use ovis_ref
- Fix ldms_xprt & rail references in the advertisement path on aggregator
- Modify ref.h so that it unlocks ref objects before calling assert() when _REF_TRACK_ is enabled