### PR TITLE
Fix parsing brittleness in lustre_client for b4.4

### DIFF
--- a/ldms/scripts/examples/lustre_client
+++ b/ldms/scripts/examples/lustre_client
@@ -3,14 +3,19 @@ export LDMSD_EXTRA="-m 1G"
 portbase=61016
 DAEMONS $(seq 3)
 JOBDATA $TESTDIR/job.data 1 2 3
-LDMSD -p prolog.jobid -p prolog.jobid.sampler 1 2
+VGARGS="--track-origins=yes --leak-check=full --show-leak-kinds=definite"
+vgoff
+LDMSD -p prolog.jobid 1
+vgoff
+LDMSD -p prolog.jobid 2
 LDMSD -p prolog.jobid.store3 3
+SLEEP 3
 MESSAGE ldms_ls on host 1:
-LDMS_LS 1 -l
+LDMS_LS 1 -lv
 MESSAGE ldms_ls on host 2:
-LDMS_LS 2 -l
+LDMS_LS 2 -lv
 MESSAGE ldms_ls on host 3:
-LDMS_LS 3
+LDMS_LS 3 -lv
 SLEEP 5
 KILL_LDMSD $(seq 3)
 file_created $STOREDIR/node/lustre_client

--- a/ldms/scripts/examples/lustre_client.1
+++ b/ldms/scripts/examples/lustre_client.1
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} job_set=localhost${i}/jobid  extra215=1 extratimes=1 test_path=${HOME}/test-llite
+start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/lustre_client.2
+++ b/ldms/scripts/examples/lustre_client.2
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} job_set=localhost${i}/jobid
+start name=${plugname} interval=1000000 offset=0

--- a/ldms/src/sampler/lustre_client/Plugin_lustre_client.man
+++ b/ldms/src/sampler/lustre_client/Plugin_lustre_client.man
@@ -50,6 +50,19 @@ Optional (defaults to 0) number of the host where the sampler is running. All se
 perm=<octal number>
 .br
 Set the access permissions for the metric sets. (default 440).
+.TP
+extra215=1
+.br
+Enable lustre 2.15 new metrics; this appends a small number, unique to the choice of extras, to the default schema name.
+.TP
+extratimes=1
+.br
+Enable start and elapsed time metrics (rounded to seconds). This appends a small number, unique to the choice of extras, to the default schema name.
+.TP
+test_path=LLITE_DIR
+.br
+This debugging option instructs the plugin to read data from a directory containing a static snapshot
+of an llite directory instead of from debugfs files.
 .RE
 
 .SH NOTES

--- a/ldms/src/sampler/lustre_client/lustre_client_general.h
+++ b/ldms/src/sampler/lustre_client/lustre_client_general.h
@@ -12,8 +12,18 @@
 #include "comp_id_helper.h"
 #include "sampler_base.h"
 
+
 int llite_general_schema_is_initialized();
-int llite_general_schema_init(comp_id_t cid);
+
+#define EXTRA215 0x1
+#define EXTRATIMES 0x2
+/*
+ * \param schema_extras is composed of the bit flags EXTRA* above
+ * to enable extra items. Fixed names for the schema variants
+ * are defined as lustre_client_%d, with the value of schema_extras,
+ * unless schema_extras==0.
+ */
+int llite_general_schema_init(comp_id_t cid, int schema_extras);
 void llite_general_schema_fini();
 ldms_set_t llite_general_create(const char *producer_name,
                                 const char *fs_name,


### PR DESCRIPTION
This also adds a test mode option for reading fake sample data without root access and two options to include new/supplementary data in the schema.

This patch cures lustre_client data loss for lustre 2.15 client metrics that do not end in .sum but do get collected from lustre metric rows that do contain sum and sumsq columns in the raw.