### PR TITLE
Always dlclose, and more API changes (remove get_plugin() and "name" from the API)

### DIFF
--- a/.github/workflows/ldms-test-build.yaml
+++ b/.github/workflows/ldms-test-build.yaml
@@ -62,6 +62,7 @@ jobs:
         # stores
         --enable-sos
         --with-sos=${PREFIX}
+        --enable-kokkos
         --enable-store-app
         --with-kafka=yes
 

--- a/ldms/src/contrib/sampler/daos/daos.c
+++ b/ldms/src/contrib/sampler/daos/daos.c
@@ -246,7 +246,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/contrib/sampler/daos/daos.c
+++ b/ldms/src/contrib/sampler/daos/daos.c
@@ -214,16 +214,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	dao_log(OVIS_LDEBUG, "term() called\n");
-	rank_targets_destroy();
-	rank_target_schema_fini();
-	pool_targets_destroy();
-	pools_destroy();
-	pool_target_schema_fini();
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	dao_log(OVIS_LDEBUG, "usage() called\n");
@@ -242,12 +232,17 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	dao_log(OVIS_LDEBUG, "destructor() called\n");
+	rank_targets_destroy();
+	rank_target_schema_fini();
+	pool_targets_destroy();
+	pools_destroy();
+	pool_target_schema_fini();
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/contrib/sampler/daos/daos.c
+++ b/ldms/src/contrib/sampler/daos/daos.c
@@ -230,27 +230,29 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	return  "config name=" SAMP " " BASE_CONFIG_USAGE;
 }
 
-static struct ldmsd_sampler daos_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	dao_log(OVIS_LDEBUG, "constructor() called ("PACKAGE_STRING")\n");
+	gethostname(producer_name, sizeof(producer_name));
+	strncpy(system_name, DEFAULT_SYS_NAME, sizeof(system_name));
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	mylog = ovis_log_register("sampler." SAMP, "Messages for the " SAMP " plugin");
-	if (!mylog) {
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the " SAMP
-				"plugin's log subsystem. Error %d.\n", errno);
-	}
-	dao_log(OVIS_LDEBUG, "get_plugin() called ("PACKAGE_STRING")\n");
-	gethostname(producer_name, sizeof(producer_name));
-	strncpy(system_name, DEFAULT_SYS_NAME, sizeof(system_name));
-
-	return &daos_plugin.base;
-}

--- a/ldms/src/contrib/sampler/daos/test/test_daos_sampler.c
+++ b/ldms/src/contrib/sampler/daos/test/test_daos_sampler.c
@@ -91,7 +91,7 @@ int basic_smoke_test(void)
 		return -1;
 	}
 
-	plugin->term(plugin);
+	plugin->(plugin);
 	free(cfg);
 
 	return 0;

--- a/ldms/src/contrib/sampler/daos/test/test_daos_sampler.c
+++ b/ldms/src/contrib/sampler/daos/test/test_daos_sampler.c
@@ -69,19 +69,13 @@
 #include "../daos.h"
 #include "../rank_target.h"
 
-extern struct ldmsd_plugin *get_plugin();
-
 int basic_smoke_test(void)
 {
 	int rc;
 	struct ldmsd_cfgobj *plugin = NULL;
 	struct ldmsd_plugin_cfg *cfg = NULL;
 
-	plugin = get_plugin();
-	if (!plugin) {
-		ovis_log(NULL, OVIS_LERROR, "get_plugin failed\n");
-		return -1;
-	}
+	plugin = ldmsd_plugin_interface;
 
 	cfg = malloc(sizeof(*cfg));
 	if (!cfg) {

--- a/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler.c
+++ b/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler.c
@@ -563,26 +563,28 @@ static void term(ldmsd_plug_handle_t handle)
 }
 
 
-static struct ldmsd_sampler g_geopm_sampler_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	ldms_geopm_sampler_set_log(mylog);
+	g_set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-
-struct ldmsd_plugin *get_plugin()
-{
-	mylog = ovis_log_register("sampler."SAMP, "Messages for the " SAMP " plugin");
-	if (!mylog) {
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the " SAMP " "
-				"plugin's log subsystem. Error %d.\n", errno);
-	}
-	ldms_geopm_sampler_set_log(mylog);
-	g_set = NULL;
-	return &g_geopm_sampler_plugin.base;
-}

--- a/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler.c
+++ b/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler.c
@@ -547,8 +547,16 @@ exit:
 	return rc;
 }
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	ldms_geopm_sampler_set_log(mylog);
+	g_set = NULL;
 
-static void term(ldmsd_plug_handle_t handle)
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	if (g_base) {
 		base_del(g_base);
@@ -562,24 +570,9 @@ static void term(ldmsd_plug_handle_t handle)
 	g_set = NULL;
 }
 
-
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-	ldms_geopm_sampler_set_log(mylog);
-	g_set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler.c
+++ b/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler.c
@@ -578,7 +578,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/gpu_metrics_ldms_sampler.c
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/gpu_metrics_ldms_sampler.c
@@ -353,7 +353,6 @@ static void destructor(ldmsd_plug_handle_t handle)
  */
 struct ldmsd_sampler ldmsd_plugin_interface = {
         .base = {
-                .name = SAMP,
                 .type = LDMSD_PLUGIN_SAMPLER,
                 .term = term,       // destructor
                 .config = config,

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/gpu_metrics_ldms_sampler.c
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/gpu_metrics_ldms_sampler.c
@@ -316,12 +316,21 @@ static int sample(ldmsd_plug_handle_t handle) {
     return 0;
 }
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	__gpu_metrics_log = ldmsd_plug_log_get(handle);
+        setGmgLoggingFunction(__gpu_metrics_log);
+        set = NULL;
+
+        return 0;
+}
+
 /**
  * Release any opened resource.  Note that we have to call OneAPI C++ destructor to
  * close any opened handles.
- * @param context this plugin instance's context.
  */
-static void term(ldmsd_plug_handle_t handle) {
+static void destructor(ldmsd_plug_handle_t handle)
+{
     // No longer need to free device handle array here.
 
     size_t mallocCount = getMallocCount();
@@ -335,26 +344,12 @@ static void term(ldmsd_plug_handle_t handle) {
     free_schema();
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	__gpu_metrics_log = ldmsd_plug_log_get(handle);
-        setGmgLoggingFunction(__gpu_metrics_log);
-        set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 /**
  * This structure defines the plugin interface.
  */
 struct ldmsd_sampler ldmsd_plugin_interface = {
         .base = {
                 .type = LDMSD_PLUGIN_SAMPLER,
-                .term = term,       // destructor
                 .config = config,
                 .usage = usage,
 		.constructor = constructor,

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/gpu_metrics_ldms_sampler.c
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/gpu_metrics_ldms_sampler.c
@@ -335,33 +335,31 @@ static void term(ldmsd_plug_handle_t handle) {
     free_schema();
 }
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	__gpu_metrics_log = ldmsd_plug_log_get(handle);
+        setGmgLoggingFunction(__gpu_metrics_log);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
 /**
- * This structure defines the plugin instance.  .base probably refers to the
- * base "class".  So, the assignments in base are overrides.
+ * This structure defines the plugin interface.
  */
-static struct ldmsd_sampler gpu_metrics_plugin = {
+struct ldmsd_sampler ldmsd_plugin_interface = {
         .base = {
                 .name = SAMP,
                 .type = LDMSD_PLUGIN_SAMPLER,
                 .term = term,       // destructor
                 .config = config,
                 .usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
         },
         .sample = sample,
 };
-
-/**
- * LDMS calls this to obtain a plugin instance.  Plugin is initialized here.
- * @param pf logging function provided by LDMS.
- * @return plugin instance.
- */
-struct ldmsd_plugin *get_plugin() {
-    __gpu_metrics_log = ovis_log_register("sampler."SAMP, "Messages for the " SAMP " plugin");
-    if (!__gpu_metrics_log) {
-	    ovis_log(NULL, OVIS_LWARN, "Failed to create the " SAMP " plugin's "
-			    "log subsystem. Error %d.\n", errno);
-    }
-    setGmgLoggingFunction(__gpu_metrics_log);
-    set = NULL;
-    return &gpu_metrics_plugin.base;
-}

--- a/ldms/src/contrib/sampler/ipmireader/ipmireader.c
+++ b/ldms/src/contrib/sampler/ipmireader/ipmireader.c
@@ -542,7 +542,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/contrib/sampler/ipmireader/ipmireader.c
+++ b/ldms/src/contrib/sampler/ipmireader/ipmireader.c
@@ -517,17 +517,6 @@ static int sample(ldmsd_plug_handle_t handle)
 
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-
-	cmd[0] = '\0';
-	if (base)
-		base_del(base);
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -538,12 +527,17 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	cmd[0] = '\0';
+	if (base)
+		base_del(base);
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/contrib/sampler/ipmireader/ipmireader.c
+++ b/ldms/src/contrib/sampler/ipmireader/ipmireader.c
@@ -528,24 +528,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler ipmireader_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	mylog = ovis_log_register("sampler." SAMP, "Messages for the " SAMP " plugin");
-	if (!mylog) {
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the " SAMP " plugin's "
-				"log subsystem. Error %d.\n", errno);
-	}
-	set = NULL;
-	return &ipmireader_plugin.base;
-}

--- a/ldms/src/contrib/sampler/ipmireader/ipmisensors.c
+++ b/ldms/src/contrib/sampler/ipmireader/ipmisensors.c
@@ -400,7 +400,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/contrib/sampler/ipmireader/ipmisensors.c
+++ b/ldms/src/contrib/sampler/ipmireader/ipmisensors.c
@@ -375,17 +375,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-
-	cmd[0] = '\0';
-	if (base)
-		base_del(base);
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -396,12 +385,17 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	cmd[0] = '\0';
+	if (base)
+		base_del(base);
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/contrib/sampler/ipmireader/ipmisensors.c
+++ b/ldms/src/contrib/sampler/ipmireader/ipmisensors.c
@@ -386,24 +386,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler ipmisensors_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	mylog = ovis_log_register("sampler." SAMP, "Messages for the " SAMP " plugin");
-	if (!mylog) {
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the " SAMP " plugin's "
-				"log subsystem. Error %d.\n", errno);
-	}
-	set = NULL;
-	return &ipmisensors_plugin.base;
-}

--- a/ldms/src/contrib/sampler/tutorial/tutorial_sampler.c
+++ b/ldms/src/contrib/sampler/tutorial/tutorial_sampler.c
@@ -251,23 +251,26 @@ static void term(ldmsd_plug_handle_t handle)
 	num_sets = 0;
 }
 
-static struct ldmsd_sampler tutorial_sampler_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	mylog = ovis_log_register("sampler."SAMP, "Messages for the " SAMP " plugin");
-	if (!mylog) {
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the " SAMP " plugin's "
-				"log subsystem. Error %d.\n", errno);
-	}
-	return &tutorial_sampler_plugin.base;
-}

--- a/ldms/src/contrib/sampler/tutorial/tutorial_sampler.c
+++ b/ldms/src/contrib/sampler/tutorial/tutorial_sampler.c
@@ -229,7 +229,14 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	int i;
 
@@ -251,21 +258,9 @@ static void term(ldmsd_plug_handle_t handle)
 	num_sets = 0;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/contrib/sampler/tutorial/tutorial_sampler.c
+++ b/ldms/src/contrib/sampler/tutorial/tutorial_sampler.c
@@ -264,7 +264,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/contrib/sampler/variorum_sampler/variorum_sampler.c
+++ b/ldms/src/contrib/sampler/variorum_sampler/variorum_sampler.c
@@ -196,7 +196,19 @@ static int sample(ldmsd_plug_handle_t handle)
 
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static const char *usage(ldmsd_plug_handle_t handle)
+{
+        return  "config name=" SAMP " " BASE_CONFIG_USAGE;
+}
+
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
         int metric;
 
@@ -221,26 +233,9 @@ static void term(ldmsd_plug_handle_t handle)
         set = NULL;
 }
 
-static const char *usage(ldmsd_plug_handle_t handle)
-{
-        return  "config name=" SAMP " " BASE_CONFIG_USAGE;
-}
-
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 static struct ldmsd_sampler ldmsd_plugin_interface = {
         .base = {
             .type = LDMSD_PLUGIN_SAMPLER,
-            .term = term,
             .config = config,
             .usage= usage,
             .constructor = constructor,

--- a/ldms/src/contrib/sampler/variorum_sampler/variorum_sampler.c
+++ b/ldms/src/contrib/sampler/variorum_sampler/variorum_sampler.c
@@ -226,22 +226,26 @@ static const char *usage(ldmsd_plug_handle_t handle)
         return  "config name=" SAMP " " BASE_CONFIG_USAGE;
 }
 
-static struct ldmsd_sampler variorum_sampler_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+static struct ldmsd_sampler ldmsd_plugin_interface = {
         .base = {
             .name = SAMP,
             .type = LDMSD_PLUGIN_SAMPLER,
             .term = term,
             .config = config,
             .usage= usage,
+            .constructor = constructor,
+            .destructor = destructor,
         },
         .sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	mylog = ovis_log_register("sampler."SAMP, "Messages for the " SAMP " plugin");
-	if (!mylog) {
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the " SAMP " plugin's log subsystem");
-	}
-	return &variorum_sampler_plugin.base;
-}

--- a/ldms/src/contrib/sampler/variorum_sampler/variorum_sampler.c
+++ b/ldms/src/contrib/sampler/variorum_sampler/variorum_sampler.c
@@ -239,7 +239,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 static struct ldmsd_sampler ldmsd_plugin_interface = {
         .base = {
-            .name = SAMP,
             .type = LDMSD_PLUGIN_SAMPLER,
             .term = term,
             .config = config,

--- a/ldms/src/contrib/store/timescale/store_timescale.c
+++ b/ldms/src/contrib/store/timescale/store_timescale.c
@@ -564,27 +564,30 @@ static void close_store(ldmsd_plug_handle_t handle, ldmsd_store_handle_t _sh)
 	free(is);
 }
 
-static struct ldmsd_store store_timescale = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.name = "timescale",
 		.config = config,
 		.usage = usage,
 		.type = LDMSD_PLUGIN_STORE,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.open = open_store,
 	.store = store,
 	.close = close_store,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	mylog = ovis_log_register("store.timescale", "Messages for the timescale store plugin");
-	if (!mylog) {
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the timescale "
-				"store plugin's log subsystem. Error %d.\n", errno);
-	}
-	return &store_timescale.base;
-}
 
 static void __attribute__ ((constructor)) store_timescale_init();
 static void store_timescale_init()

--- a/ldms/src/contrib/store/timescale/store_timescale.c
+++ b/ldms/src/contrib/store/timescale/store_timescale.c
@@ -577,7 +577,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-		.name = "timescale",
 		.config = config,
 		.usage = usage,
 		.type = LDMSD_PLUGIN_STORE,

--- a/ldms/src/contrib/store/tutorial/store_tutorial.c
+++ b/ldms/src/contrib/store/tutorial/store_tutorial.c
@@ -270,7 +270,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-			.name = PNAME,
 			.type = LDMSD_PLUGIN_STORE,
 			.config = config,
 			.usage = usage,

--- a/ldms/src/contrib/store/tutorial/store_tutorial.c
+++ b/ldms/src/contrib/store/tutorial/store_tutorial.c
@@ -257,26 +257,29 @@ static int store(ldmsd_plug_handle_t handle, ldmsd_store_handle_t _sh,
 	return 0;
 }
 
-static struct ldmsd_store store_tutorial = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 			.name = PNAME,
 			.type = LDMSD_PLUGIN_STORE,
 			.config = config,
 			.usage = usage,
+                        .constructor = constructor,
+                        .destructor = destructor,
 	},
 	.open = open_store,
 	.store = store,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	mylog = ovis_log_register("store."PNAME, "Messages for the "PNAME" plugin");
-	if (!mylog) {
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the "PNAME
-				" plugin's log subsystem. Error %d.\n", errno);
-	}
-	return &store_tutorial.base;
-}
 
 static void __attribute__ ((constructor)) store_tutorial_init();
 static void store_tutorial_init()

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -1009,6 +1009,7 @@ struct ldmsd_store {
 struct ldmsd_plugin_generic {
         struct ldmsd_plugin *api;
         char *libpath;
+        void *dl_handle; /* handle that was returned by dlopen() */
 };
 
 typedef struct ldmsd_cfgobj_sampler *ldmsd_cfgobj_sampler_t;

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -1002,7 +1002,7 @@ struct ldmsd_store {
 
 /**
  * struct ldmsd_plugin_generic is used to track generic information common to
- * all plugins that implement the ldms get_plugin() function.
+ * all plugins that implement the ldmsd_plugin_interface symbol.
  * NOTE: This is an ldmsd internals data structure.
  *       Not to be used from inside plugins.
  */
@@ -1163,8 +1163,6 @@ ldmsd_store_close(ldmsd_cfgobj_store_t store, ldmsd_store_handle_t sh)
 	if (store->api->close)
 		store->api->close(store, sh);
 }
-
-typedef struct ldmsd_plugin *(*ldmsd_plugin_get_f)();
 
 /* ldmsctl command callback function definition */
 typedef int (*ldmsctl_cmd_fn_t)(char *, struct attr_value_list*, struct attr_value_list *);

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -962,7 +962,6 @@ char *process_yaml_config_file(const char *path, const char *dname);
 #define LDMSD_CFG_FILE_XPRT_MAX_REC 8192
 /* This struct is owned by the plugin. ldmsd should never modify the contents. */
 typedef struct ldmsd_plugin {
-	char name[LDMSD_MAX_PLUGIN_NAME_LEN]; /* plugin name (e.g. meminfo) */
 	enum ldmsd_plugin_type {
 		LDMSD_PLUGIN_OTHER = 0,
 		LDMSD_PLUGIN_SAMPLER,
@@ -1008,6 +1007,7 @@ struct ldmsd_store {
  */
 struct ldmsd_plugin_generic {
         struct ldmsd_plugin *api;
+        char *name;
         char *libpath;
         void *dl_handle; /* handle that was returned by dlopen() */
 };

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -999,6 +999,18 @@ struct ldmsd_store {
 		      ldmsd_row_list_t row_list, int row_count);
 };
 
+
+/**
+ * struct ldmsd_plugin_generic is used to track generic information common to
+ * all plugins that implement the ldms get_plugin() function.
+ * NOTE: This is an ldmsd internals data structure.
+ *       Not to be used from inside plugins.
+ */
+struct ldmsd_plugin_generic {
+        struct ldmsd_plugin *api;
+        char *libpath;
+};
+
 typedef struct ldmsd_cfgobj_sampler *ldmsd_cfgobj_sampler_t;
 typedef struct ldmsd_sampler {
 	struct ldmsd_plugin base;
@@ -1007,6 +1019,7 @@ typedef struct ldmsd_sampler {
 
 struct ldmsd_cfgobj_store {
 	struct ldmsd_cfgobj cfg;
+	struct ldmsd_plugin_generic *plugin;
 	struct ldmsd_store *api;
 
 	/* Set to 1 if the plugin has been configured */
@@ -1015,7 +1028,6 @@ struct ldmsd_cfgobj_store {
 	/* List of strgp that are using this store */
 	LIST_HEAD(, ldmsd_strgp) strgp_list;
 
-	char *libpath;
 	/* Private context pointer, managed by plugin */
 	void *context;
 	/* ovis_log handle to use when logging plugin messages */
@@ -1030,12 +1042,12 @@ typedef struct ldmsd_sampler_set {
 
 struct ldmsd_cfgobj_sampler {
 	struct ldmsd_cfgobj cfg;
+	struct ldmsd_plugin_generic *plugin;
 	struct ldmsd_sampler *api;
 
 	/* Set to 1 if the plugin has been configured */
 	int configured;
 
-	char *libpath;
 	/* Private context pointer, managed by plugin */
 	void *context;
 	/* ovis_log handle to use when logging plugin messages */
@@ -1061,8 +1073,7 @@ struct ldmsd_cfgobj_sampler {
 #define LDMSD_JOBID "job_id"
 
 ldmsd_cfgobj_sampler_t ldmsd_sampler_add(const char *name,
-					struct ldmsd_sampler *api,
-					const char *libpath,
+					struct ldmsd_plugin_generic *plugin,
 					ldmsd_cfgobj_del_fn_t __del,
 					uid_t uid, gid_t gid, int perm);
 
@@ -1117,8 +1128,7 @@ void ldmsd_set_deregister(const char *inst_name, const char *plugin_name);
  */
 
 ldmsd_cfgobj_store_t ldmsd_store_add(const char *name,
-				struct ldmsd_store *store,
-				const char *libpath,
+				struct ldmsd_plugin_generic *plugin,
 				ldmsd_cfgobj_del_fn_t __del,
 				uid_t uid, gid_t gid, int perm);
 

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -978,9 +978,6 @@ typedef struct ldmsd_plugin {
 	int (*constructor)(ldmsd_plug_handle_t handle);
 	void (*destructor)(ldmsd_plug_handle_t handle);
 
-	/* Deprecated, use destructor() */
-	void (*term)(ldmsd_plug_handle_t handle);
-
 	void *reserved[8]; /* reserved for future use */
 } *ldmsd_plugin_t;
 

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -153,15 +153,13 @@ static struct ldmsd_plugin_generic *load_plugin(const char *plugin_name)
 		goto err_1;
 	}
 
-	ldmsd_plugin_get_f pget;
-	pget = dlsym(plugin->dl_handle, "get_plugin");
-        if (!pget) {
+        plugin->api = dlsym(plugin->dl_handle, "ldmsd_plugin_interface");
+        if (!plugin->api) {
 		ovis_log(config_log, OVIS_LWARNING,
 			"The library, '%s',  is missing the ldmsd_plugin_interface "
 			"symbol.", plugin_name);
                 goto err_2;
 	}
-	plugin->api = pget();
 
 	/* Verify the following API contract:
 	 * - If flags & MULTI_INSTANCE is !0, then

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -164,15 +164,13 @@ static struct ldmsd_plugin_generic *load_plugin(const char *plugin_name)
 	/* Verify the following API contract:
 	 * - If flags & MULTI_INSTANCE is !0, then
 	 *   -- both constructor() and destructor() must be defined
-	 *   -- term() must not be defined
 	 */
 	if (plugin->api->flags && LDMSD_PLUGIN_MULTI_INSTANCE) {
-		if (!plugin->api->constructor || !plugin->api->destructor
-                    || plugin->api->term) {
+		if (!plugin->api->constructor || !plugin->api->destructor) {
 			ovis_log(config_log, OVIS_LERROR,
 				 "The library, '%s', has the multi-instance flag, "
 				 "but is missing either the constructor or "
-				 "destructor functions, or has term defined.\n",
+				 "destructor functions.\n",
 				 plugin_name);
 			goto err_2;
 		}
@@ -342,8 +340,6 @@ void ldmsd_sampler___del(ldmsd_cfgobj_t obj)
 	ldmsd_cfgobj_sampler_t samp = (void*)obj;
 	if (samp->plugin->api->destructor)
 		samp->plugin->api->destructor(obj);
-	else if (samp->plugin->api->term)
-		samp->plugin->api->term(obj);
         unload_plugin(samp->plugin);
 	ldmsd_cfgobj___del(obj);
 }

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -224,10 +224,7 @@ ldmsd_sampler_add(const char *cfg_name,
         sampler->plugin = plugin;
 	sampler->api = (struct ldmsd_sampler *)plugin->api;
 	sampler->thread_id = -1; /* stopped */
-	if (sampler->api->base.constructor != NULL
-		&& sampler->api->base.destructor != NULL)
-	{
-		/* This plugin is multi-instance capable */
+	if (sampler->api->base.constructor != NULL) {
 		rc = sampler->api->base.constructor(&sampler->cfg);
 		if (rc)
 			goto err;
@@ -269,10 +266,7 @@ ldmsd_store_add(const char *cfg_name,
 	store->log = ovis_log_register(log_name, "Store plugin log file.");
         store->plugin = plugin;
 	store->api = (struct ldmsd_store *)plugin->api;
-	if (store->api->base.constructor != NULL
-		&& store->api->base.destructor != NULL)
-	{
-		/* This plugin is multi-instance capable */
+	if (store->api->base.constructor != NULL) {
 		rc = store->api->base.constructor(&store->cfg);
 		if (rc)
 			goto err;

--- a/ldms/src/ldmsd/ldmsd_plug_api.c
+++ b/ldms/src/ldmsd/ldmsd_plug_api.c
@@ -71,9 +71,9 @@ const char *ldmsd_plug_name_get(ldmsd_plug_handle_t handle)
 
 	switch (cfg->type) {
 	case LDMSD_CFGOBJ_SAMPLER:
-		return ((ldmsd_cfgobj_sampler_t)cfg)->api->base.name;
+		return ((ldmsd_cfgobj_sampler_t)cfg)->plugin->api->name;
 	case LDMSD_CFGOBJ_STORE:
-		return ((ldmsd_cfgobj_store_t)cfg)->api->base.name;
+		return ((ldmsd_cfgobj_store_t)cfg)->plugin->api->name;
 	default:
 		ovis_log(NULL, OVIS_LERROR,
 			 "%s : handle is not a plugin cfgobj\n", __func__);

--- a/ldms/src/ldmsd/ldmsd_plug_api.c
+++ b/ldms/src/ldmsd/ldmsd_plug_api.c
@@ -71,9 +71,9 @@ const char *ldmsd_plug_name_get(ldmsd_plug_handle_t handle)
 
 	switch (cfg->type) {
 	case LDMSD_CFGOBJ_SAMPLER:
-		return ((ldmsd_cfgobj_sampler_t)cfg)->plugin->api->name;
+		return ((ldmsd_cfgobj_sampler_t)cfg)->plugin->name;
 	case LDMSD_CFGOBJ_STORE:
-		return ((ldmsd_cfgobj_store_t)cfg)->plugin->api->name;
+		return ((ldmsd_cfgobj_store_t)cfg)->plugin->name;
 	default:
 		ovis_log(NULL, OVIS_LERROR,
 			 "%s : handle is not a plugin cfgobj\n", __func__);

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -3230,7 +3230,7 @@ int __strgp_status_json_obj(ldmsd_req_ctxt_t reqc, ldmsd_strgp_t strgp,
 		       strgp->container,
 		       ((strgp->schema)?strgp->schema:"-"),
 		       ((strgp->regex_s)?strgp->regex_s:"-"),
-		       strgp->store->api->base.name,
+		       strgp->store->plugin->api->name,
 		       strgp->flush_interval.tv_sec,
 		       (strgp->flush_interval.tv_nsec/1000),
 		       ldmsd_strgp_state_str(strgp->state),
@@ -5106,9 +5106,9 @@ int __plugn_status_json_obj(ldmsd_req_ctxt_t reqc)
 			       "{\"name\":\"%s\",\"plugin\":\"%s\",\"type\":\"%s\","
 			       "\"libpath\":\"%s\"}",
 			       samp->cfg.name,
-			       samp->api->base.name,
+			       samp->plugin->api->name,
 			       plugin_type_str(samp->api->base.type),
-			       samp->libpath);
+			       samp->plugin->libpath);
 		if (rc) {
 			ldmsd_cfg_unlock(LDMSD_CFGOBJ_SAMPLER);
 			goto err;
@@ -5129,9 +5129,9 @@ int __plugn_status_json_obj(ldmsd_req_ctxt_t reqc)
 				    "{\"name\":\"%s\",\"plugin\":\"%s\",\"type\":\"%s\","
 				    "\"libpath\":\"%s\"}",
 				    store->cfg.name,
-				    store->api->base.name,
+				    store->plugin->api->name,
 				    plugin_type_str(store->api->base.type),
-				    store->libpath);
+				    store->plugin->libpath);
 		if (rc) {
 			ldmsd_cfg_unlock(LDMSD_CFGOBJ_STORE);
 			goto err;
@@ -6483,8 +6483,8 @@ static int dump_cfg_handler(ldmsd_req_ctxt_t reqc)
 	ldmsd_cfg_lock(LDMSD_CFGOBJ_STORE);
 	for (store = ldmsd_store_first(LDMSD_CFGOBJ_STORE); store;
 			store = ldmsd_store_next(store)) {
-		fprintf(fp, "load name=%s plugin=%s\n", store->cfg.name, store->api->base.name);
-		fprintf(fp, "load name=%s plugin=%s\n", store->cfg.name, store->api->base.name);
+		fprintf(fp, "load name=%s plugin=%s\n", store->cfg.name, store->plugin->api->name);
+		fprintf(fp, "load name=%s plugin=%s\n", store->cfg.name, store->plugin->api->name);
 		if (store->cfg.avl_str || store->cfg.kvl_str)
 			fprintf(fp, "config name=%s %s %s\n",
 				store->cfg.name,
@@ -6496,8 +6496,8 @@ static int dump_cfg_handler(ldmsd_req_ctxt_t reqc)
 	ldmsd_cfgobj_sampler_t samp;
 	for (samp = ldmsd_sampler_first(); samp;
 			samp = ldmsd_sampler_next(samp)) {
-		fprintf(fp, "load name=%s plugin=%s\n", samp->cfg.name, samp->api->base.name);
-		fprintf(fp, "load name=%s plugin=%s\n", samp->cfg.name, samp->api->base.name);
+		fprintf(fp, "load name=%s plugin=%s\n", samp->cfg.name, samp->plugin->api->name);
+		fprintf(fp, "load name=%s plugin=%s\n", samp->cfg.name, samp->plugin->api->name);
 		if (samp->cfg.avl_str || samp->cfg.kvl_str)
 			fprintf(fp, "config name=%s %s %s\n",
 				samp->cfg.name,
@@ -6574,7 +6574,7 @@ static int dump_cfg_handler(ldmsd_req_ctxt_t reqc)
 			"flush=%ld "
 			"perm=%d",
 			strgp->obj.name,
-			strgp->store->api->base.name,
+			strgp->store->plugin->api->name,
 			strgp->container,
 			strgp->flush_interval.tv_sec,
 			strgp->obj.perm);

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -3230,7 +3230,7 @@ int __strgp_status_json_obj(ldmsd_req_ctxt_t reqc, ldmsd_strgp_t strgp,
 		       strgp->container,
 		       ((strgp->schema)?strgp->schema:"-"),
 		       ((strgp->regex_s)?strgp->regex_s:"-"),
-		       strgp->store->plugin->api->name,
+		       strgp->store->plugin->name,
 		       strgp->flush_interval.tv_sec,
 		       (strgp->flush_interval.tv_nsec/1000),
 		       ldmsd_strgp_state_str(strgp->state),
@@ -5106,7 +5106,7 @@ int __plugn_status_json_obj(ldmsd_req_ctxt_t reqc)
 			       "{\"name\":\"%s\",\"plugin\":\"%s\",\"type\":\"%s\","
 			       "\"libpath\":\"%s\"}",
 			       samp->cfg.name,
-			       samp->plugin->api->name,
+			       samp->plugin->name,
 			       plugin_type_str(samp->api->base.type),
 			       samp->plugin->libpath);
 		if (rc) {
@@ -5129,7 +5129,7 @@ int __plugn_status_json_obj(ldmsd_req_ctxt_t reqc)
 				    "{\"name\":\"%s\",\"plugin\":\"%s\",\"type\":\"%s\","
 				    "\"libpath\":\"%s\"}",
 				    store->cfg.name,
-				    store->plugin->api->name,
+				    store->plugin->name,
 				    plugin_type_str(store->api->base.type),
 				    store->plugin->libpath);
 		if (rc) {
@@ -6483,8 +6483,8 @@ static int dump_cfg_handler(ldmsd_req_ctxt_t reqc)
 	ldmsd_cfg_lock(LDMSD_CFGOBJ_STORE);
 	for (store = ldmsd_store_first(LDMSD_CFGOBJ_STORE); store;
 			store = ldmsd_store_next(store)) {
-		fprintf(fp, "load name=%s plugin=%s\n", store->cfg.name, store->plugin->api->name);
-		fprintf(fp, "load name=%s plugin=%s\n", store->cfg.name, store->plugin->api->name);
+		fprintf(fp, "load name=%s plugin=%s\n", store->cfg.name, store->plugin->name);
+		fprintf(fp, "load name=%s plugin=%s\n", store->cfg.name, store->plugin->name);
 		if (store->cfg.avl_str || store->cfg.kvl_str)
 			fprintf(fp, "config name=%s %s %s\n",
 				store->cfg.name,
@@ -6496,8 +6496,8 @@ static int dump_cfg_handler(ldmsd_req_ctxt_t reqc)
 	ldmsd_cfgobj_sampler_t samp;
 	for (samp = ldmsd_sampler_first(); samp;
 			samp = ldmsd_sampler_next(samp)) {
-		fprintf(fp, "load name=%s plugin=%s\n", samp->cfg.name, samp->plugin->api->name);
-		fprintf(fp, "load name=%s plugin=%s\n", samp->cfg.name, samp->plugin->api->name);
+		fprintf(fp, "load name=%s plugin=%s\n", samp->cfg.name, samp->plugin->name);
+		fprintf(fp, "load name=%s plugin=%s\n", samp->cfg.name, samp->plugin->name);
 		if (samp->cfg.avl_str || samp->cfg.kvl_str)
 			fprintf(fp, "config name=%s %s %s\n",
 				samp->cfg.name,
@@ -6574,7 +6574,7 @@ static int dump_cfg_handler(ldmsd_req_ctxt_t reqc)
 			"flush=%ld "
 			"perm=%d",
 			strgp->obj.name,
-			strgp->store->plugin->api->name,
+			strgp->store->plugin->name,
 			strgp->container,
 			strgp->flush_interval.tv_sec,
 			strgp->obj.perm);

--- a/ldms/src/sampler/app_sampler/app_sampler.c
+++ b/ldms/src/sampler/app_sampler/app_sampler.c
@@ -1722,7 +1722,7 @@ static void destructor(ldmsd_plug_handle_t handle)
 	free(inst);
 };
 
-static struct ldmsd_sampler app_sampler_plugin = {
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base.name = SAMP,
 	.base.type = LDMSD_PLUGIN_SAMPLER,
 	.base.flags = LDMSD_PLUGIN_MULTI_INSTANCE,
@@ -1733,11 +1733,6 @@ static struct ldmsd_sampler app_sampler_plugin = {
 
 	.sample = app_sampler_sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	return &app_sampler_plugin.base;
-}
 
 __attribute__((constructor))
 static void __init__()

--- a/ldms/src/sampler/app_sampler/app_sampler.c
+++ b/ldms/src/sampler/app_sampler/app_sampler.c
@@ -1723,7 +1723,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 };
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
-	.base.name = SAMP,
 	.base.type = LDMSD_PLUGIN_SAMPLER,
 	.base.flags = LDMSD_PLUGIN_MULTI_INSTANCE,
 	.base.config = app_sampler_config,

--- a/ldms/src/sampler/app_sampler/linux_proc_sampler.c
+++ b/ldms/src/sampler/app_sampler/linux_proc_sampler.c
@@ -4107,8 +4107,7 @@ static void destructor(ldmsd_plug_handle_t handle)
         free(inst);
 }
 
-static
-struct ldmsd_sampler plugin_inst = {
+struct ldmsd_sampler ldmsd_plugin_interface = {
         .base.name = SAMP,
         .base.type = LDMSD_PLUGIN_SAMPLER,
         .base.constructor = constructor,
@@ -4118,11 +4117,6 @@ struct ldmsd_sampler plugin_inst = {
         .base.usage = linux_proc_sampler_usage,
         .sample = linux_proc_sampler_sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	return &plugin_inst.base;
-}
 
 __attribute__((destructor))
 static

--- a/ldms/src/sampler/app_sampler/linux_proc_sampler.c
+++ b/ldms/src/sampler/app_sampler/linux_proc_sampler.c
@@ -3651,7 +3651,7 @@ static int __stream_cb(ldms_stream_event_t ev, void *ctxt)
 	return rc;
 }
 
-static void linux_proc_sampler_term(ldmsd_plug_handle_t handle);
+static void linux_proc_sampler_cleanup(linux_proc_sampler_inst_t inst);
 
 static int
 linux_proc_sampler_config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl,
@@ -3950,14 +3950,13 @@ no_pids:	;
 
  err:
 	/* undo the config */
-	linux_proc_sampler_term(handle);
+	linux_proc_sampler_cleanup(inst);
 	return rc;
 }
 
 static
-void linux_proc_sampler_term(ldmsd_plug_handle_t handle)
+void linux_proc_sampler_cleanup(linux_proc_sampler_inst_t inst)
 {
-	linux_proc_sampler_inst_t inst = ldmsd_plug_ctxt_get(handle);
 	struct rbn *rbn;
 	struct linux_proc_sampler_set *app_set;
 
@@ -4104,6 +4103,8 @@ static void destructor(ldmsd_plug_handle_t handle)
 {
         linux_proc_sampler_inst_t inst = ldmsd_plug_ctxt_get(handle);
 
+        linux_proc_sampler_cleanup(inst);
+
         free(inst);
 }
 
@@ -4111,7 +4112,6 @@ struct ldmsd_sampler ldmsd_plugin_interface = {
         .base.type = LDMSD_PLUGIN_SAMPLER,
         .base.constructor = constructor,
         .base.destructor = destructor,
-        .base.term = linux_proc_sampler_term,
         .base.config = linux_proc_sampler_config,
         .base.usage = linux_proc_sampler_usage,
         .sample = linux_proc_sampler_sample,

--- a/ldms/src/sampler/app_sampler/linux_proc_sampler.c
+++ b/ldms/src/sampler/app_sampler/linux_proc_sampler.c
@@ -4108,7 +4108,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
-        .base.name = SAMP,
         .base.type = LDMSD_PLUGIN_SAMPLER,
         .base.constructor = constructor,
         .base.destructor = destructor,

--- a/ldms/src/sampler/appinfo.c
+++ b/ldms/src/sampler/appinfo.c
@@ -447,10 +447,15 @@ out:
 	return 0;
 }
 
-/**
- * Sampler termination.
- **/
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	ovis_log(mylog, OVIS_LDEBUG, "Terminating sampler.\n");
 	if (base)
@@ -468,25 +473,12 @@ static void term(ldmsd_plug_handle_t handle)
 	ovis_log(mylog, OVIS_LDEBUG, "Done terminating.\n");
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-        set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 /**
  * Sampler LDMS definition.
  **/
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/appinfo.c
+++ b/ldms/src/sampler/appinfo.c
@@ -485,7 +485,6 @@ static void destructor(ldmsd_plug_handle_t handle)
  **/
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/appinfo.c
+++ b/ldms/src/sampler/appinfo.c
@@ -468,35 +468,33 @@ static void term(ldmsd_plug_handle_t handle)
 	ovis_log(mylog, OVIS_LDEBUG, "Done terminating.\n");
 }
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
 /**
  * Sampler LDMS definition.
  **/
-static struct ldmsd_sampler appinfo_plugin = {
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-/**
- * LDMS creation hook.
- **/
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &appinfo_plugin.base;
-}
 
 /**
  * Create shared memory structs and data from the newly defined

--- a/ldms/src/sampler/aries_mmr/aries_linkstatus.c
+++ b/ldms/src/sampler/aries_mmr/aries_linkstatus.c
@@ -291,7 +291,15 @@ err:
 	return EINVAL;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	//don't close the file handle since we open and close it each time
 	if (lsfile)
@@ -307,22 +315,9 @@ static void term(ldmsd_plug_handle_t handle)
 	base = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-	set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/aries_mmr/aries_linkstatus.c
+++ b/ldms/src/sampler/aries_mmr/aries_linkstatus.c
@@ -307,26 +307,27 @@ static void term(ldmsd_plug_handle_t handle)
 	base = NULL;
 }
 
-static struct ldmsd_sampler aries_linkstatus_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &aries_linkstatus_plugin.base;
-}

--- a/ldms/src/sampler/aries_mmr/aries_linkstatus.c
+++ b/ldms/src/sampler/aries_mmr/aries_linkstatus.c
@@ -321,7 +321,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/aries_mmr/aries_mmr.c
+++ b/ldms/src/sampler/aries_mmr/aries_mmr.c
@@ -521,9 +521,23 @@ out:
 
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static const char *usage(ldmsd_plug_handle_t handle)
 {
+	return  "config name=aries_mmr" BASE_CONFIG_USAGE " file=<file> [aries_rtr_id=<rtrid>]\n"
+		"    <file>         File with full names of metrics\n"
+		"    <rtrid>        Optional unique rtr string identifier. Defaults to 0 length string.\n";
+}
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
 	int i;
 
 	if (rtrid)
@@ -568,29 +582,9 @@ static void term(ldmsd_plug_handle_t handle)
 	base = NULL;
 }
 
-static const char *usage(ldmsd_plug_handle_t handle)
-{
-	return  "config name=aries_mmr" BASE_CONFIG_USAGE " file=<file> [aries_rtr_id=<rtrid>]\n"
-		"    <file>         File with full names of metrics\n"
-		"    <rtrid>        Optional unique rtr string identifier. Defaults to 0 length string.\n";
-}
-
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-        set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/aries_mmr/aries_mmr.c
+++ b/ldms/src/sampler/aries_mmr/aries_mmr.c
@@ -575,26 +575,27 @@ static const char *usage(ldmsd_plug_handle_t handle)
 		"    <rtrid>        Optional unique rtr string identifier. Defaults to 0 length string.\n";
 }
 
-static struct ldmsd_sampler aries_mmr_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &aries_mmr_plugin.base;
-}

--- a/ldms/src/sampler/aries_mmr/aries_mmr.c
+++ b/ldms/src/sampler/aries_mmr/aries_mmr.c
@@ -589,7 +589,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/aries_mmr/aries_mmr.c
+++ b/ldms/src/sampler/aries_mmr/aries_mmr.c
@@ -64,6 +64,7 @@
 #include "gpcd_lib.h"
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 #include "sampler_base.h"
 
 #define SAMP "aries_mmr"

--- a/ldms/src/sampler/aries_mmr/aries_mmr_configurable.c
+++ b/ldms/src/sampler/aries_mmr/aries_mmr_configurable.c
@@ -945,7 +945,13 @@ out:
 
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	int i;
 
@@ -959,20 +965,9 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-        set = NULL;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/aries_mmr/aries_mmr_configurable.c
+++ b/ldms/src/sampler/aries_mmr/aries_mmr_configurable.c
@@ -959,26 +959,25 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler aries_mmr_configurable_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &aries_mmr_configurable_plugin.base;
-}

--- a/ldms/src/sampler/aries_mmr/aries_mmr_configurable.c
+++ b/ldms/src/sampler/aries_mmr/aries_mmr_configurable.c
@@ -971,7 +971,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/aries_mmr/aries_nic_mmr.c
+++ b/ldms/src/sampler/aries_mmr/aries_nic_mmr.c
@@ -518,9 +518,21 @@ out:
 
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static const char *usage(ldmsd_plug_handle_t handle)
 {
+	return  "config name=aries_nic_mmr" BASE_CONFIG_USAGE " file=<file> [aries_rtr_id=<rtrid>]\n"
+		"    <file>         File with full names of metrics\n"
+		"    <rtrid>        Optional unique rtr string identifier. Defaults to 0 length string.\n";
+}
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
 	int i;
 
 	if (rtrid)
@@ -565,27 +577,9 @@ static void term(ldmsd_plug_handle_t handle)
 	base = NULL;
 }
 
-static const char *usage(ldmsd_plug_handle_t handle)
-{
-	return  "config name=aries_nic_mmr" BASE_CONFIG_USAGE " file=<file> [aries_rtr_id=<rtrid>]\n"
-		"    <file>         File with full names of metrics\n"
-		"    <rtrid>        Optional unique rtr string identifier. Defaults to 0 length string.\n";
-}
-
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-        set = NULL;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/aries_mmr/aries_nic_mmr.c
+++ b/ldms/src/sampler/aries_mmr/aries_nic_mmr.c
@@ -572,26 +572,25 @@ static const char *usage(ldmsd_plug_handle_t handle)
 		"    <rtrid>        Optional unique rtr string identifier. Defaults to 0 length string.\n";
 }
 
-static struct ldmsd_sampler aries_nic_mmr_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = "aries_nic_mmr",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler.aries_nic_mmr", "Message for the aries_nic_mmr plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of 'aries_nic_mmr' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &aries_nic_mmr_plugin.base;
-}

--- a/ldms/src/sampler/aries_mmr/aries_nic_mmr.c
+++ b/ldms/src/sampler/aries_mmr/aries_nic_mmr.c
@@ -584,7 +584,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = "aries_nic_mmr",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/aries_mmr/aries_rtr_mmr.c
+++ b/ldms/src/sampler/aries_mmr/aries_rtr_mmr.c
@@ -584,7 +584,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = "aries_rtr_mmr",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/aries_mmr/aries_rtr_mmr.c
+++ b/ldms/src/sampler/aries_mmr/aries_rtr_mmr.c
@@ -570,26 +570,27 @@ static const char *usage(ldmsd_plug_handle_t handle)
 		"    <rtrid>        Optional unique rtr string identifier. Defaults to 0 length string.\n";
 }
 
-static struct ldmsd_sampler aries_rtr_mmr_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = "aries_rtr_mmr",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler.aries_rtr_mmr", "Message for the aries_rtr_mmr plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of 'aries_rtr_mmr' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &aries_rtr_mmr_plugin.base;
-}

--- a/ldms/src/sampler/aries_mmr/aries_rtr_mmr.c
+++ b/ldms/src/sampler/aries_mmr/aries_rtr_mmr.c
@@ -516,9 +516,23 @@ out:
 
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static const char *usage(ldmsd_plug_handle_t handle)
 {
+	return  "config name=aries_rtr_mmr" BASE_CONFIG_USAGE " file=<file> [aries_rtr_id=<rtrid>]\n"
+		"    <file>         File with full names of metrics\n"
+		"    <rtrid>        Optional unique rtr string identifier. Defaults to 0 length string.\n";
+}
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
 	int i;
 
 	if (rtrid)
@@ -563,29 +577,9 @@ static void term(ldmsd_plug_handle_t handle)
 	base = NULL;
 }
 
-static const char *usage(ldmsd_plug_handle_t handle)
-{
-	return  "config name=aries_rtr_mmr" BASE_CONFIG_USAGE " file=<file> [aries_rtr_id=<rtrid>]\n"
-		"    <file>         File with full names of metrics\n"
-		"    <rtrid>        Optional unique rtr string identifier. Defaults to 0 length string.\n";
-}
-
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-        set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/blob_stream/blob_stream_writer.c
+++ b/ldms/src/sampler/blob_stream/blob_stream_writer.c
@@ -606,25 +606,6 @@ static void stream_data_close( stream_data_t sd )
 	pthread_mutex_destroy(&sd->write_lock);
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	pthread_mutex_lock(&cfg_lock);
-	closing = 1;
-	stream_data_t sd = LIST_FIRST(&data_list);
-	while (sd) {
-		stream_data_close(sd);
-		LIST_REMOVE(sd, entry);
-		free(sd);
-		sd = LIST_FIRST(&data_list);
-	}
-	pthread_mutex_unlock(&cfg_lock);
-	free(root_path);
-	root_path = NULL;
-	free(container);
-	container = NULL;
-	return;
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	return  "    config name=blob_stream_writer path=<path> container=<container> stream=<stream> \n"
@@ -656,12 +637,25 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	pthread_mutex_lock(&cfg_lock);
+	closing = 1;
+	stream_data_t sd = LIST_FIRST(&data_list);
+	while (sd) {
+		stream_data_close(sd);
+		LIST_REMOVE(sd, entry);
+		free(sd);
+		sd = LIST_FIRST(&data_list);
+	}
+	pthread_mutex_unlock(&cfg_lock);
+	free(root_path);
+	root_path = NULL;
+	free(container);
+	container = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 			.type = LDMSD_PLUGIN_SAMPLER,
-			.term = term,
 			.config = config,
 			.usage = usage,
                         .constructor = constructor,

--- a/ldms/src/sampler/blob_stream/blob_stream_writer.c
+++ b/ldms/src/sampler/blob_stream/blob_stream_writer.c
@@ -646,29 +646,30 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static struct ldmsd_sampler blob_stream_writer = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	LIST_INIT(&data_list);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 			.name = "blob_stream_writer",
 			.type = LDMSD_PLUGIN_SAMPLER,
 			.term = term,
 			.config = config,
 			.usage = usage,
+                        .constructor = constructor,
+                        .destructor = destructor,
 	},
 	.sample = sample
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler.blob_stream_writer", "Message for the blob_stream_writer plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of 'blob_stream_writer' plugin. Error %d\n", rc);
-	}
-	LIST_INIT(&data_list);
-	return &blob_stream_writer.base;
-}
 
 static void __attribute__ ((constructor)) blob_stream_writer_init();
 static void blob_stream_writer_init()

--- a/ldms/src/sampler/blob_stream/blob_stream_writer.c
+++ b/ldms/src/sampler/blob_stream/blob_stream_writer.c
@@ -660,7 +660,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-			.name = "blob_stream_writer",
 			.type = LDMSD_PLUGIN_SAMPLER,
 			.term = term,
 			.config = config,

--- a/ldms/src/sampler/blob_stream/blob_stream_writer.c
+++ b/ldms/src/sampler/blob_stream/blob_stream_writer.c
@@ -66,6 +66,7 @@
 #include <ovis_json/ovis_json.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 #define PNAME "blob_stream_writer"
 

--- a/ldms/src/sampler/clock/clock.c
+++ b/ldms/src/sampler/clock/clock.c
@@ -221,7 +221,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/clock/clock.c
+++ b/ldms/src/sampler/clock/clock.c
@@ -207,26 +207,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler clock_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &clock_plugin.base;
-}

--- a/ldms/src/sampler/clock/clock.c
+++ b/ldms/src/sampler/clock/clock.c
@@ -197,16 +197,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (base)
-		base_del(base);
-	base = NULL;
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -217,12 +207,17 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (base)
+		base_del(base);
+	base = NULL;
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/coretemp/coretemp.c
+++ b/ldms/src/sampler/coretemp/coretemp.c
@@ -430,7 +430,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/coretemp/coretemp.c
+++ b/ldms/src/sampler/coretemp/coretemp.c
@@ -391,8 +391,15 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
 
-static void term(ldmsd_plug_handle_t handle)
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	/* Clean up the sensor tree */
 	while (!rbt_empty(&sensor_tree)) {
@@ -416,22 +423,9 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-	set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/coretemp/coretemp.c
+++ b/ldms/src/sampler/coretemp/coretemp.c
@@ -416,26 +416,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler coretemp_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &coretemp_plugin.base;
-}

--- a/ldms/src/sampler/cray_system_sampler/cray_aries_r_sampler.c
+++ b/ldms/src/sampler/cray_system_sampler/cray_aries_r_sampler.c
@@ -346,37 +346,32 @@ static const char *usage(ldmsd_plug_handle_t handle)
 }
 
 
-static struct ldmsd_sampler cray_aries_r_sampler_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	static int init_complete = 0;
+	if (init_complete)
+		return -1;
+
+	cray_aries_log = ldmsd_plug_log_get(handle);
+	set_cray_sampler_log(cray_aries_log);
+	init_complete = 1;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = "cray_aries_r_sampler",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	cray_aries_log = ovis_log_register("sampler.cray_aries_r_sampler", "Message for the cray_aries_r_sampler plugin");
-	if (!cray_aries_log) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of 'cray_aries_r_sampler' plugin. Error %d\n", rc);
-	}
-	static int init_complete = 0;
-	if (init_complete)
-		goto out;
-
-	set_cray_sampler_log(cray_aries_log);
-	init_complete = 1;
-
-out:
-	return &cray_aries_r_sampler_plugin.base;
-
-err:
-
-	return NULL;
-}

--- a/ldms/src/sampler/cray_system_sampler/cray_aries_r_sampler.c
+++ b/ldms/src/sampler/cray_system_sampler/cray_aries_r_sampler.c
@@ -314,17 +314,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (base) {
-		base_del(base);
-		base = NULL;
-	}
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 
@@ -361,12 +350,18 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (base) {
+		base_del(base);
+		base = NULL;
+	}
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/cray_system_sampler/cray_aries_r_sampler.c
+++ b/ldms/src/sampler/cray_system_sampler/cray_aries_r_sampler.c
@@ -365,7 +365,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = "cray_aries_r_sampler",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/cray_system_sampler/cray_gemini_r_sampler.c
+++ b/ldms/src/sampler/cray_system_sampler/cray_gemini_r_sampler.c
@@ -355,42 +355,32 @@ static const char *usage(ldmsd_plug_handle_t handle)
 		"                        lustre, procnetdev, nvidia\n";
 }
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	static int init_complete = 0;
+	if (init_complete)
+		return -1;
 
-static struct ldmsd_sampler cray_gemini_r_sampler_plugin = {
+	cray_gemini_log = ldmsd_plug_log_get(handle);
+	set_cray_sampler_log(cray_gemini_log);
+	init_complete = 1;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = "cray_gemini_r_sampler",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	cray_gemini_log = ovis_log_register("sampler.cray_gemini_r_sampler",
-			"Message for the cray_gemini_r_sampler plugin");
-	if (!cray_gemini_log) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					   "of 'cray_gemini_r_sampler' plugin. "
-					   "Error %d\n", rc);
-	}
-	static int init_complete = 0;
-	int i;
-
-	if (init_complete)
-		goto out;
-
-	set_cray_sampler_log(cray_gemini_log);
-	init_complete = 1;
-
-out:
-	return &cray_gemini_r_sampler_plugin.base;
-
-err:
-
-	return NULL;
-}

--- a/ldms/src/sampler/cray_system_sampler/cray_gemini_r_sampler.c
+++ b/ldms/src/sampler/cray_system_sampler/cray_gemini_r_sampler.c
@@ -324,17 +324,6 @@ static int sample(ldmsd_plug_handle_t handle)
 
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (base) {
-                base_del(base);
-                base = NULL;
-        }
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	return  "config name=cray_gemini_r_sampler producer=<pname> component_id=<compid>"
@@ -370,12 +359,18 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (base) {
+                base_del(base);
+                base = NULL;
+        }
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/cray_system_sampler/cray_gemini_r_sampler.c
+++ b/ldms/src/sampler/cray_system_sampler/cray_gemini_r_sampler.c
@@ -374,7 +374,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = "cray_gemini_r_sampler",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/cray_system_sampler/dvs_sampler.c
+++ b/ldms/src/sampler/cray_system_sampler/dvs_sampler.c
@@ -734,7 +734,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/cray_system_sampler/dvs_sampler.c
+++ b/ldms/src/sampler/cray_system_sampler/dvs_sampler.c
@@ -715,31 +715,32 @@ static void term(ldmsd_plug_handle_t handle)
 	num_cfgmetrics = 0;
 }
 
-static struct ldmsd_sampler dvs_plugin = {
+static int mount_comparator(void *a, const void *b)
+{
+	return strcmp(a, b);
+}
+
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	rbt_init(&mount_tree, mount_comparator);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-static int mount_comparator(void *a, const void *b)
-{
-	return strcmp(a, b);
-}
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	rbt_init(&mount_tree, mount_comparator);
-	return &dvs_plugin.base;
-}

--- a/ldms/src/sampler/cray_system_sampler/dvs_sampler.c
+++ b/ldms/src/sampler/cray_system_sampler/dvs_sampler.c
@@ -700,21 +700,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	int i;
-
-	/* TODO: Run through the tree and blow everything away */
-	if (cfg_base)
-		base_del(cfg_base);
-	for (i = 0; i <num_cfgmetrics; i++){
-		free(cfgmetrics[i]);
-	}
-	free(cfgmetrics);
-	cfgmetrics = NULL;
-	num_cfgmetrics = 0;
-}
-
 static int mount_comparator(void *a, const void *b)
 {
 	return strcmp(a, b);
@@ -730,12 +715,22 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	int i;
+
+	/* TODO: Run through the tree and blow everything away */
+	if (cfg_base)
+		base_del(cfg_base);
+	for (i = 0; i <num_cfgmetrics; i++){
+		free(cfgmetrics[i]);
+	}
+	free(cfgmetrics);
+	cfgmetrics = NULL;
+	num_cfgmetrics = 0;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/dcgm_sampler/Makefile.am
+++ b/ldms/src/sampler/dcgm_sampler/Makefile.am
@@ -12,7 +12,7 @@ libdcgm_sampler_la_LIBADD = \
 	-ldcgm
 libdcgm_sampler_la_LDFLAGS = \
 	-no-undefined \
-        -export-symbols-regex 'get_plugin' \
+        -export-symbols-regex 'ldmsd_plugin_interface' \
         -version-info 1:0:0
 libdcgm_sampler_la_CPPFLAGS = \
 	@OVIS_INCLUDE_ABS@

--- a/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
+++ b/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
@@ -691,28 +691,27 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	return field_help ? field_help : preamble;
 }
 
-static struct ldmsd_sampler nvidia_dcgm_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	gethostname(producer_name, sizeof(producer_name));
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	ovis_log(mylog, OVIS_LDEBUG, "get_plugin() called ("PACKAGE_STRING")\n");
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	gethostname(producer_name, sizeof(producer_name));
-
-	return &nvidia_dcgm_plugin.base;
-}

--- a/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
+++ b/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
@@ -705,7 +705,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
+++ b/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
@@ -629,32 +629,6 @@ static int sample(ldmsd_plug_handle_t handle)
         return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	int i;
-
-	ovis_log(mylog, OVIS_LDEBUG, "term() called\n");
-        gpu_schema_destroy();
-	if (base) {
-		free(base->instance_name);
-		base->instance_name = NULL;
-		base_del(base);
-		base = NULL;
-	}
-	free(conf.schema_name);
-	conf.schema_name = NULL;
-        free(conf.fields);
-        conf.fields = NULL;
-        conf.fields_len = 0;
-        conf.interval = 0;
-        for (i = 0; i < gpu_ids_count; i++) {
-                gpu_metric_set_destroy(gpu_sets[gpu_ids[i]]);
-        }
-        dcgm_fini();
-	free(field_help);
-	field_help = NULL;
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
         ovis_log(mylog, OVIS_LDEBUG, "usage() called\n");
@@ -701,12 +675,33 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	int i;
+
+	ovis_log(mylog, OVIS_LDEBUG, "term() called\n");
+        gpu_schema_destroy();
+	if (base) {
+		free(base->instance_name);
+		base->instance_name = NULL;
+		base_del(base);
+		base = NULL;
+	}
+	free(conf.schema_name);
+	conf.schema_name = NULL;
+        free(conf.fields);
+        conf.fields = NULL;
+        conf.fields_len = 0;
+        conf.interval = 0;
+        for (i = 0; i < gpu_ids_count; i++) {
+                gpu_metric_set_destroy(gpu_sets[gpu_ids[i]]);
+        }
+        dcgm_fini();
+	free(field_help);
+	field_help = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/dstat/dstat.c
+++ b/ldms/src/sampler/dstat/dstat.c
@@ -567,15 +567,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (base)
-		base_del(base);
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -586,12 +577,16 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (base)
+		base_del(base);
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/dstat/dstat.c
+++ b/ldms/src/sampler/dstat/dstat.c
@@ -590,7 +590,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/dstat/dstat.c
+++ b/ldms/src/sampler/dstat/dstat.c
@@ -576,29 +576,30 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler dstat_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &dstat_plugin.base;
-}
 
 #else /* MAIN */
 #include "dstring.h"

--- a/ldms/src/sampler/examples/array_example/all_example.c
+++ b/ldms/src/sampler/examples/array_example/all_example.c
@@ -266,16 +266,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (base)
-		base_del(base);
-	base = NULL;
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	return "config_name=" SAMP " " BASE_CONFIG_USAGE;
@@ -291,11 +281,16 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (base)
+		base_del(base);
+	base = NULL;
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.term = term,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.config = config,
 		.usage = usage,

--- a/ldms/src/sampler/examples/array_example/all_example.c
+++ b/ldms/src/sampler/examples/array_example/all_example.c
@@ -281,26 +281,27 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	return "config_name=" SAMP " " BASE_CONFIG_USAGE;
 }
 
-static struct ldmsd_sampler all_example_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.term = term,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &all_example_plugin.base;
-}

--- a/ldms/src/sampler/examples/array_example/all_example.c
+++ b/ldms/src/sampler/examples/array_example/all_example.c
@@ -295,7 +295,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.term = term,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.config = config,

--- a/ldms/src/sampler/examples/array_example/array_example.c
+++ b/ldms/src/sampler/examples/array_example/array_example.c
@@ -306,7 +306,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/examples/array_example/array_example.c
+++ b/ldms/src/sampler/examples/array_example/array_example.c
@@ -292,26 +292,27 @@ static const char *usage(ldmsd_plug_handle_t handle)
 		"    <type>       The type of metric arrays, e.g., U64_ARRAY, U8_ARRAY, etc\n";
 }
 
-static struct ldmsd_sampler array_example_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &array_example_plugin.base;
-}

--- a/ldms/src/sampler/examples/array_example/array_example.c
+++ b/ldms/src/sampler/examples/array_example/array_example.c
@@ -273,15 +273,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (base)
-		base_del(base);
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 
@@ -302,12 +293,16 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (base)
+		base_del(base);
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/examples/list_sampler/list_sampler.c
+++ b/ldms/src/sampler/examples/list_sampler/list_sampler.c
@@ -379,15 +379,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (base)
-		base_del(base);
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -398,12 +389,16 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (base)
+		base_del(base);
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/examples/list_sampler/list_sampler.c
+++ b/ldms/src/sampler/examples/list_sampler/list_sampler.c
@@ -402,7 +402,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/examples/list_sampler/list_sampler.c
+++ b/ldms/src/sampler/examples/list_sampler/list_sampler.c
@@ -388,26 +388,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler __plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &__plugin.base;
-}

--- a/ldms/src/sampler/examples/record_sampler/record_sampler.c
+++ b/ldms/src/sampler/examples/record_sampler/record_sampler.c
@@ -413,26 +413,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler __plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &__plugin.base;
-}

--- a/ldms/src/sampler/examples/record_sampler/record_sampler.c
+++ b/ldms/src/sampler/examples/record_sampler/record_sampler.c
@@ -427,7 +427,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/examples/record_sampler/record_sampler.c
+++ b/ldms/src/sampler/examples/record_sampler/record_sampler.c
@@ -404,15 +404,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (base)
-		base_del(base);
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -423,12 +414,16 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (base)
+		base_del(base);
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/examples/synthetic/synthetic.c
+++ b/ldms/src/sampler/examples/synthetic/synthetic.c
@@ -312,7 +312,14 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	uint64_t k;
 	if (extras) {
@@ -330,21 +337,9 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/examples/synthetic/synthetic.c
+++ b/ldms/src/sampler/examples/synthetic/synthetic.c
@@ -343,7 +343,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/examples/synthetic/synthetic.c
+++ b/ldms/src/sampler/examples/synthetic/synthetic.c
@@ -330,25 +330,26 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler synthetic_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	return &synthetic_plugin.base;
-}

--- a/ldms/src/sampler/examples/test_sampler/test_sampler.c
+++ b/ldms/src/sampler/examples/test_sampler/test_sampler.c
@@ -2024,7 +2024,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
-	.base.name = SAMP,
 	.base.type = LDMSD_PLUGIN_SAMPLER,
 	.base.flags = LDMSD_PLUGIN_MULTI_INSTANCE,
 	.base.config = config,

--- a/ldms/src/sampler/examples/test_sampler/test_sampler.c
+++ b/ldms/src/sampler/examples/test_sampler/test_sampler.c
@@ -2023,7 +2023,7 @@ static void destructor(ldmsd_plug_handle_t handle)
 	}
 }
 
-static struct ldmsd_sampler test_sampler = {
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base.name = SAMP,
 	.base.type = LDMSD_PLUGIN_SAMPLER,
 	.base.flags = LDMSD_PLUGIN_MULTI_INSTANCE,
@@ -2034,8 +2034,3 @@ static struct ldmsd_sampler test_sampler = {
 
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	return &test_sampler.base;
-}

--- a/ldms/src/sampler/filesingle/filesingle.c
+++ b/ldms/src/sampler/filesingle/filesingle.c
@@ -424,7 +424,7 @@ static void destructor(ldmsd_plug_handle_t handle)
         free(fsc);
 }
 
-static struct ldmsd_sampler filesingle_plugin = {
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base.name = SAMP,
 	.base.type = LDMSD_PLUGIN_SAMPLER,
         .base.constructor = constructor,
@@ -433,8 +433,3 @@ static struct ldmsd_sampler filesingle_plugin = {
 	.base.usage = usage,
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	return (struct ldmsd_plugin *)&filesingle_plugin;
-}

--- a/ldms/src/sampler/filesingle/filesingle.c
+++ b/ldms/src/sampler/filesingle/filesingle.c
@@ -425,7 +425,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
-	.base.name = SAMP,
 	.base.type = LDMSD_PLUGIN_SAMPLER,
         .base.constructor = constructor,
         .base.destructor = destructor,

--- a/ldms/src/sampler/fptrans/fptrans.c
+++ b/ldms/src/sampler/fptrans/fptrans.c
@@ -251,7 +251,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/fptrans/fptrans.c
+++ b/ldms/src/sampler/fptrans/fptrans.c
@@ -227,16 +227,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (base)
-		base_del(base);
-	base = NULL;
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -247,12 +237,17 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (base)
+		base_del(base);
+	base = NULL;
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/fptrans/fptrans.c
+++ b/ldms/src/sampler/fptrans/fptrans.c
@@ -237,26 +237,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler fptrans_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &fptrans_plugin.base;
-}

--- a/ldms/src/sampler/generic_sampler.c
+++ b/ldms/src/sampler/generic_sampler.c
@@ -423,7 +423,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = "generic_sampler",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/generic_sampler.c
+++ b/ldms/src/sampler/generic_sampler.c
@@ -321,16 +321,6 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	return create_metric_set(value, prod_name);
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (schema)
-		ldms_schema_delete(schema);
-	schema = NULL;
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static int sample(ldmsd_plug_handle_t handle)
 {
 	gs_metric_t gs_metric;
@@ -419,12 +409,17 @@ int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (schema)
+		ldms_schema_delete(schema);
+	schema = NULL;
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/generic_sampler.c
+++ b/ldms/src/sampler/generic_sampler.c
@@ -406,30 +406,30 @@ out:
 	return rc;
 }
 
-static struct ldmsd_sampler gs_plugin = {
+int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	if (!gs_map)
+		gs_map = str_map_create(65537);
+	if (!gs_map)
+		return -1;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = "generic_sampler",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler.generic_sampler",
-			"The log subsystem of the generic_sampler plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of 'generic_sampler' plugin. Error %d\n", rc);
-	}
-	if (!gs_map)
-		gs_map = str_map_create(65537);
-	if (!gs_map)
-		return NULL;
-	return &gs_plugin.base;
-}

--- a/ldms/src/sampler/grptest.c
+++ b/ldms/src/sampler/grptest.c
@@ -261,36 +261,38 @@ static void term(ldmsd_plug_handle_t handle)
 	grp = NULL;
 }
 
-static struct ldmsd_sampler meminfo_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	if (!sc) {
+                int rc;
+		sc = ldms_schema_new("set_schema");
+		if (!sc)
+			return -1;
+		rc = ldms_schema_metric_add(sc, "counter", LDMS_V_U32);
+		if (rc) {
+			ldms_schema_delete(sc);
+			sc = NULL;
+			return -1;
+		}
+	}
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	if (!sc) {
-		sc = ldms_schema_new("set_schema");
-		if (!sc)
-			return NULL;
-		rc = ldms_schema_metric_add(sc, "counter", LDMS_V_U32);
-		if (rc) {
-			ldms_schema_delete(sc);
-			sc = NULL;
-			return NULL;
-		}
-	}
-	return &meminfo_plugin.base;
-}

--- a/ldms/src/sampler/grptest.c
+++ b/ldms/src/sampler/grptest.c
@@ -286,7 +286,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/grptest.c
+++ b/ldms/src/sampler/grptest.c
@@ -249,18 +249,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (mf)
-		fclose(mf);
-	mf = NULL;
-	if (base)
-		base_del(base);
-	if (grp)
-		ldms_set_delete(grp);
-	grp = NULL;
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -282,12 +270,19 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (mf)
+		fclose(mf);
+	mf = NULL;
+	if (base)
+		base_del(base);
+	if (grp)
+		ldms_set_delete(grp);
+	grp = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/hello_stream/hello_sampler.c
+++ b/ldms/src/sampler/hello_stream/hello_sampler.c
@@ -144,7 +144,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = "hello_sampler",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.config = config,
 		.usage = usage,

--- a/ldms/src/sampler/hello_stream/hello_sampler.c
+++ b/ldms/src/sampler/hello_stream/hello_sampler.c
@@ -131,25 +131,25 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl,
 	return rc;
 }
 
-static struct ldmsd_sampler hello_sampler = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = "hello_sampler",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler.hello_sampler",
-				"Message for the hello_sampler plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of 'hello_sampler' plugin. Error %d\n", rc);
-	}
-	return &hello_sampler.base;
-}

--- a/ldms/src/sampler/hweventpapi/hweventpapi.c
+++ b/ldms/src/sampler/hweventpapi/hweventpapi.c
@@ -1364,30 +1364,6 @@ static void term_hw(ldmsd_plug_handle_t handle)
 	}
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (hw_only) {
-		term_hw(handle);
-		return;
-	}
-	if (file)
-		fclose(file);
-
-	if (papi_event_set) {
-		PAPI_destroy_eventset(&papi_event_set);
-		PAPI_shutdown();
-	}
-
-	if (papi_event_val)
-		free(papi_event_val);
-	if (base)
-		base_del(base);
-	base = NULL;
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	return
@@ -1417,11 +1393,30 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (hw_only) {
+		term_hw(handle);
+		return;
+	}
+	if (file)
+		fclose(file);
+
+	if (papi_event_set) {
+		PAPI_destroy_eventset(&papi_event_set);
+		PAPI_shutdown();
+	}
+
+	if (papi_event_val)
+		free(papi_event_val);
+	if (base)
+		base_del(base);
+	base = NULL;
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base.type = LDMSD_PLUGIN_SAMPLER,
-	.base.term = term,
 	.base.config = config,
 	.base.usage = usage,
         .base.constructor = constructor,

--- a/ldms/src/sampler/hweventpapi/hweventpapi.c
+++ b/ldms/src/sampler/hweventpapi/hweventpapi.c
@@ -1420,7 +1420,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
-	.base.name = "spapi",
 	.base.type = LDMSD_PLUGIN_SAMPLER,
 	.base.term = term,
 	.base.config = config,

--- a/ldms/src/sampler/hweventpapi/hweventpapi.c
+++ b/ldms/src/sampler/hweventpapi/hweventpapi.c
@@ -1408,24 +1408,25 @@ static const char *usage(ldmsd_plug_handle_t handle)
 
 }
 
-static struct ldmsd_sampler papi_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base.name = "spapi",
 	.base.type = LDMSD_PLUGIN_SAMPLER,
 	.base.term = term,
 	.base.config = config,
 	.base.usage = usage,
+        .base.constructor = constructor,
+        .base.destructor = destructor,
 
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler.spapi", "Message for the spapi plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of 'spapi' plugin. Error %d\n", rc);
-	}
-	return &papi_plugin.base;
-}

--- a/ldms/src/sampler/ibm_occ/ibm_occ.c
+++ b/ldms/src/sampler/ibm_occ/ibm_occ.c
@@ -325,15 +325,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (base)
-		base_del(base);
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -344,12 +335,16 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (base)
+		base_del(base);
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/ibm_occ/ibm_occ.c
+++ b/ldms/src/sampler/ibm_occ/ibm_occ.c
@@ -334,26 +334,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler ibm_occ_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &ibm_occ_plugin.base;
-}

--- a/ldms/src/sampler/ibm_occ/ibm_occ.c
+++ b/ldms/src/sampler/ibm_occ/ibm_occ.c
@@ -348,7 +348,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/ibmad_records_sampler/Makefile.am
+++ b/ldms/src/sampler/ibmad_records_sampler/Makefile.am
@@ -10,7 +10,7 @@ libibmad_records_sampler_la_LIBADD = \
 	$(LTLIBIBMAD) $(LTLIBIBUMAD)
 libibmad_records_sampler_la_LDFLAGS = \
 	-no-undefined \
-        -export-symbols-regex 'get_plugin'
+        -export-symbols-regex 'ldmsd_plugin_interface'
 libibmad_records_sampler_la_CPPFLAGS = \
 	@OVIS_INCLUDE_ABS@ \
 	-I/usr/include/infiniband

--- a/ldms/src/sampler/ibmad_records_sampler/ibmad_records_sampler.c
+++ b/ldms/src/sampler/ibmad_records_sampler/ibmad_records_sampler.c
@@ -872,7 +872,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/ibmad_records_sampler/ibmad_records_sampler.c
+++ b/ldms/src/sampler/ibmad_records_sampler/ibmad_records_sampler.c
@@ -857,29 +857,28 @@ static const char *usage(ldmsd_plug_handle_t handle)
                 ;
 }
 
-static struct ldmsd_sampler ibmad_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        rbt_init(&interfaces_tree, string_comparator);
+	conf.use_rate_metrics = true;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler.ibmad_records", "Messages for ibmad_records sampler plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d.\n", rc);
-	}
-        ovis_log(mylog, OVIS_LDEBUG, "get_plugin() called ("PACKAGE_STRING")\n");
-        rbt_init(&interfaces_tree, string_comparator);
-	conf.use_rate_metrics = true;
-
-        return &ibmad_plugin.base;
-}

--- a/ldms/src/sampler/ibmad_records_sampler/ibmad_records_sampler.c
+++ b/ldms/src/sampler/ibmad_records_sampler/ibmad_records_sampler.c
@@ -840,15 +840,6 @@ static int sample(ldmsd_plug_handle_t handle)
         return interfaces_tree_sample();
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-        ovis_log(mylog, OVIS_LDEBUG, "term() called\n");
-        interfaces_tree_destroy();
-        base_set_delete(sampler_base);
-        base_del(sampler_base);
-        sampler_base = NULL;
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
         ovis_log(mylog, OVIS_LDEBUG, "usage() called\n");
@@ -868,12 +859,16 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+        ovis_log(mylog, OVIS_LDEBUG, "term() called\n");
+        interfaces_tree_destroy();
+        base_set_delete(sampler_base);
+        base_del(sampler_base);
+        sampler_base = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/ibmad_sampler/Makefile.am
+++ b/ldms/src/sampler/ibmad_sampler/Makefile.am
@@ -11,7 +11,7 @@ libibmad_sampler_la_LIBADD = \
 	$(LTLIBIBMAD) $(LTLIBIBUMAD)
 libibmad_sampler_la_LDFLAGS = \
 	-no-undefined \
-        -export-symbols-regex 'get_plugin'
+        -export-symbols-regex 'ldmsd_plugin_interface'
 libibmad_sampler_la_CPPFLAGS = \
 	@OVIS_INCLUDE_ABS@ \
 	-I/usr/include/infiniband

--- a/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
+++ b/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
@@ -774,30 +774,29 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	return  "config name=" SAMP;
 }
 
-static struct ldmsd_sampler ibmad_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	rbt_init(&metrics_tree, string_comparator);
+	conf.schema_name = strdup("ibmad");
+	conf.use_rate_metrics = true;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	ovis_log(mylog, OVIS_LDEBUG, " get_plugin() called ("PACKAGE_STRING")\n");
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	rbt_init(&metrics_tree, string_comparator);
-	conf.schema_name = strdup("ibmad");
-	conf.use_rate_metrics = true;
-
-	return &ibmad_plugin.base;
-}

--- a/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
+++ b/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
@@ -760,14 +760,6 @@ static int sample(ldmsd_plug_handle_t handle)
         return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	ovis_log(mylog, OVIS_LDEBUG, "term() called\n");
-	metrics_tree_destroy();
-	ibmad_schema_destroy();
-	free(conf.schema_name);
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
         ovis_log(mylog, OVIS_LDEBUG, "usage() called\n");
@@ -786,12 +778,15 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	ovis_log(mylog, OVIS_LDEBUG, "term() called\n");
+	metrics_tree_destroy();
+	ibmad_schema_destroy();
+	free(conf.schema_name);
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
+++ b/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
@@ -790,7 +790,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
+++ b/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 #include <mad.h>
 #include <umad.h>
 #include <iba/ib_types.h>

--- a/ldms/src/sampler/ibnet/ibnet_plugin.c
+++ b/ldms/src/sampler/ibnet/ibnet_plugin.c
@@ -106,19 +106,6 @@ static int sample_ibnet(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term_ibnet(ldmsd_plug_handle_t handle)
-{
-	pthread_mutex_lock(&only_lock);
-	ovis_log(mylog, OVIS_LDEBUG, SAMP " term() called\n");
-	ibnet_data_delete(only);
-	only = NULL;
-	if (usage) {
-		free(usage);
-		usage = NULL;
-	}
-	pthread_mutex_unlock(&only_lock);
-}
-
 static const char *usage_ibnet(ldmsd_plug_handle_t handle)
 {
 	ovis_log(mylog, OVIS_LDEBUG, SAMP " usage() called\n");
@@ -136,12 +123,20 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	pthread_mutex_lock(&only_lock);
+	ovis_log(mylog, OVIS_LDEBUG, SAMP " term() called\n");
+	ibnet_data_delete(only);
+	only = NULL;
+	if (usage) {
+		free(usage);
+		usage = NULL;
+	}
+	pthread_mutex_unlock(&only_lock);
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term_ibnet,
 		.config = config_ibnet,
 		.usage = usage_ibnet,
 		.constructor = constructor,

--- a/ldms/src/sampler/ibnet/ibnet_plugin.c
+++ b/ldms/src/sampler/ibnet/ibnet_plugin.c
@@ -140,7 +140,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term_ibnet,
 		.config = config_ibnet,

--- a/ldms/src/sampler/ibnet/ibnet_plugin.c
+++ b/ldms/src/sampler/ibnet/ibnet_plugin.c
@@ -127,26 +127,26 @@ static const char *usage_ibnet(ldmsd_plug_handle_t handle)
 	return usage;
 }
 
-static struct ldmsd_sampler ibnet_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term_ibnet,
 		.config = config_ibnet,
 		.usage = usage_ibnet,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample_ibnet,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	ovis_log(mylog, OVIS_LDEBUG, SAMP" get_plugin() called\n");
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	return &ibnet_plugin.base;
-}

--- a/ldms/src/sampler/ibnet/ibnet_plugin.c
+++ b/ldms/src/sampler/ibnet/ibnet_plugin.c
@@ -54,6 +54,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include "ibnet_data.h"
+#include "ldmsd_plug_api.h"
 #include <pthread.h>
 
 #define _GNU_SOURCE

--- a/ldms/src/sampler/job_info/jobinfo.c
+++ b/ldms/src/sampler/job_info/jobinfo.c
@@ -438,17 +438,6 @@ sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void
-term(ldmsd_plug_handle_t handle)
-{
-	if (job_schema)
-		ldms_schema_delete(job_schema);
-	job_schema = NULL;
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -459,12 +448,17 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (job_schema)
+		ldms_schema_delete(job_schema);
+	job_schema = NULL;
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/job_info/jobinfo.c
+++ b/ldms/src/sampler/job_info/jobinfo.c
@@ -463,7 +463,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/job_info/jobinfo.c
+++ b/ldms/src/sampler/job_info/jobinfo.c
@@ -449,26 +449,27 @@ term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler job_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &job_plugin.base;
-}

--- a/ldms/src/sampler/job_info/jobinfo.c
+++ b/ldms/src/sampler/job_info/jobinfo.c
@@ -71,6 +71,7 @@
 #include <grp.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 #include "jobinfo.h"
 
 static ovis_log_t mylog;

--- a/ldms/src/sampler/json/json_stream_sampler.c
+++ b/ldms/src/sampler/json/json_stream_sampler.c
@@ -1240,7 +1240,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/json/json_stream_sampler.c
+++ b/ldms/src/sampler/json/json_stream_sampler.c
@@ -1220,13 +1220,6 @@ static int json_recv_cb(ldms_stream_event_t ev, void *arg)
 	}
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	js_stream_sampler_t js = ldmsd_plug_ctxt_get(handle);
-	if (js->stream_client)
-		ldms_stream_close(js->stream_client); /* CLOSE event will clean up `p` */
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	__log = ldmsd_plug_log_get(handle);
@@ -1236,12 +1229,14 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	js_stream_sampler_t js = ldmsd_plug_ctxt_get(handle);
+	if (js->stream_client)
+		ldms_stream_close(js->stream_client); /* CLOSE event will clean up `p` */
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/json/json_stream_sampler.c
+++ b/ldms/src/sampler/json/json_stream_sampler.c
@@ -1227,24 +1227,25 @@ static void term(ldmsd_plug_handle_t handle)
 		ldms_stream_close(js->stream_client); /* CLOSE event will clean up `p` */
 }
 
-static struct ldmsd_sampler js_stream_sampler = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	__log = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
-		.usage = usage
+		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	__log = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!__log) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	return &js_stream_sampler.base;
-}

--- a/ldms/src/sampler/kgnilnd/kgnilnd.c
+++ b/ldms/src/sampler/kgnilnd/kgnilnd.c
@@ -331,26 +331,26 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	return  "config name=" SAMP BASE_CONFIG_USAGE;
 }
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
 
-static struct ldmsd_sampler kgnilnd_plugin = {
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	return &kgnilnd_plugin.base;
-}

--- a/ldms/src/sampler/kgnilnd/kgnilnd.c
+++ b/ldms/src/sampler/kgnilnd/kgnilnd.c
@@ -344,7 +344,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/kgnilnd/kgnilnd.c
+++ b/ldms/src/sampler/kgnilnd/kgnilnd.c
@@ -314,18 +314,6 @@ out:
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (mf)
-		fclose(mf);
-	mf = NULL;
-	if (base)
-		base_del(base);
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	return  "config name=" SAMP BASE_CONFIG_USAGE;
@@ -340,12 +328,19 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (mf)
+		fclose(mf);
+	mf = NULL;
+	if (base)
+		base_del(base);
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/ldms_jobid.c
+++ b/ldms/src/sampler/ldms_jobid.c
@@ -591,25 +591,6 @@ int ldms_job_info_get(struct ldms_job_info *ji, unsigned flags)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (set) {
-		ldmsd_set_deregister(ldms_set_instance_name_get(set), SAMP);
-		ldms_set_delete(set);
-	}
-	set = NULL;
-	if (schema)
-		ldms_schema_delete(schema);
-	schema = NULL;
-
-	if (metric_name && metric_name != JOBID_COLNAME ) {
-		free(metric_name);
-	}
-	if ( procfile && procfile != JOBID_FILE ) {
-		free(procfile);
-	}
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	return "config name=jobid producer=<prod_name> instance=<inst_name> "
@@ -633,12 +614,26 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (set) {
+		ldmsd_set_deregister(ldms_set_instance_name_get(set), SAMP);
+		ldms_set_delete(set);
+	}
+	set = NULL;
+	if (schema)
+		ldms_schema_delete(schema);
+	schema = NULL;
+
+	if (metric_name && metric_name != JOBID_COLNAME ) {
+		free(metric_name);
+	}
+	if ( procfile && procfile != JOBID_FILE ) {
+		free(procfile);
+	}
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/ldms_jobid.c
+++ b/ldms/src/sampler/ldms_jobid.c
@@ -637,7 +637,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/ldms_jobid.c
+++ b/ldms/src/sampler/ldms_jobid.c
@@ -623,26 +623,27 @@ static const char *usage(ldmsd_plug_handle_t handle)
 		;
 }
 
-static struct ldmsd_sampler jobid_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &jobid_plugin.base;
-}

--- a/ldms/src/sampler/llnl/edac.c
+++ b/ldms/src/sampler/llnl/edac.c
@@ -432,16 +432,6 @@ out:
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (base)
-		base_del(base);
-	base = NULL;
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -452,12 +442,17 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (base)
+		base_del(base);
+	base = NULL;
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/llnl/edac.c
+++ b/ldms/src/sampler/llnl/edac.c
@@ -442,26 +442,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler edac_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &edac_plugin.base;
-}

--- a/ldms/src/sampler/llnl/edac.c
+++ b/ldms/src/sampler/llnl/edac.c
@@ -456,7 +456,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/lnet_stats/lnet_stats.c
+++ b/ldms/src/sampler/lnet_stats/lnet_stats.c
@@ -358,26 +358,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler lnet_stats_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface  = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &lnet_stats_plugin.base;
-}

--- a/ldms/src/sampler/lnet_stats/lnet_stats.c
+++ b/ldms/src/sampler/lnet_stats/lnet_stats.c
@@ -372,7 +372,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface  = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/lnet_stats/lnet_stats.c
+++ b/ldms/src/sampler/lnet_stats/lnet_stats.c
@@ -347,17 +347,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	base_del(base);
-	base = NULL;
-	free(lnet_state_file);
-	lnet_state_file = NULL;
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -368,12 +357,18 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	base_del(base);
+	base = NULL;
+	free(lnet_state_file);
+	lnet_state_file = NULL;
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface  = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/loadavg/loadavg.c
+++ b/ldms/src/sampler/loadavg/loadavg.c
@@ -450,7 +450,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/loadavg/loadavg.c
+++ b/ldms/src/sampler/loadavg/loadavg.c
@@ -436,27 +436,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
 
-static struct ldmsd_sampler loadavg_plugin = {
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &loadavg_plugin.base;
-}

--- a/ldms/src/sampler/loadavg/loadavg.c
+++ b/ldms/src/sampler/loadavg/loadavg.c
@@ -424,7 +424,15 @@ out:
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	if (mf)
 		fclose(mf);
@@ -436,22 +444,9 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-        set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/lustre/lustre2_client.c
+++ b/ldms/src/sampler/lustre/lustre2_client.c
@@ -473,7 +473,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/lustre/lustre2_client.c
+++ b/ldms/src/sampler/lustre/lustre2_client.c
@@ -452,35 +452,34 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static struct ldmsd_sampler lustre_client_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	static int init_complete = 0;
+
+	if (init_complete)
+		return -1;
+
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+	lustre_sampler_set_pilog(mylog);
+	init_complete = 1;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	static int init_complete = 0;
-	if (init_complete)
-		goto out;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	lustre_sampler_set_pilog(mylog);
-
-	init_complete = 1;
-out:
-	return &lustre_client_plugin.base;
-	errno = ENOMEM;
-	return NULL;
-}

--- a/ldms/src/sampler/lustre/lustre2_client.c
+++ b/ldms/src/sampler/lustre/lustre2_client.c
@@ -344,18 +344,6 @@ err0:
 	return errno;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (set) {
-		ldms_set_delete(set);
-		set = NULL;
-	}
-	if (base) {
-		base_del(base);
-		base = NULL;
-	}
-}
-
 /**
  * \brief Configuration
  *
@@ -469,12 +457,19 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (set) {
+		ldms_set_delete(set);
+		set = NULL;
+	}
+	if (base) {
+		base_del(base);
+		base = NULL;
+	}
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/lustre/lustre2_mds.c
+++ b/ldms/src/sampler/lustre/lustre2_mds.c
@@ -326,7 +326,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = "lustre_mds",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/lustre/lustre2_mds.c
+++ b/ldms/src/sampler/lustre/lustre2_mds.c
@@ -234,16 +234,6 @@ err0:
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-	if (base)
-		base_del(base);
-	base = NULL;
-}
-
 /**
  * \brief Configuration
  *
@@ -322,12 +312,17 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
+	if (base)
+		base_del(base);
+	base = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/lustre/lustre2_mds.c
+++ b/ldms/src/sampler/lustre/lustre2_mds.c
@@ -311,29 +311,28 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static struct ldmsd_sampler lustre_mds_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+	lustre_sampler_set_pilog(mylog);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = "lustre_mds",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler.lustre_mds", "Message for the lustre_mds plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of 'lustre_mds' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	lustre_sampler_set_pilog(mylog);
-	return &lustre_mds_plugin.base;
-	errno = ENOMEM;
-	return NULL;
-}

--- a/ldms/src/sampler/lustre/lustre2_oss.c
+++ b/ldms/src/sampler/lustre/lustre2_oss.c
@@ -393,36 +393,32 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static struct ldmsd_sampler lustre_oss_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	int init_complete = 0;
+	if (init_complete)
+		return -1;
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+	lustre_sampler_set_pilog(mylog);
+	init_complete = 1;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = "lustre_oss",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	int init_complete = 0;
-	if (init_complete)
-		goto out;
-	mylog = ovis_log_register("sampler.lustre_oss", "Message for the lustre_oss plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of 'lustre_oss' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	lustre_sampler_set_pilog(mylog);
-
-	init_complete = 1;
-out:
-	return &lustre_oss_plugin.base;
-
-
-
-}

--- a/ldms/src/sampler/lustre/lustre2_oss.c
+++ b/ldms/src/sampler/lustre/lustre2_oss.c
@@ -313,18 +313,6 @@ err0:
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (set) {
-		ldms_set_delete(set);
-		set = NULL;
-	}
-	if (base) {
-		base_del(base);
-		base = NULL;
-	}
-}
-
 /**
  * \brief Configuration
  *
@@ -408,12 +396,19 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (set) {
+		ldms_set_delete(set);
+		set = NULL;
+	}
+	if (base) {
+		base_del(base);
+		base = NULL;
+	}
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/lustre/lustre2_oss.c
+++ b/ldms/src/sampler/lustre/lustre2_oss.c
@@ -412,7 +412,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = "lustre_oss",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/lustre_client/Makefile.am
+++ b/ldms/src/sampler/lustre_client/Makefile.am
@@ -15,7 +15,7 @@ liblustre_client_la_LIBADD = \
 
 liblustre_client_la_LDFLAGS = \
 	-no-undefined \
-        -export-symbols-regex 'get_plugin' \
+        -export-symbols-regex 'ldmsd_plugin_interface' \
         -version-info 1:0:0
 liblustre_client_la_CPPFLAGS = \
 	@OVIS_INCLUDE_ABS@

--- a/ldms/src/sampler/lustre_client/lustre_client.c
+++ b/ldms/src/sampler/lustre_client/lustre_client.c
@@ -283,13 +283,6 @@ static int sample(ldmsd_plug_handle_t handle)
         return err;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	ovis_log(lustre_client_log, OVIS_LDEBUG, "term() called\n");
-	llites_destroy();
-	llite_general_schema_fini();
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
         ovis_log(lustre_client_log, OVIS_LDEBUG, "usage() called\n");
@@ -307,12 +300,14 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	ovis_log(lustre_client_log, OVIS_LDEBUG, "term() called\n");
+	llites_destroy();
+	llite_general_schema_fini();
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/lustre_client/lustre_client.c
+++ b/ldms/src/sampler/lustre_client/lustre_client.c
@@ -296,29 +296,28 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	return  "config name=" SAMP;
 }
 
-static struct ldmsd_sampler llite_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+        lustre_client_log = ldmsd_plug_log_get(handle);
+	rbt_init(&llite_tree, string_comparator);
+	gethostname(producer_name, sizeof(producer_name));
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	lustre_client_log = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!lustre_client_log) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem of "
-					"'" SAMP "' plugin. Error %d\n", rc);
-	}
-	ovis_log(lustre_client_log, OVIS_LDEBUG, "get_plugin() called ("PACKAGE_STRING")\n");
-	rbt_init(&llite_tree, string_comparator);
-	gethostname(producer_name, sizeof(producer_name));
-
-	return &llite_plugin.base;
-}

--- a/ldms/src/sampler/lustre_client/lustre_client.c
+++ b/ldms/src/sampler/lustre_client/lustre_client.c
@@ -311,7 +311,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/lustre_client/lustre_client.c
+++ b/ldms/src/sampler/lustre_client/lustre_client.c
@@ -14,6 +14,7 @@
 #include <unistd.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 #include "config.h"
 #include "lustre_client.h"
 #include "lustre_client_general.h"

--- a/ldms/src/sampler/lustre_mdc/Makefile.am
+++ b/ldms/src/sampler/lustre_mdc/Makefile.am
@@ -16,7 +16,7 @@ liblustre_mdc_la_LIBADD = \
 
 liblustre_mdc_la_LDFLAGS = \
 	-no-undefined \
-	-export-symbols-regex 'get_plugin' \
+	-export-symbols-regex 'ldmsd_plugin_interface' \
 	-version-info 1:0:0
 liblustre_mdc_la_CFLAGS = $(AM_CFLAGS)
 liblustre_mdc_la_CPPFLAGS = \

--- a/ldms/src/sampler/lustre_mdc/lustre_mdc.c
+++ b/ldms/src/sampler/lustre_mdc/lustre_mdc.c
@@ -275,13 +275,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return err;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	ovis_log(lustre_mdc_log, OVIS_LDEBUG, "term() called\n");
-	mdcs_destroy();
-	mdc_general_schema_fini();
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	ovis_log(lustre_mdc_log, OVIS_LDEBUG, "usage() called\n");
@@ -299,12 +292,14 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	ovis_log(lustre_mdc_log, OVIS_LDEBUG, "term() called\n");
+	mdcs_destroy();
+	mdc_general_schema_fini();
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/lustre_mdc/lustre_mdc.c
+++ b/ldms/src/sampler/lustre_mdc/lustre_mdc.c
@@ -303,7 +303,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/lustre_mdc/lustre_mdc.c
+++ b/ldms/src/sampler/lustre_mdc/lustre_mdc.c
@@ -288,29 +288,28 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	return  "config name=" SAMP;
 }
 
-static struct ldmsd_sampler mdc_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	lustre_mdc_log = ldmsd_plug_log_get(handle);
+	rbt_init(&mdc_tree, string_comparator);
+	gethostname(producer_name, sizeof(producer_name));
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	lustre_mdc_log = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!lustre_mdc_log) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' pluginl. Error %d\n", rc);
-	}
-	ovis_log(lustre_mdc_log, OVIS_LDEBUG, "get_plugin() called ("PACKAGE_STRING")\n");
-	rbt_init(&mdc_tree, string_comparator);
-	gethostname(producer_name, sizeof(producer_name));
-
-	return &mdc_plugin.base;
-}

--- a/ldms/src/sampler/lustre_mdc/lustre_mdc.c
+++ b/ldms/src/sampler/lustre_mdc/lustre_mdc.c
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 #include "config.h"
 #include "lustre_mdc.h"
 #include "lustre_mdc_general.h"

--- a/ldms/src/sampler/lustre_mdt/Makefile.am
+++ b/ldms/src/sampler/lustre_mdt/Makefile.am
@@ -15,7 +15,7 @@ liblustre_mdt_la_LIBADD = \
 
 liblustre_mdt_la_LDFLAGS = \
 	-no-undefined \
-        -export-symbols-regex 'get_plugin' \
+        -export-symbols-regex 'ldmsd_plugin_interface' \
         -version-info 1:0:0
 liblustre_mdt_la_CPPFLAGS = \
 	@OVIS_INCLUDE_ABS@

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt.c
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt.c
@@ -257,29 +257,28 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	return  "config name=" SAMP;
 }
 
-static struct ldmsd_sampler mdt_job_stats_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	luster_mdt_log = ldmsd_plug_log_get(handle);
+        rbt_init(&mdt_tree, string_comparator);
+        gethostname(producer_name, sizeof(producer_name));
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	luster_mdt_log = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!luster_mdt_log) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-				"of '" SAMP "' plugin. Error %d.\n", rc);
-	}
-	ovis_log(luster_mdt_log, OVIS_LDEBUG, SAMP" get_plugin() called ("PACKAGE_STRING")\n");
-        rbt_init(&mdt_tree, string_comparator);
-        gethostname(producer_name, sizeof(producer_name));
-
-        return &mdt_job_stats_plugin.base;
-}

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt.c
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt.c
@@ -272,7 +272,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt.c
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt.c
@@ -243,14 +243,6 @@ static int sample(ldmsd_plug_handle_t handle)
         return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	ovis_log(luster_mdt_log, OVIS_LDEBUG, SAMP" term() called\n");
-	mdts_destroy();
-	mdt_general_schema_fini();
-	mdt_job_stats_schema_fini();
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	ovis_log(luster_mdt_log, OVIS_LDEBUG, SAMP" usage() called\n");
@@ -268,12 +260,15 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	ovis_log(luster_mdt_log, OVIS_LDEBUG, SAMP" destructor() called\n");
+	mdts_destroy();
+	mdt_general_schema_fini();
+	mdt_job_stats_schema_fini();
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt.c
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt.c
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 #include "config.h"
 #include "lustre_mdt.h"
 #include "lustre_mdt_general.h"

--- a/ldms/src/sampler/lustre_ost/Makefile.am
+++ b/ldms/src/sampler/lustre_ost/Makefile.am
@@ -15,7 +15,7 @@ liblustre_ost_la_LIBADD = \
 
 liblustre_ost_la_LDFLAGS = \
 	-no-undefined \
-        -export-symbols-regex 'get_plugin' \
+        -export-symbols-regex 'ldmsd_plugin_interface' \
         -version-info 1:0:0
 liblustre_ost_la_CPPFLAGS = \
 	@OVIS_INCLUDE_ABS@

--- a/ldms/src/sampler/lustre_ost/lustre_ost.c
+++ b/ldms/src/sampler/lustre_ost/lustre_ost.c
@@ -271,7 +271,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/lustre_ost/lustre_ost.c
+++ b/ldms/src/sampler/lustre_ost/lustre_ost.c
@@ -242,14 +242,6 @@ static int sample(ldmsd_plug_handle_t handle)
         return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	ovis_log(lustre_ost_log, OVIS_LDEBUG, "term() called\n");
-	osts_destroy();
-	ost_general_schema_fini();
-	ost_job_stats_schema_fini();
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
         ovis_log(lustre_ost_log, OVIS_LDEBUG, "usage() called\n");
@@ -267,12 +259,15 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	ovis_log(lustre_ost_log, OVIS_LDEBUG, "term() called\n");
+	osts_destroy();
+	ost_general_schema_fini();
+	ost_job_stats_schema_fini();
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/lustre_ost/lustre_ost.c
+++ b/ldms/src/sampler/lustre_ost/lustre_ost.c
@@ -256,29 +256,28 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	return  "config name=" SAMP;
 }
 
-static struct ldmsd_sampler ost_job_stats_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	lustre_ost_log = ldmsd_plug_log_get(handle);
+	rbt_init(&ost_tree, string_comparator);
+	gethostname(producer_name, sizeof(producer_name));
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	lustre_ost_log = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!lustre_ost_log) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	ovis_log(lustre_ost_log, OVIS_LDEBUG, "get_plugin() called ("PACKAGE_STRING")\n");
-	rbt_init(&ost_tree, string_comparator);
-	gethostname(producer_name, sizeof(producer_name));
-
-	return &ost_job_stats_plugin.base;
-}

--- a/ldms/src/sampler/lustre_ost/lustre_ost.c
+++ b/ldms/src/sampler/lustre_ost/lustre_ost.c
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 #include "config.h"
 #include "lustre_ost.h"
 #include "lustre_ost_general.h"

--- a/ldms/src/sampler/meminfo/meminfo.c
+++ b/ldms/src/sampler/meminfo/meminfo.c
@@ -243,7 +243,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 };
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
-	.base.name = SAMP,
 	.base.type = LDMSD_PLUGIN_SAMPLER,
 	.base.flags = LDMSD_PLUGIN_MULTI_INSTANCE,
 	.base.config = config,

--- a/ldms/src/sampler/meminfo/meminfo.c
+++ b/ldms/src/sampler/meminfo/meminfo.c
@@ -242,7 +242,7 @@ static void destructor(ldmsd_plug_handle_t handle)
 	free(mi);
 };
 
-static struct ldmsd_sampler meminfo_plugin = {
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base.name = SAMP,
 	.base.type = LDMSD_PLUGIN_SAMPLER,
 	.base.flags = LDMSD_PLUGIN_MULTI_INSTANCE,
@@ -253,8 +253,3 @@ static struct ldmsd_sampler meminfo_plugin = {
 
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	return &meminfo_plugin.base;
-}

--- a/ldms/src/sampler/msr_interlagos/msr_interlagos.c
+++ b/ldms/src/sampler/msr_interlagos/msr_interlagos.c
@@ -1708,7 +1708,15 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	int i;
 
@@ -1738,22 +1746,9 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-	set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/msr_interlagos/msr_interlagos.c
+++ b/ldms/src/sampler/msr_interlagos/msr_interlagos.c
@@ -1752,7 +1752,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/msr_interlagos/msr_interlagos.c
+++ b/ldms/src/sampler/msr_interlagos/msr_interlagos.c
@@ -1738,26 +1738,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler msr_interlagos_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &msr_interlagos_plugin.base;
-}

--- a/ldms/src/sampler/opa2/opa2.c
+++ b/ldms/src/sampler/opa2/opa2.c
@@ -556,24 +556,26 @@ static void SAPI(term)(ldmsd_plug_handle_t handle)
 	}
 }
 
-static struct ldmsd_sampler SAPI(plugin) = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = SAPI(term),
 		.config = SAPI(config),
 		.usage = SAPI(usage),
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = SAPI(sample),
 };
-
-struct ldmsd_plugin *get_plugin() {
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	return &SAPI(plugin).base;
-}

--- a/ldms/src/sampler/opa2/opa2.c
+++ b/ldms/src/sampler/opa2/opa2.c
@@ -538,7 +538,14 @@ static int SAPI(sample)(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void SAPI(term)(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	struct hfi_port_comb *hpc;
 	ovis_log(mylog, OVIS_LDEBUG, SAMP ": closing plugin.\n");
@@ -556,21 +563,9 @@ static void SAPI(term)(ldmsd_plug_handle_t handle)
 	}
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = SAPI(term),
 		.config = SAPI(config),
 		.usage = SAPI(usage),
 		.constructor = constructor,

--- a/ldms/src/sampler/opa2/opa2.c
+++ b/ldms/src/sampler/opa2/opa2.c
@@ -569,7 +569,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = SAPI(term),
 		.config = SAPI(config),

--- a/ldms/src/sampler/papi/papi_sampler.c
+++ b/ldms/src/sampler/papi/papi_sampler.c
@@ -931,7 +931,14 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	return errno;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	if (papi_base) {
 		base_del(papi_base);
@@ -943,21 +950,9 @@ static void term(ldmsd_plug_handle_t handle)
 	}
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/papi/papi_sampler.c
+++ b/ldms/src/sampler/papi/papi_sampler.c
@@ -943,28 +943,29 @@ static void term(ldmsd_plug_handle_t handle)
 	}
 }
 
-static struct ldmsd_sampler papi_sampler = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	return &papi_sampler.base;
-}
 
 static int cmp_job_key(void *a, const void *b)
 {

--- a/ldms/src/sampler/papi/papi_sampler.c
+++ b/ldms/src/sampler/papi/papi_sampler.c
@@ -956,7 +956,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/perfevent/perfevent.c
+++ b/ldms/src/sampler/perfevent/perfevent.c
@@ -573,25 +573,26 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler pe_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	return &pe_plugin.base;
-}

--- a/ldms/src/sampler/perfevent/perfevent.c
+++ b/ldms/src/sampler/perfevent/perfevent.c
@@ -586,7 +586,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/perfevent/perfevent.c
+++ b/ldms/src/sampler/perfevent/perfevent.c
@@ -541,7 +541,14 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	struct pevent *pe;
 	struct event_group *ge;
@@ -573,21 +580,9 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/perfevent/perfevent.c
+++ b/ldms/src/sampler/perfevent/perfevent.c
@@ -67,6 +67,7 @@
 #include <math.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 #include "sampler_base.h"
 
 #define SAMP "perfevent"

--- a/ldms/src/sampler/procdiskstats/procdiskstats.c
+++ b/ldms/src/sampler/procdiskstats/procdiskstats.c
@@ -505,7 +505,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/procdiskstats/procdiskstats.c
+++ b/ldms/src/sampler/procdiskstats/procdiskstats.c
@@ -103,7 +103,7 @@ static FILE *mf = NULL;
 static int metric_offset;
 static base_data_t base;
 
-static long USER_HZ; /* initialized in get_plugin() */
+static long USER_HZ; /* initialized in constructor() */
 static struct timeval _tv[2] = { {0}, {0} };
 static struct timeval *curr_tv = &_tv[0];
 static struct timeval *prev_tv = &_tv[1];
@@ -490,27 +490,28 @@ static const char *usage(ldmsd_plug_handle_t handle)
 		"    <devices>       A comma-separated list of devices\n";
 }
 
-static struct ldmsd_sampler procdiskstats_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+	USER_HZ = sysconf(_SC_CLK_TCK);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	USER_HZ = sysconf(_SC_CLK_TCK);
-	return &procdiskstats_plugin.base;
-}

--- a/ldms/src/sampler/procdiskstats/procdiskstats.c
+++ b/ldms/src/sampler/procdiskstats/procdiskstats.c
@@ -464,7 +464,22 @@ out:
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static const char *usage(ldmsd_plug_handle_t handle)
+{
+	return  "config name=procdiskstats device=<devices> " BASE_CONFIG_USAGE
+		"    <devices>       A comma-separated list of devices\n";
+}
+
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+	USER_HZ = sysconf(_SC_CLK_TCK);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	if (mf)
 		fclose(mf);
@@ -484,29 +499,9 @@ static void term(ldmsd_plug_handle_t handle)
 	}
 }
 
-static const char *usage(ldmsd_plug_handle_t handle)
-{
-	return  "config name=procdiskstats device=<devices> " BASE_CONFIG_USAGE
-		"    <devices>       A comma-separated list of devices\n";
-}
-
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-	set = NULL;
-	USER_HZ = sysconf(_SC_CLK_TCK);
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/procinterrupts/procinterrupts.c
+++ b/ldms/src/sampler/procinterrupts/procinterrupts.c
@@ -276,7 +276,15 @@ out:
 }
 
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	if (mf)
 		fclose(mf);
@@ -288,22 +296,9 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-        set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/procinterrupts/procinterrupts.c
+++ b/ldms/src/sampler/procinterrupts/procinterrupts.c
@@ -288,26 +288,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler procinterrupts_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &procinterrupts_plugin.base;
-}

--- a/ldms/src/sampler/procinterrupts/procinterrupts.c
+++ b/ldms/src/sampler/procinterrupts/procinterrupts.c
@@ -302,7 +302,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/procnet/procnet.c
+++ b/ldms/src/sampler/procnet/procnet.c
@@ -473,28 +473,29 @@ static void term(ldmsd_plug_handle_t handle)
 	pthread_mutex_unlock(&cfg_lock);
 }
 
-static struct ldmsd_sampler procnet_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	return &procnet_plugin.base;
-}
 
 static void __attribute__ ((destructor)) procnet_plugin_fini(void);
 static void procnet_plugin_fini()

--- a/ldms/src/sampler/procnet/procnet.c
+++ b/ldms/src/sampler/procnet/procnet.c
@@ -486,7 +486,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/procnet/procnet.c
+++ b/ldms/src/sampler/procnet/procnet.c
@@ -465,14 +465,6 @@ err:
 }
 
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	pthread_mutex_lock(&cfg_lock);
-	procnet_reset();
-	termed = 1;
-	pthread_mutex_unlock(&cfg_lock);
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -482,12 +474,15 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	pthread_mutex_lock(&cfg_lock);
+	procnet_reset();
+	termed = 1;
+	pthread_mutex_unlock(&cfg_lock);
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,
@@ -495,9 +490,3 @@ struct ldmsd_sampler ldmsd_plugin_interface = {
 	},
 	.sample = sample,
 };
-
-static void __attribute__ ((destructor)) procnet_plugin_fini(void);
-static void procnet_plugin_fini()
-{
-	term(NULL);
-}

--- a/ldms/src/sampler/procnetdev/procnetdev.c
+++ b/ldms/src/sampler/procnetdev/procnetdev.c
@@ -342,8 +342,15 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
 
-static void term(ldmsd_plug_handle_t handle)
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	if (mf)
 		fclose(mf);
@@ -355,23 +362,9 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-        set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/procnetdev/procnetdev.c
+++ b/ldms/src/sampler/procnetdev/procnetdev.c
@@ -356,26 +356,27 @@ static void term(ldmsd_plug_handle_t handle)
 }
 
 
-static struct ldmsd_sampler procnetdev_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &procnetdev_plugin.base;
-}

--- a/ldms/src/sampler/procnetdev/procnetdev.c
+++ b/ldms/src/sampler/procnetdev/procnetdev.c
@@ -370,7 +370,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/procnetdev/procnetdev.c
+++ b/ldms/src/sampler/procnetdev/procnetdev.c
@@ -62,6 +62,7 @@
 #include <sys/time.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 #include "sampler_base.h"
 
 #ifndef ARRAY_SIZE

--- a/ldms/src/sampler/procnetdev2/procnetdev2.c
+++ b/ldms/src/sampler/procnetdev2/procnetdev2.c
@@ -476,7 +476,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
-	.base.name = SAMP,
 	.base.type = LDMSD_PLUGIN_SAMPLER,
 	.base.flags = LDMSD_PLUGIN_MULTI_INSTANCE,
 	.base.config = config,

--- a/ldms/src/sampler/procnetdev2/procnetdev2.c
+++ b/ldms/src/sampler/procnetdev2/procnetdev2.c
@@ -119,6 +119,8 @@ struct ldms_metric_template_s rec_metrics[] = {
 
 #define SAMP "procnetdev2"
 typedef struct procnetdev2_s {
+        ovis_log_t mylog;
+
 	int rec_def_idx;
 	int rec_metric_ids[REC_METRICS_LEN];
 	size_t rec_heap_sz;
@@ -135,8 +137,6 @@ typedef struct procnetdev2_s {
 	base_data_t base;
 } *procnetdev2_t;
 
-static ovis_log_t mylog;
-
 static int create_metric_set(procnetdev2_t p, base_data_t base)
 {
 	ldms_schema_t schema;
@@ -145,7 +145,7 @@ static int create_metric_set(procnetdev2_t p, base_data_t base)
 
 	p->mf = fopen(procfile, "r");
 	if (!p->mf) {
-		ovis_log(mylog, OVIS_LERROR, "Could not open " SAMP " file "
+		ovis_log(p->mylog, OVIS_LERROR, "Could not open " SAMP " file "
 				"'%s'...exiting\n",
 				procfile);
 		return ENOENT;
@@ -154,7 +154,7 @@ static int create_metric_set(procnetdev2_t p, base_data_t base)
 	/* Create a metric set of the required size */
 	schema = base_schema_new(p->base);
 	if (!schema) {
-		ovis_log(mylog, OVIS_LERROR,
+		ovis_log(p->mylog, OVIS_LERROR,
 		       "%s: The schema '%s' could not be created, errno=%d.\n",
 		       __FILE__, p->base->schema_name, errno);
 		rc = EINVAL;
@@ -210,7 +210,8 @@ err1:
 /**
  * check for invalid flags, with particular emphasis on warning the user about
  */
-static int config_check(struct attr_value_list *kwl, struct attr_value_list *avl, void *arg)
+static int config_check(struct attr_value_list *kwl, struct attr_value_list *avl, void *arg,
+                        ovis_log_t log)
 {
 	char *value;
 	int i;
@@ -220,7 +221,7 @@ static int config_check(struct attr_value_list *kwl, struct attr_value_list *avl
 	for (i = 0; i < ARRAY_LEN(deprecated); i++){
 		value = av_value(avl, deprecated[i]);
 		if (value){
-			ovis_log(mylog, OVIS_LERROR, "config argument %s has been deprecated.\n",
+			ovis_log(log, OVIS_LERROR, "config argument %s has been deprecated.\n",
 			       deprecated[i]);
 			return EINVAL;
 		}
@@ -251,12 +252,12 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	size_t excount;
 	int rc;
 
-	rc = config_check(kwl, avl, arg);
+	rc = config_check(kwl, avl, arg, p->mylog);
 	if (rc != 0)
 		return rc;
 
 	if (p->base) {
-		ovis_log(mylog, OVIS_LERROR, "Set already created.\n");
+		ovis_log(p->mylog, OVIS_LERROR, "Set already created.\n");
 		return EINVAL;
 	}
 
@@ -266,7 +267,7 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 		goto process_exclude;
 	ifacelist = strdup(ivalue);
 	if (!ifacelist) {
-		ovis_log(mylog, OVIS_LCRIT, "Out of memory\n");
+		ovis_log(p->mylog, OVIS_LCRIT, "Out of memory\n");
 		goto err;
 	}
 
@@ -275,12 +276,12 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	iface = strtok_r(ifacelist, ",", &saveptr);
 	while (iface) {
 		if (ifcount >= (MAXIFACE)) {
-			ovis_log(mylog, OVIS_LERROR,
+			ovis_log(p->mylog, OVIS_LERROR,
 				"Too many ifaces: <%s>\n", iface);
 			goto err;
 		}
 		strncpy(p->iface[ifcount++], iface, 20);
-		ovis_log(mylog, OVIS_LDEBUG,
+		ovis_log(p->mylog, OVIS_LDEBUG,
 			"Added iface <%s>\n", iface);
 		iface = strtok_r(NULL, ",", &saveptr);
 	}
@@ -294,26 +295,26 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 		goto cfg;
 	exclude = strdup(ivalue);
 	if (!exclude) {
-		ovis_log(mylog, OVIS_LCRIT, "out of memory\n");
+		ovis_log(p->mylog, OVIS_LCRIT, "out of memory\n");
 		goto err;
 	}
 	iface = strtok_r(exclude, ",", &saveptr);
 	excount = 0;
 	while (iface) {
 		if (excount >= (MAXIFACE)) {
-			ovis_log(mylog, OVIS_LERROR,
+			ovis_log(p->mylog, OVIS_LERROR,
 				"Too many exclude: <%s>\n", ivalue);
 			goto err;
 		}
 		strncpy(p->exclude[excount++], iface, 20);
-		ovis_log(mylog, OVIS_LDEBUG,
+		ovis_log(p->mylog, OVIS_LDEBUG,
 			"Excluded iface <%s>\n", iface);
 		iface = strtok_r(NULL, ",", &saveptr);
 	}
 	p->excount = excount;
 
  cfg:
-	p->base = base_config(avl, ldmsd_plug_cfg_name_get(handle), SAMP, mylog);
+	p->base = base_config(avl, ldmsd_plug_cfg_name_get(handle), SAMP, p->mylog);
 	if (!p->base){
 		rc = EINVAL;
 		goto err;
@@ -321,7 +322,7 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 
 	rc = create_metric_set(p, p->base);
 	if (rc) {
-		ovis_log(mylog, OVIS_LERROR, "failed to create a metric set.\n");
+		ovis_log(p->mylog, OVIS_LERROR, "failed to create a metric set.\n");
 		goto err;
 	}
 
@@ -347,14 +348,14 @@ static int sample(ldmsd_plug_handle_t handle)
 	ldms_mval_t lh, rec_inst, name_mval;
 
 	if (!p->base) {
-		ovis_log(mylog, OVIS_LDEBUG, "plugin not initialized\n");
+		ovis_log(p->mylog, OVIS_LDEBUG, "plugin not initialized\n");
 		return EINVAL;
 	}
 
 	if (!p->mf)
 		p->mf = fopen(procfile, "r");
 	if (!p->mf) {
-		ovis_log(mylog, OVIS_LERROR, "Could not open /proc/net/dev file "
+		ovis_log(p->mylog, OVIS_LERROR, "Could not open /proc/net/dev file "
 				"'%s'...exiting\n", procfile);
 		return ENOENT;
 	}
@@ -392,7 +393,7 @@ begin:
 				&v[11].v_u64, &v[12].v_u64, &v[13].v_u64,
 				&v[14].v_u64, &v[15].v_u64, &v[16].v_u64);
 		if (rc != 17){
-			ovis_log(mylog, OVIS_LINFO,
+			ovis_log(p->mylog, OVIS_LINFO,
 				"wrong number of fields in sscanf\n");
 			continue;
 		}
@@ -442,22 +443,24 @@ resize:
 	base_set_new_heap(p->base, p->heap_sz);
 	if (!p->base->set) {
 		rc = errno;
-		ovis_log(mylog, OVIS_LCRITICAL, SAMP " : Failed to create a set with "
+		ovis_log(p->mylog, OVIS_LCRITICAL, SAMP " : Failed to create a set with "
 						"a bigger heap. Error %d\n", rc);
 		return rc;
 	}
 	goto begin;
 }
 
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	procnetdev2_t p = calloc(1, sizeof(*p));
-	if (p) {
-		ldmsd_plug_ctxt_set(handle, p);
-		return 0;
+	if (!p) {
+                return ENOMEM;
 	}
-	return ENOMEM;
+
+        p->mylog = ldmsd_plug_log_get(handle);
+        ldmsd_plug_ctxt_set(handle, p);
+
+        return 0;
 }
 
 static void destructor(ldmsd_plug_handle_t handle)
@@ -472,7 +475,7 @@ static void destructor(ldmsd_plug_handle_t handle)
 	free(p);
 }
 
-static struct ldmsd_sampler procnetdev2_sampler = {
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base.name = SAMP,
 	.base.type = LDMSD_PLUGIN_SAMPLER,
 	.base.flags = LDMSD_PLUGIN_MULTI_INSTANCE,
@@ -483,16 +486,3 @@ static struct ldmsd_sampler procnetdev2_sampler = {
 
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-        /* FIXME - move to instance_init, and release in instance_fini
-           Or better yet, introduce plugin_init()/plugin_fini()...or maybe just add a "release_plugin"? */
-	if (!mylog) {
-		mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-		if (!mylog)
-			ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", errno);
-	}
-	return &procnetdev2_sampler.base;
-}

--- a/ldms/src/sampler/procnfs/procnfs.c
+++ b/ldms/src/sampler/procnfs/procnfs.c
@@ -350,7 +350,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/procnfs/procnfs.c
+++ b/ldms/src/sampler/procnfs/procnfs.c
@@ -336,27 +336,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
 
-static struct ldmsd_sampler procnfs_plugin = {
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &procnfs_plugin.base;
-}

--- a/ldms/src/sampler/procnfs/procnfs.c
+++ b/ldms/src/sampler/procnfs/procnfs.c
@@ -324,7 +324,15 @@ out:
 }
 
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+        set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	if (mf)
 		fclose(mf);
@@ -336,22 +344,9 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-        set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/procstat/procstat.c
+++ b/ldms/src/sampler/procstat/procstat.c
@@ -736,7 +736,14 @@ err1:
 #undef GET_STAT_SCALAR
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	g.mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	if (g.core_data) {
 		free(g.core_data);
@@ -756,25 +763,11 @@ static void term(ldmsd_plug_handle_t handle)
 		fclose(g.mf);
 		g.mf = NULL;
 	}
-	if (g.mylog)
-		ovis_log_deregister(g.mylog);
-}
-
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	g.mylog = ldmsd_plug_log_get(handle);
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/procstat/procstat.c
+++ b/ldms/src/sampler/procstat/procstat.c
@@ -773,7 +773,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/procstat/procstat.c
+++ b/ldms/src/sampler/procstat/procstat.c
@@ -760,25 +760,26 @@ static void term(ldmsd_plug_handle_t handle)
 		ovis_log_deregister(g.mylog);
 }
 
-static struct ldmsd_sampler procstat_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	g.mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	g.mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!g.mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	return &procstat_plugin.base;
-}

--- a/ldms/src/sampler/procstat2/procstat2.c
+++ b/ldms/src/sampler/procstat2/procstat2.c
@@ -703,26 +703,27 @@ static void term(ldmsd_plug_handle_t handle)
 	}
 }
 
-static struct ldmsd_sampler procstat2_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.config = config,
 		.usage = usage,
 		.term = term,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &procstat2_plugin.base;
-}

--- a/ldms/src/sampler/procstat2/procstat2.c
+++ b/ldms/src/sampler/procstat2/procstat2.c
@@ -671,7 +671,15 @@ begin:
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	if (mf) {
 		fclose(mf);
@@ -703,24 +711,11 @@ static void term(ldmsd_plug_handle_t handle)
 	}
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-	set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.config = config,
 		.usage = usage,
-		.term = term,
 		.constructor = constructor,
 		.destructor = destructor,
 	},

--- a/ldms/src/sampler/procstat2/procstat2.c
+++ b/ldms/src/sampler/procstat2/procstat2.c
@@ -717,7 +717,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.config = config,
 		.usage = usage,

--- a/ldms/src/sampler/rapl/rapl.c
+++ b/ldms/src/sampler/rapl/rapl.c
@@ -267,7 +267,20 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static const char *usage(ldmsd_plug_handle_t handle)
+{
+	return  "config name= " SAMP " " BASE_CONFIG_USAGE;
+}
+
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	int papi_event_set;
 
@@ -289,27 +302,9 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static const char *usage(ldmsd_plug_handle_t handle)
-{
-	return  "config name= " SAMP " " BASE_CONFIG_USAGE;
-}
-
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-	set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/rapl/rapl.c
+++ b/ldms/src/sampler/rapl/rapl.c
@@ -294,26 +294,27 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	return  "config name= " SAMP " " BASE_CONFIG_USAGE;
 }
 
-static struct ldmsd_sampler rapl_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &rapl_plugin.base;
-}

--- a/ldms/src/sampler/rapl/rapl.c
+++ b/ldms/src/sampler/rapl/rapl.c
@@ -308,7 +308,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/rdc_sampler/rdc_plugin.c
+++ b/ldms/src/sampler/rdc_sampler/rdc_plugin.c
@@ -135,28 +135,35 @@ static const char *usage(ldmsd_plug_handle_t handle) {
 	return usage_str;
 }
 
-static struct ldmsd_sampler plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	singleton = rdcinfo_new(ldmsd_plug_log_get(handle));
+	if (!singleton) {
+		ovis_log(ldmsd_plug_log_get(handle),
+                         OVIS_LERROR, SAMP ": unable to allocate singleton\n");
+		errno = ENOMEM;
+		return -1;
+	}
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	singleton = rdcinfo_new();
-	if (!singleton) {
-		ovis_log(singleton->mylog, OVIS_LERROR, SAMP ": unable to allocate singleton\n");
-		errno = ENOMEM;
-		return NULL;
-	}
-	ovis_log(singleton->mylog, OVIS_LDEBUG, SAMP ": get_plugin called\n");
-	return &plugin.base;
-}
 
 static void __attribute__ ((destructor)) rdc_plugin_fini(void);
 static void rdc_plugin_fini()

--- a/ldms/src/sampler/rdc_sampler/rdc_plugin.c
+++ b/ldms/src/sampler/rdc_sampler/rdc_plugin.c
@@ -84,7 +84,7 @@ static int config(ldmsd_plug_handle_t handle,
 		INST_LOG(inst, OVIS_LDEBUG, SAMP ": reconfiguring.\n");
 	}
 
-	rc = rdcinfo_config(inst, avl);
+	rc = rdcinfo_config(inst, avl, ldmsd_plug_cfg_name_get(handle));
 	if (rc)
 		goto err;
 
@@ -113,7 +113,6 @@ static int sample(ldmsd_plug_handle_t handle)
 }
 
 static const char *usage(ldmsd_plug_handle_t handle) {
-	(void)self;
 	if (!usage_str)
 		usage_str = rdcinfo_usage();
 	return usage_str;
@@ -151,7 +150,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.config = config,
 		.usage = usage,

--- a/ldms/src/sampler/rdc_sampler/rdcinfo.c
+++ b/ldms/src/sampler/rdc_sampler/rdcinfo.c
@@ -315,7 +315,7 @@ static uint32_t rdcinfo_hash(rdcinfo_inst_t inst)
 	return i;
 }
 
-rdcinfo_inst_t rdcinfo_new()
+rdcinfo_inst_t rdcinfo_new(ovis_log_t mylog)
 {
 	rdcinfo_inst_t x = calloc(1, sizeof(*x));
 	if (!x) {
@@ -323,11 +323,7 @@ rdcinfo_inst_t rdcinfo_new()
 		return NULL;
 	}
 	pthread_mutex_init(&x->lock, NULL);
-	x->mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!x->mylog) {
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-				"of '" SAMP "' plugin. Error %d\n", errno);
-	}
+	x->mylog = mylog;
 	return x;
 }
 

--- a/ldms/src/sampler/rdc_sampler/rdcinfo.c
+++ b/ldms/src/sampler/rdc_sampler/rdcinfo.c
@@ -60,6 +60,7 @@
 #include <ctype.h>
 #include <time.h>
 #include "rdcinfo.h"
+#include "ldmsd_plug_api.h"
 #include "dstring.h"
 #include "ldmsd_plugattr.h"
 #include "coll/fnv_hash.h"

--- a/ldms/src/sampler/rdc_sampler/rdcinfo.h
+++ b/ldms/src/sampler/rdc_sampler/rdcinfo.h
@@ -103,7 +103,7 @@ struct rdcinfo_inst_s {
 char * rdcinfo_usage();
 
 // create unconfigured instance
-rdcinfo_inst_t rdcinfo_new();
+rdcinfo_inst_t rdcinfo_new(ovis_log_t mylog);
 
 // clear all configuration except log and lock. caller must hold inst->lock if multithreaded.
 void rdcinfo_reset(rdcinfo_inst_t);

--- a/ldms/src/sampler/rdc_sampler/rdcinfo.h
+++ b/ldms/src/sampler/rdc_sampler/rdcinfo.h
@@ -113,7 +113,7 @@ void rdcinfo_delete(rdcinfo_inst_t inst);
 
 // set configuration. If already configured,
 // call reset first. caller must be holding inst->lock if multithreaded
-int rdcinfo_config(rdcinfo_inst_t inst, struct attr_value_list *avl);
+int rdcinfo_config(rdcinfo_inst_t inst, struct attr_value_list *avl, const char *instance_name);
 
 // caller must be holding inst->lock
 int rdcinfo_sample(rdcinfo_inst_t inst);

--- a/ldms/src/sampler/sampler_atasmart/sampler_atasmart.c
+++ b/ldms/src/sampler/sampler_atasmart/sampler_atasmart.c
@@ -462,26 +462,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler sampler_atasmart_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &sampler_atasmart_plugin.base;
-}

--- a/ldms/src/sampler/sampler_atasmart/sampler_atasmart.c
+++ b/ldms/src/sampler/sampler_atasmart/sampler_atasmart.c
@@ -476,7 +476,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/sampler_atasmart/sampler_atasmart.c
+++ b/ldms/src/sampler/sampler_atasmart/sampler_atasmart.c
@@ -443,9 +443,16 @@ err:
 	return ret;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
 {
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
 
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
 	int i;
 	for (i = 0; i < num_disks; i++) {
 		sk_disk_free(smarts->d[i]);
@@ -462,22 +469,9 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-	set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/shm/shm_sampler.c
+++ b/ldms/src/sampler/shm/shm_sampler.c
@@ -1032,7 +1032,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 		.base = {
-			.name = SAMP,
 			.type = LDMSD_PLUGIN_SAMPLER,
 			.term = term,
 			.config = config,

--- a/ldms/src/sampler/shm/shm_sampler.c
+++ b/ldms/src/sampler/shm/shm_sampler.c
@@ -1019,25 +1019,26 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	"    job_end      The name of the metric containing the Job end time, default is 'job_end'\n";
 }
 
-static struct ldmsd_sampler shm_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 		.base = {
 			.name = SAMP,
 			.type = LDMSD_PLUGIN_SAMPLER,
 			.term = term,
 			.config = config,
 			.usage = usage,
+                        .constructor = constructor,
+                        .destructor = destructor,
 		},
 		.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	return &shm_plugin.base;
-}

--- a/ldms/src/sampler/slingshot_info/Makefile.am
+++ b/ldms/src/sampler/slingshot_info/Makefile.am
@@ -10,7 +10,7 @@ libslingshot_info_la_LIBADD = \
 	$(LTLIBCXI)
 libslingshot_info_la_LDFLAGS = \
 	-no-undefined \
-        -export-symbols-regex 'get_plugin'
+        -export-symbols-regex 'ldmsd_plugin_interface'
 libslingshot_info_la_CPPFLAGS = @OVIS_INCLUDE_ABS@
 
 pkglib_LTLIBRARIES = libslingshot_info.la

--- a/ldms/src/sampler/slingshot_info/slingshot_info.c
+++ b/ldms/src/sampler/slingshot_info/slingshot_info.c
@@ -438,7 +438,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface  = {
         .base = {
-                .name = SAMP,
                 .type = LDMSD_PLUGIN_SAMPLER,
                 .term = term,
                 .config = config,

--- a/ldms/src/sampler/slingshot_info/slingshot_info.c
+++ b/ldms/src/sampler/slingshot_info/slingshot_info.c
@@ -425,28 +425,26 @@ static const char *usage(ldmsd_plug_handle_t handle)
                 ;
 }
 
-struct ldmsd_plugin *get_plugin()
+static int constructor(ldmsd_plug_handle_t handle)
 {
-	int rc;
-        static struct ldmsd_sampler plugin = {
-                .base = {
-                        .name = SAMP,
-                        .type = LDMSD_PLUGIN_SAMPLER,
-                        .term = term,
-                        .config = config,
-                        .usage = usage,
-                },
-                .sample = sample,
-        };
+	mylog = ldmsd_plug_log_get(handle);
 
-        mylog = ovis_log_register("sampler.slingshot", "Messages for the slingshot sampler plugin");
-        if (!mylog) {
-                rc = errno;
-                ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-                                    "of '" SAMP "' plugin. Error %d.\n", rc);
-        }
-
-        ovis_log(mylog, OVIS_LDEBUG, "get_plugin() called ("PACKAGE_STRING")\n");
-
-        return &plugin.base;
+        return 0;
 }
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface  = {
+        .base = {
+                .name = SAMP,
+                .type = LDMSD_PLUGIN_SAMPLER,
+                .term = term,
+                .config = config,
+                .usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
+        },
+        .sample = sample,
+};

--- a/ldms/src/sampler/slingshot_info/slingshot_info.c
+++ b/ldms/src/sampler/slingshot_info/slingshot_info.c
@@ -409,14 +409,6 @@ static int sample(ldmsd_plug_handle_t handle)
         return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-        ovis_log(mylog, OVIS_LDEBUG, "term() called\n");
-        base_set_delete(sampler_base);
-        base_del(sampler_base);
-        sampler_base = NULL;
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
         ovis_log(mylog, OVIS_LDEBUG, "usage() called\n");
@@ -434,12 +426,15 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+        ovis_log(mylog, OVIS_LDEBUG, "term() called\n");
+        base_set_delete(sampler_base);
+        base_del(sampler_base);
+        sampler_base = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface  = {
         .base = {
                 .type = LDMSD_PLUGIN_SAMPLER,
-                .term = term,
                 .config = config,
                 .usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/slingshot_metrics/Makefile.am
+++ b/ldms/src/sampler/slingshot_metrics/Makefile.am
@@ -10,7 +10,7 @@ libslingshot_metrics_la_LIBADD = \
 	$(LTLIBCXI)
 libslingshot_metrics_la_LDFLAGS = \
 	-no-undefined \
-        -export-symbols-regex 'get_plugin'
+        -export-symbols-regex 'ldmsd_plugin_interface'
 libslingshot_metrics_la_CPPFLAGS = @OVIS_INCLUDE_ABS@
 
 pkglib_LTLIBRARIES = libslingshot_metrics.la

--- a/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
+++ b/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
@@ -631,27 +631,26 @@ static const char *usage(ldmsd_plug_handle_t handle)
                 ;
 }
 
-struct ldmsd_plugin *get_plugin()
+static int constructor(ldmsd_plug_handle_t handle)
 {
-	int rc;
-        static struct ldmsd_sampler plugin = {
-                .base = {
-                        .name = SAMP,
-                        .type = LDMSD_PLUGIN_SAMPLER,
-                        .term = term,
-                        .config = config,
-                        .usage = usage,
-                },
-                .sample = sample,
-        };
+	mylog = ldmsd_plug_log_get(handle);
 
-        mylog = ovis_log_register("sampler.slingshot_metrics", "Messages for the slingshot_metrics sampler plugin");
-        if (!mylog) {
-                rc = errno;
-                ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem of '"
-                                                  SAMP "' plugin. Error %d.\n", rc);
-        }
-        ovis_log(mylog, OVIS_LDEBUG, "get_plugin() called ("PACKAGE_STRING")\n");
-
-        return &plugin.base;
+        return 0;
 }
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
+        .base = {
+                .name = SAMP,
+                .type = LDMSD_PLUGIN_SAMPLER,
+                .term = term,
+                .config = config,
+                .usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
+        },
+        .sample = sample,
+};

--- a/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
+++ b/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
@@ -644,7 +644,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
         .base = {
-                .name = SAMP,
                 .type = LDMSD_PLUGIN_SAMPLER,
                 .term = term,
                 .config = config,

--- a/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
+++ b/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
@@ -612,17 +612,6 @@ static int sample(ldmsd_plug_handle_t handle)
         return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-        ovis_log(mylog, OVIS_LDEBUG, "term() called\n");
-        base_set_delete(sampler_base);
-        base_del(sampler_base);
-        sampler_base = NULL;
-        cache_cxil_device_list_free();
-        cache_cxil_dev_close_all();
-        ovis_log(mylog, OVIS_LDEBUG, "term() called\n");
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
         ovis_log(mylog, OVIS_LDEBUG, " usage() called\n");
@@ -640,12 +629,18 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+        ovis_log(mylog, OVIS_LDEBUG, "destructor() called\n");
+        base_set_delete(sampler_base);
+        base_del(sampler_base);
+        sampler_base = NULL;
+        cache_cxil_device_list_free();
+        cache_cxil_dev_close_all();
+        ovis_log(mylog, OVIS_LDEBUG, "destructor() called\n");
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
         .base = {
                 .type = LDMSD_PLUGIN_SAMPLER,
-                .term = term,
                 .config = config,
                 .usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/slurm/slurm_sampler.c
+++ b/ldms/src/sampler/slurm/slurm_sampler.c
@@ -981,28 +981,29 @@ static void term(ldmsd_plug_handle_t handle)
 	job_set = NULL;
 }
 
-static struct ldmsd_sampler slurm_sampler = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	return &slurm_sampler.base;
-}
 
 static int cmp_job_id(void *a, const void *b)
 {

--- a/ldms/src/sampler/slurm/slurm_sampler.c
+++ b/ldms/src/sampler/slurm/slurm_sampler.c
@@ -994,7 +994,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/slurm/slurm_sampler.c
+++ b/ldms/src/sampler/slurm/slurm_sampler.c
@@ -968,7 +968,14 @@ static int slurm_recv_cb(ldms_stream_event_t ev, void *ctxt)
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	if (job_schema)
 		ldms_schema_delete(job_schema);
@@ -981,21 +988,9 @@ static void term(ldmsd_plug_handle_t handle)
 	job_set = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/slurm/slurm_sampler.c
+++ b/ldms/src/sampler/slurm/slurm_sampler.c
@@ -75,6 +75,7 @@
 #include <sched.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 #include "slurm_sampler.h"
 
 #define SAMP "slurm_sampler"

--- a/ldms/src/sampler/slurm/slurm_sampler2.c
+++ b/ldms/src/sampler/slurm/slurm_sampler2.c
@@ -1228,7 +1228,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/slurm/slurm_sampler2.c
+++ b/ldms/src/sampler/slurm/slurm_sampler2.c
@@ -1198,16 +1198,6 @@ err_0:
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (set) {
-		ldmsd_set_deregister(ldms_set_instance_name_get(set), SAMP);
-		ldms_set_unpublish(set);
-		ldms_set_delete(set);
-	}
-	set = NULL;
-}
-
 static int sample(ldmsd_plug_handle_t handle)
 {
 	/* no opt */
@@ -1224,12 +1214,17 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (set) {
+		ldmsd_set_deregister(ldms_set_instance_name_get(set), SAMP);
+		ldms_set_unpublish(set);
+		ldms_set_delete(set);
+	}
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/slurm/slurm_sampler2.c
+++ b/ldms/src/sampler/slurm/slurm_sampler2.c
@@ -1214,29 +1214,30 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static struct ldmsd_sampler slurm2_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &slurm2_plugin.base;
-}
 
 static void __attribute__ ((constructor)) slurm_sampler2_init(void)
 {

--- a/ldms/src/sampler/slurm/slurm_sampler2.c
+++ b/ldms/src/sampler/slurm/slurm_sampler2.c
@@ -58,6 +58,7 @@
 #include "ovis_json/ovis_json.h"
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 #define SAMP "slurm_sampler2"
 

--- a/ldms/src/sampler/switchx.c
+++ b/ldms/src/sampler/switchx.c
@@ -471,7 +471,20 @@ static int sx_sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void sx_term(ldmsd_plug_handle_t handle)
+static const char *usage(ldmsd_plug_handle_t handle)
+{
+	return  "config name=switchx set=<setname>\n"
+		"    setname     The set name.\n";
+}
+
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	int port;
 
@@ -489,27 +502,9 @@ static void sx_term(ldmsd_plug_handle_t handle)
 	}
 }
 
-static const char *usage(ldmsd_plug_handle_t handle)
-{
-	return  "config name=switchx set=<setname>\n"
-		"    setname     The set name.\n";
-}
-
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = sx_term,
 		.config = sx_config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/switchx.c
+++ b/ldms/src/sampler/switchx.c
@@ -508,7 +508,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = "switchx",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = sx_term,
 		.config = sx_config,

--- a/ldms/src/sampler/switchx.c
+++ b/ldms/src/sampler/switchx.c
@@ -495,25 +495,26 @@ static const char *usage(ldmsd_plug_handle_t handle)
 		"    setname     The set name.\n";
 }
 
-static struct ldmsd_sampler switchx_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = "switchx",
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = sx_term,
 		.config = sx_config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sx_sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler.switchx", "The log subsystem of the the 'switchx' sampler plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of 'switchx' sampler plugin. Error %d\n", rc);
-	}
-	return &switchx_plugin.base;
-}

--- a/ldms/src/sampler/switchx.c
+++ b/ldms/src/sampler/switchx.c
@@ -64,6 +64,7 @@
 #include <time.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 #include <infiniband/umad.h>
 #include <infiniband/mad.h>

--- a/ldms/src/sampler/switchx_eth.c
+++ b/ldms/src/sampler/switchx_eth.c
@@ -484,21 +484,6 @@ static int sx_sample(ldmsd_plug_handle_t handle)
 	}
 }
 
-static void sx_term(ldmsd_plug_handle_t handle)
-{
-	int port;
-
-	for (port = 1; port < SX_NUM_PORTS; port++) {
-		if (sx_ldms_sets[port].sx_set)
-			ldms_set_delete(sx_ldms_sets[port].sx_set);
-		sx_ldms_sets[port].sx_set = NULL;
-	}
-	if (sx_schema != NULL) {
-		ldms_schema_delete(sx_schema);
-		sx_schema = NULL;
-	}
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	return  "config name=" PNAME " set=<setname>\n"
@@ -514,12 +499,22 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	int port;
+
+	for (port = 1; port < SX_NUM_PORTS; port++) {
+		if (sx_ldms_sets[port].sx_set)
+			ldms_set_delete(sx_ldms_sets[port].sx_set);
+		sx_ldms_sets[port].sx_set = NULL;
+	}
+	if (sx_schema != NULL) {
+		ldms_schema_delete(sx_schema);
+		sx_schema = NULL;
+	}
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = sx_term,
 		.config = sx_config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/switchx_eth.c
+++ b/ldms/src/sampler/switchx_eth.c
@@ -518,7 +518,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = PNAME,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = sx_term,
 		.config = sx_config,

--- a/ldms/src/sampler/switchx_eth.c
+++ b/ldms/src/sampler/switchx_eth.c
@@ -505,25 +505,26 @@ static const char *usage(ldmsd_plug_handle_t handle)
 		"    setname     The set name.\n";
 }
 
-static struct ldmsd_sampler switchx_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = PNAME,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = sx_term,
 		.config = sx_config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sx_sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."PNAME, "The log subsystem of the the " PNAME " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" PNAME "' plugin. Error %d\n", rc);
-	}
-	return &switchx_plugin.base;
-}

--- a/ldms/src/sampler/switchx_eth.c
+++ b/ldms/src/sampler/switchx_eth.c
@@ -64,6 +64,7 @@
 #include <time.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 #include <complib/sx_log.h>
 #include <sx/sdk/sx_status.h>

--- a/ldms/src/sampler/sysclassib/sysclassib.c
+++ b/ldms/src/sampler/sysclassib/sysclassib.c
@@ -741,26 +741,27 @@ static void term(ldmsd_plug_handle_t handle){
 	set = NULL;
 }
 
-static struct ldmsd_sampler sysclassib_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
-		.usage = usage
+		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &sysclassib_plugin.base;
-}

--- a/ldms/src/sampler/sysclassib/sysclassib.c
+++ b/ldms/src/sampler/sysclassib/sysclassib.c
@@ -755,7 +755,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/sysclassib/sysclassib.c
+++ b/ldms/src/sampler/sysclassib/sysclassib.c
@@ -725,8 +725,16 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle){
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
 
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
 	struct scib_port *port;
 	while ((port = LIST_FIRST(&scib_port_list))) {
 		LIST_REMOVE(port, entry);
@@ -741,22 +749,9 @@ static void term(ldmsd_plug_handle_t handle){
 	set = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-	set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/syspapi/syspapi_sampler.c
+++ b/ldms/src/sampler/syspapi/syspapi_sampler.c
@@ -752,7 +752,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/syspapi/syspapi_sampler.c
+++ b/ldms/src/sampler/syspapi/syspapi_sampler.c
@@ -636,26 +636,6 @@ sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void
-term(ldmsd_plug_handle_t handle)
-{
-	pthread_mutex_lock(&syspapi_mutex);
-	if (base)
-		base_del(base);
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-	purge_mlist(&mlist);
-	FLAG_OFF(syspapi_flags, SYSPAPI_CONFIGURED);
-	FLAG_OFF(syspapi_flags, SYSPAPI_OPENED);
-	pthread_mutex_unlock(&syspapi_mutex);
-	if (syspapi_client) {
-		ldms_stream_close(syspapi_client);
-		syspapi_client = NULL;
-	}
-	PAPI_shutdown();
-}
-
 /* syspapi_mutex is held */
 static void
 __pause()
@@ -748,12 +728,26 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	pthread_mutex_lock(&syspapi_mutex);
+	if (base)
+		base_del(base);
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
+	purge_mlist(&mlist);
+	FLAG_OFF(syspapi_flags, SYSPAPI_CONFIGURED);
+	FLAG_OFF(syspapi_flags, SYSPAPI_OPENED);
+	pthread_mutex_unlock(&syspapi_mutex);
+	if (syspapi_client) {
+		ldms_stream_close(syspapi_client);
+		syspapi_client = NULL;
+	}
+	PAPI_shutdown();
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/syspapi/syspapi_sampler.c
+++ b/ldms/src/sampler/syspapi/syspapi_sampler.c
@@ -725,26 +725,10 @@ __stream_cb(ldms_stream_event_t ev, void *ctxt)
 	return 0;
 }
 
-static struct ldmsd_sampler syspapi_plugin = {
-	.base = {
-		.name = SAMP,
-		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
-		.config = config,
-		.usage = usage,
-	},
-	.sample = sample,
-};
-
-struct ldmsd_plugin *get_plugin()
+static int constructor(ldmsd_plug_handle_t handle)
 {
 	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
+	mylog = ldmsd_plug_log_get(handle);
 	rc = PAPI_library_init(PAPI_VER_CURRENT);
 	if (rc < 0) {
 		ovis_log(mylog, OVIS_LERROR, "Error %d attempting to initialize "
@@ -758,5 +742,23 @@ struct ldmsd_plugin *get_plugin()
 	}
 	register_task_init_hook(__on_task_init);
 	register_task_empty_hook(__on_task_empty);
-	return &syspapi_plugin.base;
+
+        return 0;
 }
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
+	.base = {
+		.name = SAMP,
+		.type = LDMSD_PLUGIN_SAMPLER,
+		.term = term,
+		.config = config,
+		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
+	},
+	.sample = sample,
+};

--- a/ldms/src/sampler/tsampler/cray_power_sampler.c
+++ b/ldms/src/sampler/tsampler/cray_power_sampler.c
@@ -270,7 +270,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface  = {
-	.base.name = "cray_power_sampler",
         .base.type = LDMSD_PLUGIN_SAMPLER,
         .base.term = timer_base_term,
 	.base.usage = cray_power_sampler_usage,

--- a/ldms/src/sampler/tsampler/cray_power_sampler.c
+++ b/ldms/src/sampler/tsampler/cray_power_sampler.c
@@ -269,18 +269,13 @@ static void destructor(ldmsd_plug_handle_t handle)
         free(cps);
 }
 
-static struct ldmsd_sampler plugin_api;
-
-struct ldmsd_plugin *get_plugin()
-{
-        timer_base_init_api(&plugin_api);
-	/* override */
-	snprintf(plugin_api.base.name, sizeof(plugin_api.base.name),
-                 "cray_power_sampler");
-	plugin_api.base.usage = cray_power_sampler_usage;
-        plugin_api.base.constructor = constructor;
-        plugin_api.base.destructor = destructor;
-	plugin_api.base.config = cray_power_sampler_config;
-
-        return &plugin_api.base;
-}
+struct ldmsd_sampler ldmsd_plugin_interface  = {
+	.base.name = "cray_power_sampler",
+        .base.type = LDMSD_PLUGIN_SAMPLER,
+        .base.term = timer_base_term,
+	.base.usage = cray_power_sampler_usage,
+        .base.constructor = constructor,
+        .base.destructor = destructor,
+	.base.config = cray_power_sampler_config,
+        .sample = timer_base_sample,
+};

--- a/ldms/src/sampler/tsampler/cray_power_sampler.c
+++ b/ldms/src/sampler/tsampler/cray_power_sampler.c
@@ -271,7 +271,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface  = {
         .base.type = LDMSD_PLUGIN_SAMPLER,
-        .base.term = timer_base_term,
 	.base.usage = cray_power_sampler_usage,
         .base.constructor = constructor,
         .base.destructor = destructor,

--- a/ldms/src/sampler/tsampler/hfclock.c
+++ b/ldms/src/sampler/tsampler/hfclock.c
@@ -191,7 +191,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
         .base.type = LDMSD_PLUGIN_SAMPLER,
-	.base.term = NULL,
 	.base.config = hfclock_config,
 	.base.usage = hfclock_usage,
         .base.constructor = constructor,

--- a/ldms/src/sampler/tsampler/hfclock.c
+++ b/ldms/src/sampler/tsampler/hfclock.c
@@ -189,19 +189,13 @@ static void destructor(ldmsd_plug_handle_t handle)
         free(hf);
 }
 
-static struct ldmsd_sampler plugin_api;
-
-struct ldmsd_plugin *get_plugin()
-{
-	timer_base_init_api(&plugin_api);
-	/* override */
-	snprintf(plugin_api.base.name, sizeof(plugin_api.base.name),
-			"hfclock");
-	plugin_api.base.usage = hfclock_usage;
-        plugin_api.base.constructor = constructor;
-        plugin_api.base.destructor = destructor;
-	plugin_api.base.term = NULL;
-	plugin_api.base.config = hfclock_config;
-
-	return &plugin_api.base;
-}
+struct ldmsd_sampler ldmsd_plugin_interface = {
+        .base.name = "hfclock",
+        .base.type = LDMSD_PLUGIN_SAMPLER,
+	.base.term = NULL,
+	.base.config = hfclock_config,
+	.base.usage = hfclock_usage,
+        .base.constructor = constructor,
+        .base.destructor = destructor,
+	.sample = timer_base_sample,
+};

--- a/ldms/src/sampler/tsampler/hfclock.c
+++ b/ldms/src/sampler/tsampler/hfclock.c
@@ -190,7 +190,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
-        .base.name = "hfclock",
         .base.type = LDMSD_PLUGIN_SAMPLER,
 	.base.term = NULL,
 	.base.config = hfclock_config,

--- a/ldms/src/sampler/tsampler/timer_base.c
+++ b/ldms/src/sampler/tsampler/timer_base.c
@@ -230,13 +230,6 @@ int timer_base_create_set(struct timer_base *tb, const char *config_name)
 
 void timer_base_cleanup(struct timer_base *tb);
 
-void timer_base_term(ldmsd_plug_handle_t handle)
-{
-	struct timer_base *tb = ldmsd_plug_ctxt_get(handle);
-	/* remove all timers when we terminate */
-	timer_base_cleanup(tb);
-}
-
 int timer_base_sample(ldmsd_plug_handle_t handle)
 {
 	struct timer_base *tb = ldmsd_plug_ctxt_get(handle);
@@ -353,7 +346,6 @@ static void __destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface  = {
         .base.type = LDMSD_PLUGIN_SAMPLER,
-        .base.term = timer_base_term,
 	.base.config = __config,
         .base.usage = timer_base_usage,
         .base.constructor = __constructor,

--- a/ldms/src/sampler/tsampler/timer_base.c
+++ b/ldms/src/sampler/tsampler/timer_base.c
@@ -352,7 +352,6 @@ static void __destructor(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface  = {
-	.base.name = "timer_base",
         .base.type = LDMSD_PLUGIN_SAMPLER,
         .base.term = timer_base_term,
 	.base.config = __config,

--- a/ldms/src/sampler/tsampler/timer_base.c
+++ b/ldms/src/sampler/tsampler/timer_base.c
@@ -320,16 +320,6 @@ struct attr_value_list *avl)
 	return ENOSYS;
 }
 
-void timer_base_init_api(struct ldmsd_sampler *api)
-{
-	snprintf(api->base.name, sizeof(api->base.name), "timer_base");
-	api->base.type = LDMSD_PLUGIN_SAMPLER;
-	api->base.term = timer_base_term;
-	api->base.config = __config;
-	api->base.usage = timer_base_usage;
-	api->sample = timer_base_sample;
-}
-
 void timer_base_init(struct timer_base *tb)
 {
 	/* sub-class can override these values after calling this function */
@@ -338,11 +328,36 @@ void timer_base_init(struct timer_base *tb)
 	pthread_mutex_init(&tb->mutex, NULL);
 }
 
-struct ldmsd_plugin *get_plugin()
+static int __constructor(ldmsd_plug_handle_t handle)
 {
-	struct timer_base *tb = calloc(1, sizeof(*tb));
+        struct timer_base *tb;
+
+        tb = calloc(1, sizeof(*tb));
 	if (!tb)
-		return NULL;
+		return ENOMEM;
+
 	timer_base_init(tb);
-	return (void*)tb;
+        ldmsd_plug_ctxt_set(handle, tb);
+
+        return 0;
 }
+
+static void __destructor(ldmsd_plug_handle_t handle)
+{
+	struct timer_base *tb = ldmsd_plug_ctxt_get(handle);
+
+        timer_base_cleanup(tb);
+
+        free(tb);
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface  = {
+	.base.name = "timer_base",
+        .base.type = LDMSD_PLUGIN_SAMPLER,
+        .base.term = timer_base_term,
+	.base.config = __config,
+        .base.usage = timer_base_usage,
+        .base.constructor = __constructor,
+        .base.destructor = __destructor,
+        .sample = timer_base_sample,
+};

--- a/ldms/src/sampler/tsampler/timer_base.h
+++ b/ldms/src/sampler/tsampler/timer_base.h
@@ -79,8 +79,6 @@ struct timer_base {
 	char pname[1024]; /* producer name for internal use */
 };
 
-void timer_base_init_api(struct ldmsd_sampler *api);
-
 void timer_base_init(struct timer_base *tb);
 
 int timer_base_config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl,

--- a/ldms/src/sampler/tx2mon/tx2mon.c
+++ b/ldms/src/sampler/tx2mon/tx2mon.c
@@ -577,18 +577,6 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	        ;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	int i;
-	if (base)
-		base_del(base);
-	for (i = 0; i < tx2mon->n_cpu; i++) {
-		if (set[i])
-			ldms_set_delete(set[i]);
-		set[i] = NULL;
-	}
-}
-
 static int sample(ldmsd_plug_handle_t handle)
 {
 	if (noop)
@@ -636,12 +624,19 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	int i;
+	if (base)
+		base_del(base);
+	for (i = 0; i < tx2mon->n_cpu; i++) {
+		if (set[i])
+			ldms_set_delete(set[i]);
+		set[i] = NULL;
+	}
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/tx2mon/tx2mon.c
+++ b/ldms/src/sampler/tx2mon/tx2mon.c
@@ -623,31 +623,33 @@ static int sample(ldmsd_plug_handle_t handle)
 	return rc;
 }
 
-static struct ldmsd_sampler tx2mon_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	int i;
+
+	mylog = ldmsd_plug_log_get(handle);
+	for (i = 0; i < MAX_CPUS_PER_SOC; i++)
+		set[i] = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	int i;
-	for (i = 0; i < MAX_CPUS_PER_SOC; i++)
-		set[i] = NULL;
-	return &tx2mon_plugin.base;
-}
 
 /***************************************************************************/
 

--- a/ldms/src/sampler/tx2mon/tx2mon.c
+++ b/ldms/src/sampler/tx2mon/tx2mon.c
@@ -640,7 +640,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/variable/variable.c
+++ b/ldms/src/sampler/variable/variable.c
@@ -356,26 +356,27 @@ static void term(ldmsd_plug_handle_t handle)
 	free(producer_name);
 }
 
-static struct ldmsd_sampler variable_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "The log subsystem of the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &variable_plugin.base;
-}

--- a/ldms/src/sampler/variable/variable.c
+++ b/ldms/src/sampler/variable/variable.c
@@ -342,7 +342,15 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	if (set) {
 		ldmsd_set_deregister(ldms_set_instance_name_get(set), SAMP);
@@ -356,22 +364,9 @@ static void term(ldmsd_plug_handle_t handle)
 	free(producer_name);
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-	set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/variable/variable.c
+++ b/ldms/src/sampler/variable/variable.c
@@ -370,7 +370,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/variable/variable.c
+++ b/ldms/src/sampler/variable/variable.c
@@ -65,6 +65,7 @@
 #include <pthread.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 static ovis_log_t mylog;
 

--- a/ldms/src/sampler/vmstat/vmstat.c
+++ b/ldms/src/sampler/vmstat/vmstat.c
@@ -238,27 +238,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
 
-static struct ldmsd_sampler vmstat_plugin = {
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
-		.usage = usage
+		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-					"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-	set = NULL;
-	return &vmstat_plugin.base;
-}

--- a/ldms/src/sampler/vmstat/vmstat.c
+++ b/ldms/src/sampler/vmstat/vmstat.c
@@ -225,7 +225,15 @@ static int sample(ldmsd_plug_handle_t handle)
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	if (mf)
 		fclose(mf);
@@ -238,22 +246,9 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-	set = NULL;
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/vmstat/vmstat.c
+++ b/ldms/src/sampler/vmstat/vmstat.c
@@ -252,7 +252,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/sampler/zfs_leafvdevs/zfs_leafvdevs.c
+++ b/ldms/src/sampler/zfs_leafvdevs/zfs_leafvdevs.c
@@ -231,14 +231,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	ovis_log(mylog, OVIS_LDEBUG, SAMP " term() called\n");
-	base_set_delete(sampler_base);
-	base_del(sampler_base);
-	sampler_base = NULL;
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	ovis_log(mylog, OVIS_LDEBUG, SAMP " usage() called\n");
@@ -259,7 +251,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 struct ldmsd_sampler ldmsd_plugin_interface = {
         .base = {
                 .type = LDMSD_PLUGIN_SAMPLER,
-                .term = term,
                 .config = config,
                 .usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/zfs_leafvdevs/zfs_leafvdevs.c
+++ b/ldms/src/sampler/zfs_leafvdevs/zfs_leafvdevs.c
@@ -245,29 +245,29 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	return "config name=" SAMP " " BASE_CONFIG_SYNOPSIS BASE_CONFIG_DESC;
 }
 
-struct ldmsd_plugin *get_plugin()
+static int constructor(ldmsd_plug_handle_t handle)
 {
-	int rc;
-	static struct ldmsd_sampler plugin = {
-		.base = {
-			 .name = SAMP,
-			 .type = LDMSD_PLUGIN_SAMPLER,
-			 .term = term,
-			 .config = config,
-			 .usage = usage,
-			 },
-		.sample = sample,
-	};
+	mylog = ldmsd_plug_log_get(handle);
 
-        mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-		"of '" SAMP "' plugin. Error %d\n", rc);
-	}
-
-	return &plugin.base;
+        return 0;
 }
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
+        .base = {
+                .name = SAMP,
+                .type = LDMSD_PLUGIN_SAMPLER,
+                .term = term,
+                .config = config,
+                .usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
+        },
+        .sample = sample,
+};
 
 /*********** let's count the vdev here *************/
 static int get_leaf_vdevs_count(nvlist_t * nvroot, const char *pool_name)

--- a/ldms/src/sampler/zfs_leafvdevs/zfs_leafvdevs.c
+++ b/ldms/src/sampler/zfs_leafvdevs/zfs_leafvdevs.c
@@ -258,7 +258,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
         .base = {
-                .name = SAMP,
                 .type = LDMSD_PLUGIN_SAMPLER,
                 .term = term,
                 .config = config,

--- a/ldms/src/sampler/zfs_topvdevs/zfs_topvdevs.c
+++ b/ldms/src/sampler/zfs_topvdevs/zfs_topvdevs.c
@@ -250,29 +250,29 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	return "config name=" SAMP " " BASE_CONFIG_SYNOPSIS BASE_CONFIG_DESC;
 }
 
-struct ldmsd_plugin *get_plugin()
+static int constructor(ldmsd_plug_handle_t handle)
 {
-	int rc;
-	static struct ldmsd_sampler plugin = {
-		.base = {
-			 .name = SAMP,
-			 .type = LDMSD_PLUGIN_SAMPLER,
-			 .term = term,
-			 .config = config,
-			 .usage = usage,
-			 },
-		.sample = sample,
-	};
+	mylog = ldmsd_plug_log_get(handle);
 
-        mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-        if (!mylog) {
-                rc = errno;
-                ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-                                        "of '" SAMP "' plugin. Error %d\n", rc);
-        }
-
-	return &plugin.base;
+        return 0;
 }
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
+        .base = {
+                .name = SAMP,
+                .type = LDMSD_PLUGIN_SAMPLER,
+                .term = term,
+                .config = config,
+                .usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
+        },
+        .sample = sample,
+};
 
 static int vdevs_count(zpool_handle_t * zhp, void *data)
 {

--- a/ldms/src/sampler/zfs_topvdevs/zfs_topvdevs.c
+++ b/ldms/src/sampler/zfs_topvdevs/zfs_topvdevs.c
@@ -235,15 +235,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	ovis_log(mylog, OVIS_LDEBUG, SAMP " term() called\n");
-	base_set_delete(sampler_base);
-	base_del(sampler_base);
-	sampler_base = NULL;
-
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	ovis_log(mylog, OVIS_LDEBUG, SAMP " usage() called\n");
@@ -259,12 +250,15 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	ovis_log(mylog, OVIS_LDEBUG, SAMP " term() called\n");
+	base_set_delete(sampler_base);
+	base_del(sampler_base);
+	sampler_base = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
         .base = {
                 .type = LDMSD_PLUGIN_SAMPLER,
-                .term = term,
                 .config = config,
                 .usage = usage,
 		.constructor = constructor,

--- a/ldms/src/sampler/zfs_topvdevs/zfs_topvdevs.c
+++ b/ldms/src/sampler/zfs_topvdevs/zfs_topvdevs.c
@@ -263,7 +263,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
         .base = {
-                .name = SAMP,
                 .type = LDMSD_PLUGIN_SAMPLER,
                 .term = term,
                 .config = config,

--- a/ldms/src/sampler/zfs_zpool/zfs_zpool.c
+++ b/ldms/src/sampler/zfs_zpool/zfs_zpool.c
@@ -282,7 +282,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
         .base = {
-                .name = SAMP,
                 .type = LDMSD_PLUGIN_SAMPLER,
                 .term = term,
                 .config = config,

--- a/ldms/src/sampler/zfs_zpool/zfs_zpool.c
+++ b/ldms/src/sampler/zfs_zpool/zfs_zpool.c
@@ -269,28 +269,29 @@ static const char *usage(ldmsd_plug_handle_t handle)
 	return "config name=" SAMP " " BASE_CONFIG_SYNOPSIS BASE_CONFIG_DESC;
 }
 
-struct ldmsd_plugin *get_plugin()
+static int constructor(ldmsd_plug_handle_t handle)
 {
-	int rc;
-	static struct ldmsd_sampler plugin = {
-		.base = {
-			 .name = SAMP,
-			 .type = LDMSD_PLUGIN_SAMPLER,
-			 .term = term,
-			 .config = config,
-			 .usage = usage,
-			 },
-		.sample = sample,
-	};
-	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-				"of '" SAMP "' plugin. Error %d\n", rc);
-	}
+	mylog = ldmsd_plug_log_get(handle);
 
-	return &plugin.base;
+        return 0;
 }
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
+        .base = {
+                .name = SAMP,
+                .type = LDMSD_PLUGIN_SAMPLER,
+                .term = term,
+                .config = config,
+                .usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
+        },
+        .sample = sample,
+};
 
 /*
  * top-level vdev stats are at the pool level moving to its own plugin

--- a/ldms/src/sampler/zfs_zpool/zfs_zpool.c
+++ b/ldms/src/sampler/zfs_zpool/zfs_zpool.c
@@ -255,14 +255,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	ovis_log(mylog, OVIS_LDEBUG, SAMP " term() called\n");
-	base_set_delete(sampler_base);
-	base_del(sampler_base);
-	sampler_base = NULL;
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	ovis_log(mylog, OVIS_LDEBUG, SAMP " usage() called\n");
@@ -278,12 +270,15 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	ovis_log(mylog, OVIS_LDEBUG, SAMP " term() called\n");
+	base_set_delete(sampler_base);
+	base_del(sampler_base);
+	sampler_base = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
         .base = {
                 .type = LDMSD_PLUGIN_SAMPLER,
-                .term = term,
                 .config = config,
                 .usage = usage,
 		.constructor = constructor,

--- a/ldms/src/store/avro_kafka/store_avro_kafka.c
+++ b/ldms/src/store/avro_kafka/store_avro_kafka.c
@@ -1042,7 +1042,6 @@ static void destructor(ldmsd_plug_handle_t handle) {
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base.type   = LDMSD_PLUGIN_STORE,
-	.base.name   = "store_avro_kafka",
 	.base.config = config,
 	.base.usage  = usage,
         .base.constructor = constructor,

--- a/ldms/src/store/darshan/darshan_stream_store.c
+++ b/ldms/src/store/darshan/darshan_stream_store.c
@@ -577,7 +577,7 @@ static int stream_recv_cb(ldmsd_stream_client_t c, void *handle,
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	if (sos)
 		sos_container_close(sos, SOS_COMMIT_ASYNC);
@@ -586,7 +586,7 @@ static void term(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_plugin ldmsd_plugin_interface = {
-	.term = term,
 	.config = config,
 	.usage = usage,
+        .destructor = destructor,
 };

--- a/ldms/src/store/darshan/darshan_stream_store.c
+++ b/ldms/src/store/darshan/darshan_stream_store.c
@@ -586,7 +586,6 @@ static void term(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_plugin ldmsd_plugin_interface = {
-	.name = "darshan_stream_store",
 	.term = term,
 	.config = config,
 	.usage = usage,

--- a/ldms/src/store/darshan/darshan_stream_store.c
+++ b/ldms/src/store/darshan/darshan_stream_store.c
@@ -585,14 +585,9 @@ static void term(ldmsd_plug_handle_t handle)
 		free(root_path);
 }
 
-static struct ldmsd_plugin darshan_stream_store = {
+struct ldmsd_plugin ldmsd_plugin_interface = {
 	.name = "darshan_stream_store",
 	.term = term,
 	.config = config,
 	.usage = usage,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-        return &darshan_stream_store;
-}

--- a/ldms/src/store/darshan/darshan_stream_store.c
+++ b/ldms/src/store/darshan/darshan_stream_store.c
@@ -68,6 +68,7 @@
 #include <ovis_json/ovis_json.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 #include "ldmsd_stream.h"
 
 static sos_schema_t app_schema;

--- a/ldms/src/store/influx/store_influx.c
+++ b/ldms/src/store/influx/store_influx.c
@@ -420,7 +420,6 @@ static void close_store(ldmsd_plug_handle_t handle, ldmsd_store_handle_t _sh)
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-		.name = "influx",
 		.config = config,
 		.usage = usage,
 		.type = LDMSD_PLUGIN_STORE,

--- a/ldms/src/store/influx/store_influx.c
+++ b/ldms/src/store/influx/store_influx.c
@@ -418,7 +418,7 @@ static void close_store(ldmsd_plug_handle_t handle, ldmsd_store_handle_t _sh)
 	free(is);
 }
 
-static struct ldmsd_store store_influx = {
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.name = "influx",
 		.config = config,
@@ -429,11 +429,6 @@ static struct ldmsd_store store_influx = {
 	.store = store,
 	.close = close_store,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	return &store_influx.base;
-}
 
 static void __attribute__ ((constructor)) store_influx_init();
 static void store_influx_init()

--- a/ldms/src/store/influx/store_influx.c
+++ b/ldms/src/store/influx/store_influx.c
@@ -58,6 +58,7 @@
 #include <curl/curl.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 static char host_port[64];	/* hostname:port_no for influxdb */
 struct influx_store {

--- a/ldms/src/store/kafka/store_kafka.c
+++ b/ldms/src/store/kafka/store_kafka.c
@@ -269,16 +269,6 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl,
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	pthread_mutex_lock(&sk_lock);
-	if (common_rconf) {
-		rd_kafka_conf_destroy(common_rconf);
-		common_rconf = NULL;
-	}
-	pthread_mutex_unlock(&sk_lock);
-}
-
 typedef struct store_kafka_handle_s {
 	rd_kafka_t *rk; /* The Kafka handle */
 	rd_kafka_conf_t *rconf; /* The Kafka configuration */
@@ -395,10 +385,15 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	pthread_mutex_lock(&sk_lock);
+	if (common_rconf) {
+		rd_kafka_conf_destroy(common_rconf);
+		common_rconf = NULL;
+	}
+	pthread_mutex_unlock(&sk_lock);
 }
 
 struct ldmsd_store ldmsd_plugin_interface = {
-	.base.term = term,
 	.base.config = config,
 	.base.usage = usage,
 	.base.type = LDMSD_PLUGIN_STORE,

--- a/ldms/src/store/kafka/store_kafka.c
+++ b/ldms/src/store/kafka/store_kafka.c
@@ -398,7 +398,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_store ldmsd_plugin_interface = {
-	.base.name = "kafka",
 	.base.term = term,
 	.base.config = config,
 	.base.usage = usage,

--- a/ldms/src/store/kafka/store_kafka.c
+++ b/ldms/src/store/kafka/store_kafka.c
@@ -386,24 +386,25 @@ commit_rows(ldmsd_plug_handle_t handle, ldmsd_strgp_t strgp, ldms_set_t set, ldm
 	return 0;
 }
 
-static struct ldmsd_store store_kafka = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base.name = "kafka",
 	.base.term = term,
 	.base.config = config,
 	.base.usage = usage,
 	.base.type = LDMSD_PLUGIN_STORE,
+        .base.constructor = constructor,
+        .base.destructor = destructor,
 	.close = close_store,
 	.commit = commit_rows,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store.kafka", "Log subsystem of the 'kafka' plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of 'kafka' plugin. Error %d\n", rc);
-	}
-	return &store_kafka.base;
-}

--- a/ldms/src/store/kafka/store_kafka.c
+++ b/ldms/src/store/kafka/store_kafka.c
@@ -68,6 +68,7 @@
 #include <ovis_json/ovis_json.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 static ovis_log_t mylog;
 

--- a/ldms/src/store/kokkos/kokkos_store.c
+++ b/ldms/src/store/kokkos/kokkos_store.c
@@ -984,14 +984,6 @@ static int slurm_recv_cb(ldms_stream_event_t ev, void *ctxt)
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (sos)
-		sos_container_close(sos, SOS_COMMIT_ASYNC);
-	if (root_path)
-		free(root_path);
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -1001,10 +993,13 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (sos)
+		sos_container_close(sos, SOS_COMMIT_ASYNC);
+	if (root_path)
+		free(root_path);
 }
 
 struct ldmsd_plugin ldmsd_plugin_interface = {
-	.term = term,
 	.config = config,
 	.usage = usage,
         .constructor = constructor,

--- a/ldms/src/store/kokkos/kokkos_store.c
+++ b/ldms/src/store/kokkos/kokkos_store.c
@@ -992,21 +992,22 @@ static void term(ldmsd_plug_handle_t handle)
 		free(root_path);
 }
 
-static struct ldmsd_plugin kokkos_store = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_plugin ldmsd_plugin_interface = {
 	.name = "kokkos_store",
 	.term = term,
 	.config = config,
 	.usage = usage,
+        .constructor = constructor,
+        .destructor = destructor,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store.kokkos_store", "Log subsystem of the 'kokkos_store' plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of 'kokkos_store' plugin. Error %d\n", rc);
-	}
-	return &kokkos_store;
-}

--- a/ldms/src/store/kokkos/kokkos_store.c
+++ b/ldms/src/store/kokkos/kokkos_store.c
@@ -1004,7 +1004,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_plugin ldmsd_plugin_interface = {
-	.name = "kokkos_store",
 	.term = term,
 	.config = config,
 	.usage = usage,

--- a/ldms/src/store/kokkos/kokkos_store.c
+++ b/ldms/src/store/kokkos/kokkos_store.c
@@ -67,6 +67,7 @@
 #include <ovis_json/ovis_json.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 static ovis_log_t mylog;
 

--- a/ldms/src/store/kokkos_appmon/kokkos_appmon.c
+++ b/ldms/src/store/kokkos_appmon/kokkos_appmon.c
@@ -415,22 +415,22 @@ static void term(ldmsd_plug_handle_t handle)
 		free(root_path);
 }
 
-static struct ldmsd_plugin kokkos_store = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_plugin ldmsd_plugin_interface = {
 	.name = "kokkos_appmon_store",
 	.term = term,
 	.config = config,
 	.usage = usage,
+        .constructor = constructor,
+        .destructor = destructor,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store.kokkos_appmon_store",
-				"Log subsystem of the 'kokkos_appmon_store' plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of 'kokkos_appmon_store' plugin. Error %d\n", rc);
-	}
-	return &kokkos_store;
-}

--- a/ldms/src/store/kokkos_appmon/kokkos_appmon.c
+++ b/ldms/src/store/kokkos_appmon/kokkos_appmon.c
@@ -427,7 +427,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_plugin ldmsd_plugin_interface = {
-	.name = "kokkos_appmon_store",
 	.term = term,
 	.config = config,
 	.usage = usage,

--- a/ldms/src/store/kokkos_appmon/kokkos_appmon.c
+++ b/ldms/src/store/kokkos_appmon/kokkos_appmon.c
@@ -407,14 +407,6 @@ static int stream_recv_cb(ldms_stream_event_t ev, void *ctxt)
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (sos)
-		sos_container_close(sos, SOS_COMMIT_ASYNC);
-	if (root_path)
-		free(root_path);
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -424,10 +416,13 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (sos)
+		sos_container_close(sos, SOS_COMMIT_ASYNC);
+	if (root_path)
+		free(root_path);
 }
 
 struct ldmsd_plugin ldmsd_plugin_interface = {
-	.term = term,
 	.config = config,
 	.usage = usage,
         .constructor = constructor,

--- a/ldms/src/store/kokkos_appmon/kokkos_appmon.c
+++ b/ldms/src/store/kokkos_appmon/kokkos_appmon.c
@@ -67,6 +67,7 @@
 #include <ovis_json/ovis_json.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 static ovis_log_t mylog;
 

--- a/ldms/src/store/kokkos_appmon/kokkos_appmon.c
+++ b/ldms/src/store/kokkos_appmon/kokkos_appmon.c
@@ -70,6 +70,7 @@
 #include "ldmsd_plug_api.h"
 
 static ovis_log_t mylog;
+static char *plugin_config_name;
 
 static sos_schema_t app_schema;
 static char path_buff[PATH_MAX];
@@ -78,7 +79,6 @@ static char *verbosity = "WARN";
 static char *stream;
 static char *root_path;
 static pthread_mutex_t cfg_lock = PTHREAD_MUTEX_INITIALIZER;
-static struct ldmsd_plugin kokkos_store;
 
 static const char *time_job_rank_attrs[] = { "timestamp", "job_id", "rank" };
 static const char *job_time_rank_attrs[] = { "job_id", "timestamp", "rank" };
@@ -167,13 +167,13 @@ static int create_schema(sos_t sos, sos_schema_t *app)
 	schema = sos_schema_from_template(&kokkos_appmon_template);
 	if (!schema) {
 		ovis_log(mylog, OVIS_LERROR, "%s: Error %d creating Kokkos App schema.\n",
-		       kokkos_store.name, errno);
+		       plugin_config_name, errno);
 		return errno;
 	}
 	rc = sos_schema_add(sos, schema);
 	if (rc) {
 		ovis_log(mylog, OVIS_LERROR, "%s: Error %d adding Kokkos App schema.\n",
-		       kokkos_store.name, rc);
+		       plugin_config_name, rc);
 		return rc;
 	}
 	*app = schema;
@@ -232,7 +232,7 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	if (!container_mode) {
 		ovis_log(mylog, OVIS_LERROR,
 		       "%s: ignoring container permission mode of %s, using 0660.\n",
-		       kokkos_store.name, value);
+		       plugin_config_name, value);
 	}
 	value = av_value(avl, "stream");
 	if (value)
@@ -245,7 +245,7 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	if (!value) {
 		ovis_log(mylog, OVIS_LERROR,
 		       "%s: the path to the container (path=) must be specified.\n",
-		       kokkos_store.name);
+		       plugin_config_name);
 		rc = ENOENT;
 		goto out;
 	}
@@ -255,7 +255,7 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	if (!root_path) {
 		ovis_log(mylog, OVIS_LERROR,
 		       "%s: Error allocating %d bytes for the container path.\n",
-		       strlen(value) + 1);
+		       plugin_config_name, strlen(value) + 1);
 		rc = ENOMEM;
 		goto out;
 	}
@@ -263,7 +263,7 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	rc = reopen_container(root_path);
 	if (rc) {
 		ovis_log(mylog, OVIS_LERROR, "%s: Error opening %s.\n",
-		       kokkos_store.name, root_path);
+		       plugin_config_name, root_path);
 	}
  out:
 	pthread_mutex_unlock(&cfg_lock);
@@ -278,7 +278,7 @@ static int get_json_value(json_entity_t e, char *name, int expected_type, json_e
 	if (!a) {
 		ovis_log(mylog, OVIS_LERROR,
 		       "%s: The JSON entity is missing the '%s' attribute.\n",
-		       kokkos_store.name,
+		       plugin_config_name,
 		       name);
 		return EINVAL;
 	}
@@ -288,7 +288,7 @@ static int get_json_value(json_entity_t e, char *name, int expected_type, json_e
 		ovis_log(mylog, OVIS_LERROR,
 		       "%s: The '%s' JSON entity is the wrong type. "
 		       "Expected %d, received %d\n",
-		       kokkos_store.name,
+		       plugin_config_name,
 		       name, expected_type, v_type);
 		return EINVAL;
 	}
@@ -341,7 +341,7 @@ static int stream_recv_cb(ldms_stream_event_t ev, void *ctxt)
 		if (json_entity_type(item) != JSON_DICT_VALUE) {
 			ovis_log(mylog, OVIS_LERROR,
 			       "%s: Items in kokkos-perf-data must all be dictionaries.\n",
-			       kokkos_store.name);
+			       plugin_config_name);
 			rc = EINVAL;
 			goto out;
 		}
@@ -386,7 +386,7 @@ static int stream_recv_cb(ldms_stream_event_t ev, void *ctxt)
 			rc = errno;
 			ovis_log(mylog, OVIS_LERROR,
 			       "%s: Error %d creating Kokkos App Mon object.\n",
-			       kokkos_store.name, errno);
+			       plugin_config_name, errno);
 			goto out;
 		}
 		sos_obj_attr_by_id_set(obj, TIMESTAMP_ID, timestamp);
@@ -411,6 +411,7 @@ static int stream_recv_cb(ldms_stream_event_t ev, void *ctxt)
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
+        plugin_config_name = strdup(ldmsd_plug_cfg_name_get(handle));
 
         return 0;
 }
@@ -421,6 +422,7 @@ static void destructor(ldmsd_plug_handle_t handle)
 		sos_container_close(sos, SOS_COMMIT_ASYNC);
 	if (root_path)
 		free(root_path);
+        free(plugin_config_name);
 }
 
 struct ldmsd_plugin ldmsd_plugin_interface = {

--- a/ldms/src/store/papi/store_papi.c
+++ b/ldms/src/store/papi/store_papi.c
@@ -660,7 +660,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-		.name = STORE,
 		.config = config,
 		.usage = usage,
 		.type = LDMSD_PLUGIN_STORE,

--- a/ldms/src/store/papi/store_papi.c
+++ b/ldms/src/store/papi/store_papi.c
@@ -647,30 +647,31 @@ static void close_store(ldmsd_plug_handle_t handle, ldmsd_store_handle_t _sh)
 	free(si);
 }
 
-static struct ldmsd_store store_papi = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.name = STORE,
 		.config = config,
 		.usage = usage,
 		.type = LDMSD_PLUGIN_STORE,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.open = open_store,
 	.store = store,
 	.flush = flush_store,
 	.close = close_store,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store."STORE, "The log subsystem of " STORE " store plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the "
-				"log subsystem of %s. Error %d", STORE, rc);
-	}
-	return &store_papi.base;
-}
 
 static void __attribute__ ((constructor)) store_papi_init();
 static void store_papi_init()

--- a/ldms/src/store/papi/store_papi.c
+++ b/ldms/src/store/papi/store_papi.c
@@ -63,6 +63,7 @@
 #include <sos/sos.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 /**
  * \brief PAPI-store

--- a/ldms/src/store/proc_store/linux_proc_sampler_argv_store.c
+++ b/ldms/src/store/proc_store/linux_proc_sampler_argv_store.c
@@ -445,7 +445,14 @@ static int stream_recv_cb(ldms_stream_event_t ev, void *ctxt)
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	ovis_log(mylog, OVIS_LDEBUG, "term %s\n", ldmsd_plug_cfg_name_get(handle));
 	if (sos)
@@ -456,19 +463,7 @@ static void term(ldmsd_plug_handle_t handle)
 	stream = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_plugin ldmsd_plugin_interface = {
-	.term = term,
 	.config = config,
 	.usage = usage,
         .constructor = constructor,

--- a/ldms/src/store/proc_store/linux_proc_sampler_argv_store.c
+++ b/ldms/src/store/proc_store/linux_proc_sampler_argv_store.c
@@ -468,7 +468,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_plugin ldmsd_plugin_interface = {
-	.name = STREAM "_store",
 	.term = term,
 	.config = config,
 	.usage = usage,

--- a/ldms/src/store/proc_store/linux_proc_sampler_argv_store.c
+++ b/ldms/src/store/proc_store/linux_proc_sampler_argv_store.c
@@ -456,22 +456,22 @@ static void term(ldmsd_plug_handle_t handle)
 	stream = NULL;
 }
 
-static struct ldmsd_plugin stream_store = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_plugin ldmsd_plugin_interface = {
 	.name = STREAM "_store",
 	.term = term,
 	.config = config,
 	.usage = usage,
+        .constructor = constructor,
+        .destructor = destructor,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store.linux_proc_sampler_argv_store",
-				"log subsystem of 'linux_proc_sampler_argv_store' plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Faild to create the log subsystem "
-				"of 'linux_proc_sampler_argv_store' plugin. Error %d\n", rc);
-	}
-	return &stream_store;
-}

--- a/ldms/src/store/proc_store/linux_proc_sampler_argv_store.c
+++ b/ldms/src/store/proc_store/linux_proc_sampler_argv_store.c
@@ -75,10 +75,10 @@
 #define LISTNAME "data"
 
 static ovis_log_t mylog;
+static char *plugin_config_name;
 static sos_schema_t app_schema;
 static char *stream;
 static char *root_path;
-static struct ldmsd_plugin stream_store;
 
 static const char *job_component_k_pid_attrs[] = { "job_id", "component_id", "k", "pid" };
 static const char *k_job_component_pid_attrs[] = { "k", "job_id", "component_id", "pid" };
@@ -158,14 +158,14 @@ static int create_schema(sos_t sos, sos_schema_t *app)
 	schema = sos_schema_from_template(&proc_template);
 	if (!schema) {
 		ovis_log(mylog, OVIS_LERROR, "%s: Error creating data schema %s: %s\n",
-		       stream_store.name, STREAM, STRERROR(errno));
+		       plugin_config_name, STREAM, STRERROR(errno));
 		rc = errno;
 		goto err;
 	}
 	rc = sos_schema_add(sos, schema);
 	if (rc) {
 		ovis_log(mylog, OVIS_LERROR, "%s: Error %s adding stream %s data schema.\n",
-				stream_store.name, STRERROR(rc), stream);
+				plugin_config_name, STRERROR(rc), stream);
 		goto err;
 	}
 	*app = schema;
@@ -258,7 +258,7 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	if (!container_mode) {
 		ovis_log(mylog, OVIS_LERROR,
 		       "%s: ignoring bogus container permission mode of %s, using 0660.\n",
-		       stream_store.name, value);
+		       plugin_config_name, value);
 	}
 
 	value = av_value(avl, "stream");
@@ -272,7 +272,7 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	if (!value) {
 		ovis_log(mylog, OVIS_LERROR,
 		       "%s: the path to the container (path=) must be specified.\n",
-		       stream_store.name);
+		       plugin_config_name);
 		return ENOENT;
 	}
 
@@ -290,7 +290,7 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	rc = reopen_container(root_path);
 	if (rc) {
 		ovis_log(mylog, OVIS_LERROR, "%s: Error opening %s.\n",
-		       stream_store.name, root_path);
+		       plugin_config_name, root_path);
 		return ENOENT;
 	}
 	return 0;
@@ -304,7 +304,7 @@ static int get_json_value(json_entity_t e, char *name, int expected_type, json_e
 	if (!a) {
 		ovis_log(mylog, OVIS_LERROR,
 		       "%s: The JSON entity is missing the '%s' attribute.\n",
-		       stream_store.name,
+		       plugin_config_name,
 		       name);
 		return EINVAL;
 	}
@@ -314,7 +314,7 @@ static int get_json_value(json_entity_t e, char *name, int expected_type, json_e
 		ovis_log(mylog, OVIS_LERROR,
 		       "%s: The '%s' JSON entity is the wrong type. "
 		       "Expected %d, received %d\n",
-		       stream_store.name,
+		       plugin_config_name,
 		       name, expected_type, v_type);
 		return EINVAL;
 	}
@@ -394,7 +394,7 @@ static int stream_recv_cb(ldms_stream_event_t ev, void *ctxt)
 		if (json_entity_type(item) != JSON_DICT_VALUE) {
 			ovis_log(mylog, OVIS_LERROR,
 			       "%s: Items in segment must all be dictionaries.\n",
-			       stream_store.name);
+			       plugin_config_name);
 			rc = EINVAL;
 			goto err;
 		}
@@ -414,12 +414,12 @@ static int stream_recv_cb(ldms_stream_event_t ev, void *ctxt)
 			rc = errno;
 			ovis_log(mylog, OVIS_LERROR,
 			       "%s: Error %d creating Darshan data object.\n",
-			       stream_store.name, errno);
+			       plugin_config_name, errno);
 			goto err;
 		}
 
 		ovis_log(mylog, OVIS_LDEBUG, "%s: Got a record from stream (%s)\n",
-				stream_store.name, stream);
+				plugin_config_name, stream);
 
 
 		sos_obj_attr_by_id_set(obj, JOB_ID, job_id);
@@ -448,6 +448,7 @@ static int stream_recv_cb(ldms_stream_event_t ev, void *ctxt)
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
+        plugin_config_name = strdup(ldmsd_plug_cfg_name_get(handle));
 
         return 0;
 }
@@ -461,6 +462,7 @@ static void destructor(ldmsd_plug_handle_t handle)
 	root_path = NULL;
 	free(stream);
 	stream = NULL;
+        free(plugin_config_name);
 }
 
 struct ldmsd_plugin ldmsd_plugin_interface = {

--- a/ldms/src/store/proc_store/linux_proc_sampler_env_store.c
+++ b/ldms/src/store/proc_store/linux_proc_sampler_env_store.c
@@ -446,7 +446,14 @@ static int stream_recv_cb(ldms_stream_event_t ev, void *ctxt)
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	ovis_log(mylog, OVIS_LDEBUG, "term %s\n", ldmsd_plug_cfg_name_get(handle));
 	if (sos)
@@ -457,19 +464,7 @@ static void term(ldmsd_plug_handle_t handle)
 	stream = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_plugin ldmsd_plugin_interface = {
-	.term = term,
 	.config = config,
 	.usage = usage,
         .constructor = constructor,

--- a/ldms/src/store/proc_store/linux_proc_sampler_env_store.c
+++ b/ldms/src/store/proc_store/linux_proc_sampler_env_store.c
@@ -469,7 +469,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_plugin ldmsd_plugin_interface = {
-	.name = STREAM "_store",
 	.term = term,
 	.config = config,
 	.usage = usage,

--- a/ldms/src/store/proc_store/linux_proc_sampler_env_store.c
+++ b/ldms/src/store/proc_store/linux_proc_sampler_env_store.c
@@ -457,22 +457,22 @@ static void term(ldmsd_plug_handle_t handle)
 	stream = NULL;
 }
 
-static struct ldmsd_plugin stream_store = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_plugin ldmsd_plugin_interface = {
 	.name = STREAM "_store",
 	.term = term,
 	.config = config,
 	.usage = usage,
+        .constructor = constructor,
+        .destructor = destructor,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store.linux_proc_sampler_env_store",
-				"log subsystem of 'linux_proc_sampler_env_store' plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Faild to create the log subsystem "
-				"of 'linux_proc_sampler_env_store' plugin. Error %d\n", rc);
-	}
-	return &stream_store;
-}

--- a/ldms/src/store/proc_store/linux_proc_sampler_files_store.c
+++ b/ldms/src/store/proc_store/linux_proc_sampler_files_store.c
@@ -498,7 +498,14 @@ static int stream_recv_cb(ldms_stream_event_t ev, void *ctxt)
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
 {
 	ovis_log(mylog, OVIS_LDEBUG, "term %s\n", ldmsd_plug_cfg_name_get(handle));
 	if (sos)
@@ -509,19 +516,7 @@ static void term(ldmsd_plug_handle_t handle)
 	stream = NULL;
 }
 
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_plugin ldmsd_plugin_interface = {
-	.term = term,
 	.config = config,
 	.usage = usage,
         .constructor = constructor,

--- a/ldms/src/store/proc_store/linux_proc_sampler_files_store.c
+++ b/ldms/src/store/proc_store/linux_proc_sampler_files_store.c
@@ -509,22 +509,22 @@ static void term(ldmsd_plug_handle_t handle)
 	stream = NULL;
 }
 
-static struct ldmsd_plugin stream_store = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_plugin ldmsd_plugin_interface = {
 	.name = STREAM "_store",
 	.term = term,
 	.config = config,
 	.usage = usage,
+        .constructor = constructor,
+        .destructor = destructor,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store.linux_proc_sampler_files_store",
-				"log subsystem of 'linux_proc_sampler_files_store' plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Faild to create the log subsystem "
-				"of 'linux_proc_sampler_files_store' plugin. Error %d\n", rc);
-	}
-	return &stream_store;
-}

--- a/ldms/src/store/proc_store/linux_proc_sampler_files_store.c
+++ b/ldms/src/store/proc_store/linux_proc_sampler_files_store.c
@@ -521,7 +521,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 }
 
 struct ldmsd_plugin ldmsd_plugin_interface = {
-	.name = STREAM "_store",
 	.term = term,
 	.config = config,
 	.usage = usage,

--- a/ldms/src/store/proc_store/linux_proc_sampler_files_store.c
+++ b/ldms/src/store/proc_store/linux_proc_sampler_files_store.c
@@ -75,10 +75,10 @@
 #define LISTNAME "data"
 
 static ovis_log_t mylog;
+static char *plugin_config_name;
 static sos_schema_t app_schema;
 static char *stream;
 static char *root_path;
-static struct ldmsd_plugin stream_store;
 
 static const char *time_job_component_attrs[] = { "timestamp", "job_id", "component_id", "file", "pid" };
 static const char *job_component_timestamp_attrs[] = { "job_id", "component_id", "timestamp", "pid", "file" };
@@ -180,14 +180,14 @@ static int create_schema(sos_t sos, sos_schema_t *app)
 	schema = sos_schema_from_template(&proc_template);
 	if (!schema) {
 		ovis_log(mylog, OVIS_LERROR, "%s: Error creating data schema %s: %s\n",
-		       stream_store.name, STREAM, STRERROR(errno));
+		       plugin_config_name, STREAM, STRERROR(errno));
 		rc = errno;
 		goto err;
 	}
 	rc = sos_schema_add(sos, schema);
 	if (rc) {
 		ovis_log(mylog, OVIS_LERROR, "%s: Error %s adding stream %s data schema.\n",
-				stream_store.name, STRERROR(rc), stream);
+				plugin_config_name, STRERROR(rc), stream);
 		goto err;
 	}
 	*app = schema;
@@ -280,7 +280,7 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	if (!container_mode) {
 		ovis_log(mylog, OVIS_LERROR,
 		       "%s: ignoring bogus container permission mode of %s, using 0660.\n",
-		       stream_store.name, value);
+		       plugin_config_name, value);
 	}
 
 	value = av_value(avl, "stream");
@@ -294,7 +294,7 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	if (!value) {
 		ovis_log(mylog, OVIS_LERROR,
 		       "%s: the path to the container (path=) must be specified.\n",
-		       stream_store.name);
+		       plugin_config_name);
 		return ENOENT;
 	}
 
@@ -312,7 +312,7 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	rc = reopen_container(root_path);
 	if (rc) {
 		ovis_log(mylog, OVIS_LERROR, "%s: Error opening %s.\n",
-		       stream_store.name, root_path);
+		       plugin_config_name, root_path);
 		return ENOENT;
 	}
 	return 0;
@@ -326,7 +326,7 @@ static int get_json_value(json_entity_t e, char *name, int expected_type, json_e
 	if (!a) {
 		ovis_log(mylog, OVIS_LERROR,
 		       "%s: The JSON entity is missing the '%s' attribute.\n",
-		       stream_store.name,
+		       plugin_config_name,
 		       name);
 		return EINVAL;
 	}
@@ -336,7 +336,7 @@ static int get_json_value(json_entity_t e, char *name, int expected_type, json_e
 		ovis_log(mylog, OVIS_LERROR,
 		       "%s: The '%s' JSON entity is the wrong type. "
 		       "Expected %d, received %d\n",
-		       stream_store.name,
+		       plugin_config_name,
 		       name, expected_type, v_type);
 		return EINVAL;
 	}
@@ -417,7 +417,7 @@ static int stream_recv_cb(ldms_stream_event_t ev, void *ctxt)
 		if (json_entity_type(item) != JSON_DICT_VALUE) {
 			ovis_log(mylog, OVIS_LERROR,
 			       "%s: Items in segment must all be dictionaries.\n",
-			       stream_store.name);
+			       plugin_config_name);
 			rc = EINVAL;
 			goto err;
 		}
@@ -462,12 +462,12 @@ static int stream_recv_cb(ldms_stream_event_t ev, void *ctxt)
 			rc = errno;
 			ovis_log(mylog, OVIS_LERROR,
 			       "%s: Error %d creating Darshan data object.\n",
-			       stream_store.name, errno);
+			       plugin_config_name, errno);
 			goto err;
 		}
 
 		ovis_log(mylog, OVIS_LDEBUG, "%s: Got a record from stream (%s)\n",
-				stream_store.name, stream);
+				plugin_config_name, stream);
 
 
 		sos_obj_attr_by_id_set(obj, JOB_ID, job_id);
@@ -501,6 +501,7 @@ static int stream_recv_cb(ldms_stream_event_t ev, void *ctxt)
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
+        plugin_config_name = strdup(ldmsd_plug_cfg_name_get(handle));
 
         return 0;
 }
@@ -514,6 +515,7 @@ static void destructor(ldmsd_plug_handle_t handle)
 	root_path = NULL;
 	free(stream);
 	stream = NULL;
+        free(plugin_config_name);
 }
 
 struct ldmsd_plugin ldmsd_plugin_interface = {

--- a/ldms/src/store/slurm/store_slurm.c
+++ b/ldms/src/store/slurm/store_slurm.c
@@ -472,10 +472,6 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	return  "    config name=" STORE " path=<path>\n"
@@ -994,7 +990,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.type = LDMSD_PLUGIN_STORE,

--- a/ldms/src/store/slurm/store_slurm.c
+++ b/ldms/src/store/slurm/store_slurm.c
@@ -981,31 +981,32 @@ static void close_store(ldmsd_plug_handle_t handle, ldmsd_store_handle_t _sh)
 	free(si);
 }
 
-static struct ldmsd_store slurm_store = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.name = STORE,
 		.term = term,
 		.config = config,
 		.usage = usage,
 		.type = LDMSD_PLUGIN_STORE,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.open = open_store,
 	.store = store,
 	.flush = flush_store,
 	.close = close_store,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store."STORE, "Log susbsystem of " STORE " plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-				"of '" STORE "' plugin. Error %d\n", rc);
-	}
-	return &slurm_store.base;
-}
 
 static void __attribute__ ((constructor)) store_slurm_init();
 static void store_slurm_init()

--- a/ldms/src/store/slurm/store_slurm.c
+++ b/ldms/src/store/slurm/store_slurm.c
@@ -994,7 +994,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-		.name = STORE,
 		.term = term,
 		.config = config,
 		.usage = usage,

--- a/ldms/src/store/slurm/store_slurm.c
+++ b/ldms/src/store/slurm/store_slurm.c
@@ -63,6 +63,7 @@
 #include <sos/sos.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 #include "slurm_sampler.h"
 
 #define STORE "store_slurm"

--- a/ldms/src/store/store_amqp.c
+++ b/ldms/src/store/store_amqp.c
@@ -903,7 +903,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 static struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-		.name = "amqp",
 		.type = LDMSD_PLUGIN_STORE,
 		.term = term,
 		.config = config,

--- a/ldms/src/store/store_amqp.c
+++ b/ldms/src/store/store_amqp.c
@@ -890,30 +890,31 @@ static amqp_msg_formatter_t formatters[] = {
 	[BIN_FMT] = bin_msg_formatter,
 };
 
-static struct ldmsd_store store_amqp = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+static struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.name = "amqp",
 		.type = LDMSD_PLUGIN_STORE,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.open = open_store,
 	.store = store,
 	.close = close_store,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store.amqp", "Log subsystem of the 'amqp' plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of 'amqp' plugin. Error %d\n", rc);
-	}
-	return &store_amqp.base;
-}
 
 static void __attribute__ ((constructor)) store_amqp_init();
 static void store_amqp_init()

--- a/ldms/src/store/store_amqp.c
+++ b/ldms/src/store/store_amqp.c
@@ -61,6 +61,7 @@
 #include <pthread.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 static ovis_log_t mylog;
 

--- a/ldms/src/store/store_app/store_app.c
+++ b/ldms/src/store/store_app/store_app.c
@@ -595,27 +595,28 @@ store_app_config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl,
 	return 0;
 }
 
-static struct ldmsd_store store_app = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.name = "store_app",
 		.config = store_app_config,
 		.usage = store_app_usage,
 		.type = LDMSD_PLUGIN_STORE,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.open = store_app_open,
 	.store = store_app_store,
 	.flush = store_app_flush,
 	.close = store_app_close,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store.store_app", "Log subsystem of the 'store_app' plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of 'store_app' plugin. Error %d\n", rc);
-	}
-	return &store_app.base;
-}

--- a/ldms/src/store/store_app/store_app.c
+++ b/ldms/src/store/store_app/store_app.c
@@ -608,7 +608,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-		.name = "store_app",
 		.config = store_app_config,
 		.usage = store_app_usage,
 		.type = LDMSD_PLUGIN_STORE,

--- a/ldms/src/store/store_app/store_app.c
+++ b/ldms/src/store/store_app/store_app.c
@@ -55,6 +55,7 @@
 #include <sos/sos.h>
 
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 int perm = 0660;
 

--- a/ldms/src/store/store_csv.c
+++ b/ldms/src/store/store_csv.c
@@ -2333,10 +2333,11 @@ static int constructor(ldmsd_plug_handle_t handle)
 
         sc = calloc(1, sizeof(*sc));
         if (sc == NULL) {
-		ovis_log(NULL, OVIS_LERROR,
+		ovis_log(ldmsd_plug_log_get(handle), OVIS_LERROR,
                          "Failed to allocate context in plugin store_csv: %d", errno);
                 return ENOMEM;
         }
+	mylog = ldmsd_plug_log_get(handle);
         ldmsd_plug_ctxt_set(handle, sc);
 
         return 0;
@@ -2362,7 +2363,7 @@ static void destructor(ldmsd_plug_handle_t handle)
         free(sc);
 }
 
-static struct ldmsd_store store_csv = {
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base.type   = LDMSD_PLUGIN_STORE,
 	.base.flags  = LDMSD_PLUGIN_MULTI_INSTANCE,
 	.base.name   = "store_csv",
@@ -2376,18 +2377,6 @@ static struct ldmsd_store store_csv = {
 	.close       = close_store,
 	.commit      = commit_rows,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-        int rc;
-        mylog = ovis_log_register("store."PNAME, "The log subsystem of '" PNAME "' plugin");
-        if (!mylog) {
-                rc = errno;
-                ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-                                "of '" PNAME "' plugin. Error %d\n", rc);
-        }
-        return &store_csv.base;
-}
 
 static void __attribute__ ((constructor)) store_csv_init();
 static void store_csv_init()

--- a/ldms/src/store/store_csv.c
+++ b/ldms/src/store/store_csv.c
@@ -2366,7 +2366,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base.type   = LDMSD_PLUGIN_STORE,
 	.base.flags  = LDMSD_PLUGIN_MULTI_INSTANCE,
-	.base.name   = "store_csv",
 	.base.config = config,
 	.base.usage  = usage,
         .base.constructor = constructor,

--- a/ldms/src/store/store_flatfile/store_flatfile.c
+++ b/ldms/src/store/store_flatfile/store_flatfile.c
@@ -124,14 +124,6 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	return EINVAL;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	/*
-	 * TODO: Iterate through all unclosed stores and cleanup resources
-	 * and close any open files.
-	 */
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	return
@@ -446,12 +438,15 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	/*
+	 * TODO: Iterate through all unclosed stores and cleanup resources
+	 * and close any open files.
+	 */
 }
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_STORE,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/store/store_flatfile/store_flatfile.c
+++ b/ldms/src/store/store_flatfile/store_flatfile.c
@@ -450,7 +450,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-		.name = STRFF,
 		.type = LDMSD_PLUGIN_STORE,
 		.term = term,
 		.config = config,

--- a/ldms/src/store/store_flatfile/store_flatfile.c
+++ b/ldms/src/store/store_flatfile/store_flatfile.c
@@ -437,31 +437,32 @@ static void close_store(ldmsd_plug_handle_t handle, ldmsd_store_handle_t _sh)
 	pthread_mutex_unlock(&cfg_lock);
 }
 
-static struct ldmsd_store store_flatfile = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.name = STRFF,
 		.type = LDMSD_PLUGIN_STORE,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.open = open_store,
 	.close = close_store,
 	.store = store,
 	.flush = flush_store,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store."STRFF, "Log subsystem of the '" STRFF "' plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of '" STRFF "' plugin. Error %d\n", rc);
-	}
-	return &store_flatfile.base;
-}
 
 static void __attribute__ ((constructor)) store_flatfile_init();
 static void store_flatfile_init()

--- a/ldms/src/store/store_function_csv.c
+++ b/ldms/src/store/store_function_csv.c
@@ -3034,32 +3034,32 @@ static void close_store(ldmsd_plug_handle_t handle, ldmsd_store_handle_t _s_hand
 	free(s_handle); //FIXME: should this happen?
 }
 
-static struct ldmsd_store store_function_csv = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 			.name = "function_csv",
 			.type = LDMSD_PLUGIN_STORE,
 			.term = term,
 			.config = config,
 			.usage = usage,
+                        .constructor = constructor,
+                        .destructor = destructor,
 	},
 	.open = open_store,
 	.store = store,
 	.flush = flush_store,
 	.close = close_store,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store.store_function_csv", "The log subsystem of "
-						"'store_function_csv' plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-				"of 'store_function_csv' plugin. Error %d\n", rc);
-	}
-	return &store_function_csv.base;
-}
 
 static void __attribute__ ((constructor)) store_function_csv_init();
 static void store_function_csv_init()

--- a/ldms/src/store/store_function_csv.c
+++ b/ldms/src/store/store_function_csv.c
@@ -1198,18 +1198,6 @@ static void printStructs(struct function_store_handle *s_handle){
 	ovis_log(mylog, OVIS_LDEBUG, "=========================================\n");
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-
-	//FIXME: update this for the free's.
-	//Keep in mind restart and what vals have to be kept (if any).
-
-	if (root_path)
-		free(root_path);
-	if (derivedconf)
-		free(derivedconf);
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	return  "    config name=store_function_csv [path=<path> altheader=<0|1>]\n"
@@ -3043,12 +3031,18 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	//FIXME: update this for the free's.
+	//Keep in mind restart and what vals have to be kept (if any).
+
+	if (root_path)
+		free(root_path);
+	if (derivedconf)
+		free(derivedconf);
 }
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 			.type = LDMSD_PLUGIN_STORE,
-			.term = term,
 			.config = config,
 			.usage = usage,
                         .constructor = constructor,

--- a/ldms/src/store/store_function_csv.c
+++ b/ldms/src/store/store_function_csv.c
@@ -3047,7 +3047,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-			.name = "function_csv",
 			.type = LDMSD_PLUGIN_STORE,
 			.term = term,
 			.config = config,

--- a/ldms/src/store/store_none.c
+++ b/ldms/src/store/store_none.c
@@ -95,7 +95,6 @@ store(ldmsd_plug_handle_t handle, ldmsd_store_handle_t _sh, ldms_set_t set,
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-		.name = "sos",
 		.term = term,
 		.config = config,
 		.usage = usage,

--- a/ldms/src/store/store_none.c
+++ b/ldms/src/store/store_none.c
@@ -93,7 +93,7 @@ store(ldmsd_plug_handle_t handle, ldmsd_store_handle_t _sh, ldms_set_t set,
 	return 0;
 }
 
-static struct ldmsd_store store_none = {
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.name = "sos",
 		.term = term,
@@ -104,8 +104,3 @@ static struct ldmsd_store store_none = {
 	.open = open_store,
 	.store = store,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	return &store_none.base;
-}

--- a/ldms/src/store/store_none.c
+++ b/ldms/src/store/store_none.c
@@ -73,10 +73,6 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl,
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-}
-
 static ldmsd_store_handle_t
 open_store(ldmsd_plug_handle_t s, const char *container, const char *schema,
 	   struct ldmsd_strgp_metric_list *metric_list)
@@ -95,7 +91,6 @@ store(ldmsd_plug_handle_t handle, ldmsd_store_handle_t _sh, ldms_set_t set,
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.type = LDMSD_PLUGIN_STORE,

--- a/ldms/src/store/store_rabbitkw.c
+++ b/ldms/src/store/store_rabbitkw.c
@@ -1100,35 +1100,35 @@ static void close_store(ldmsd_plug_handle_t handle, ldmsd_store_handle_t _sh)
 	}
 }
 
-static struct ldmsd_store store_rabbitkw = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+	rabbit_store_pi_log_set(mylog);
+
+	ovis_log(mylog, OVIS_LINFO,"Loading support for rabbitmq amqp version%s\n",
+			amqp_version());
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.name = "rabbitkw",
 		.type = LDMSD_PLUGIN_STORE,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.open = open_store,
 	.store = store,
 	.close = close_store,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store.rabbitkw", "Log subsystem of the 'rabbitkw' plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of 'rabbitkw' plugin. Error %d\n", rc);
-	}
-
-	rabbit_store_pi_log_set(mylog);
-
-	ovis_log(mylog, OVIS_LINFO,"Loading support for rabbitmq amqp version%s\n",
-			amqp_version());
-	return &store_rabbitkw.base;
-}
 
 static void __attribute__ ((constructor)) store_rabbitkw_init();
 static void store_rabbitkw_init()

--- a/ldms/src/store/store_rabbitkw.c
+++ b/ldms/src/store/store_rabbitkw.c
@@ -1117,7 +1117,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-		.name = "rabbitkw",
 		.type = LDMSD_PLUGIN_STORE,
 		.term = term,
 		.config = config,

--- a/ldms/src/store/store_rabbitkw.c
+++ b/ldms/src/store/store_rabbitkw.c
@@ -583,13 +583,6 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	}
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	/* What contract is this supposed to meet. Shall close(sh) have
-	been called for all existing sh already before this is reached.?
-	*/
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	return
@@ -1113,12 +1106,14 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	/* What contract is this supposed to meet. Shall close(sh) have
+	been called for all existing sh already before this is reached.?
+	*/
 }
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_STORE,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/store/store_rabbitkw.c
+++ b/ldms/src/store/store_rabbitkw.c
@@ -60,6 +60,7 @@
 #include <coll/idx.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 #if OVIS_LDMS_HAVE_AUTH
 #include "ovis_auth/auth.h"
 #endif /* OVIS_LDMS_HAVE_AUTH */

--- a/ldms/src/store/store_rabbitv3.c
+++ b/ldms/src/store/store_rabbitv3.c
@@ -1299,7 +1299,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-		.name = "rabbitv3",
 		.type = LDMSD_PLUGIN_STORE,
 		.term = term,
 		.config = config,

--- a/ldms/src/store/store_rabbitv3.c
+++ b/ldms/src/store/store_rabbitv3.c
@@ -1283,33 +1283,34 @@ static void close_store(ldmsd_plug_handle_t handle, ldmsd_store_handle_t _sh)
 	}
 }
 
-static struct ldmsd_store store_rabbitv3 = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	ovis_log(mylog, OVIS_LINFO,"Loading support for rabbitmq amqp version%s\n",
+			amqp_version());
+	rabbit_store_pi_log_set(mylog);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.name = "rabbitv3",
 		.type = LDMSD_PLUGIN_STORE,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.open = open_store,
 	.store = store,
 	.close = close_store,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store.rabbitv3", "Log subsystem of the 'rabbitv3' plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of 'rabbitv3' plugin. Error %d\n", rc);
-	}
-	ovis_log(mylog, OVIS_LINFO,"Loading support for rabbitmq amqp version%s\n",
-			amqp_version());
-	rabbit_store_pi_log_set(mylog);
-	return &store_rabbitv3.base;
-}
 
 static void __attribute__ ((constructor)) store_rabbitv3_init();
 static void store_rabbitv3_init()

--- a/ldms/src/store/store_rabbitv3.c
+++ b/ldms/src/store/store_rabbitv3.c
@@ -522,13 +522,6 @@ out:
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	/* What contract is this supposed to meet. Shall close(sh) have
-	been called for all existing sh already before this is reached.?
-	*/
-}
-
 static const char *usage(ldmsd_plug_handle_t handle)
 {
 	return
@@ -1295,12 +1288,14 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	/* What contract is this supposed to meet. Shall close(sh) have
+	been called for all existing sh already before this is reached.?
+	*/
 }
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_STORE,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/store/store_rabbitv3.c
+++ b/ldms/src/store/store_rabbitv3.c
@@ -64,6 +64,7 @@
 #include <coll/label-set.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 #include "ovis_util/dstring.h"
 #if OVIS_LDMS_HAVE_AUTH
 #include "ovis_auth/auth.h"

--- a/ldms/src/store/store_sos.c
+++ b/ldms/src/store/store_sos.c
@@ -1746,7 +1746,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base.type   = LDMSD_PLUGIN_STORE,
 	.base.flags  = LDMSD_PLUGIN_MULTI_INSTANCE,
-	.base.name   = "store_sos",
 	.base.config = config,
 	.base.usage  = usage,
 	.base.constructor = constructor,

--- a/ldms/src/store/store_sos.c
+++ b/ldms/src/store/store_sos.c
@@ -1743,7 +1743,7 @@ static void destructor(ldmsd_plug_handle_t handle)
         free(ss);
 }
 
-static struct ldmsd_store sos_store = {
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base.type   = LDMSD_PLUGIN_STORE,
 	.base.flags  = LDMSD_PLUGIN_MULTI_INSTANCE,
 	.base.name   = "store_sos",
@@ -1758,11 +1758,6 @@ static struct ldmsd_store sos_store = {
 	.close       = close_store,
 	.commit      = commit_rows,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	return &sos_store.base;
-}
 
 static void __attribute__ ((constructor)) store_sos_init();
 static void store_sos_init()

--- a/ldms/src/store/store_sos.c
+++ b/ldms/src/store/store_sos.c
@@ -68,6 +68,7 @@
 #include <coll/rbt.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 static ovis_log_t mylog;
 #define LOG_(level, ...) do { \

--- a/ldms/src/store/stream/stream_csv_store.c
+++ b/ldms/src/store/stream/stream_csv_store.c
@@ -1498,7 +1498,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-		.name = "stream_csv_store",
 		.type = LDMSD_PLUGIN_STORE,
 		.term = term,
 		.config = config,

--- a/ldms/src/store/stream/stream_csv_store.c
+++ b/ldms/src/store/stream/stream_csv_store.c
@@ -1432,9 +1432,31 @@ out:
 	return rc;
 }
 
-static void term(ldmsd_plug_handle_t handle)
+static const char* usage(ldmsd_plug_handle_t handle)
 {
+	return "    config name=stream_csv_store path=<path> container=<container> stream=<stream> \n"
+			"          [flushtime=<N>] [buffer=<0/1>] [rollover=<N> rolltype=<N>]\n"
+			"         - Set the root path for the storage of csvs and some default parameters\n"
+			"         - path          The path to the root of the csv directory\n"
+			"         - container     The directory under the path\n"
+			"         - stream        a comma separated list of streams, each of which will also be its file name\n"
+			"         - flushtime     Time in sec for a regular flush (independent of any other rollover or flush directives)\n"
+			" 	  - buffer        0 to disable buffering, 1 to enable it with autosize (default)\n"
+			"         - rollover      Greater than or equal to zero; enables file rollover and sets interval\n"
+			"         - rolltype      [1-n] Defines the policy used to schedule rollover events.\n"
+	ROLLTYPES
+	"\n";
+}
 
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
 	if (rothread_used) {
 		void *dontcare = NULL;
 		pthread_cancel(rothread);
@@ -1469,37 +1491,9 @@ static void term(ldmsd_plug_handle_t handle)
 	return;
 }
 
-static const char* usage(ldmsd_plug_handle_t handle)
-{
-	return "    config name=stream_csv_store path=<path> container=<container> stream=<stream> \n"
-			"          [flushtime=<N>] [buffer=<0/1>] [rollover=<N> rolltype=<N>]\n"
-			"         - Set the root path for the storage of csvs and some default parameters\n"
-			"         - path          The path to the root of the csv directory\n"
-			"         - container     The directory under the path\n"
-			"         - stream        a comma separated list of streams, each of which will also be its file name\n"
-			"         - flushtime     Time in sec for a regular flush (independent of any other rollover or flush directives)\n"
-			" 	  - buffer        0 to disable buffering, 1 to enable it with autosize (default)\n"
-			"         - rollover      Greater than or equal to zero; enables file rollover and sets interval\n"
-			"         - rolltype      [1-n] Defines the policy used to schedule rollover events.\n"
-	ROLLTYPES
-	"\n";
-}
-
-static int constructor(ldmsd_plug_handle_t handle)
-{
-	mylog = ldmsd_plug_log_get(handle);
-
-        return 0;
-}
-
-static void destructor(ldmsd_plug_handle_t handle)
-{
-}
-
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_STORE,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,

--- a/ldms/src/store/stream/stream_csv_store.c
+++ b/ldms/src/store/stream/stream_csv_store.c
@@ -1485,25 +1485,25 @@ static const char* usage(ldmsd_plug_handle_t handle)
 	"\n";
 }
 
-static struct ldmsd_store stream_csv_store = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.name = "stream_csv_store",
 		.type = LDMSD_PLUGIN_STORE,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 };
-
-struct ldmsd_plugin* get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store.stream_csv_store",
-				"Log subsystem of the 'stream_csv_store' plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the subsystem "
-				"of 'stream_csv_store' plugin. Error %d\n", rc);
-	}
-	return &stream_csv_store.base;
-}

--- a/ldms/src/store/stream/stream_csv_store.c
+++ b/ldms/src/store/stream/stream_csv_store.c
@@ -67,6 +67,7 @@
 #include <coll/rbt.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 /*
  * CURRENT GROUND RULES:

--- a/ldms/src/store/stream_dump/stream_dump.c
+++ b/ldms/src/store/stream_dump/stream_dump.c
@@ -319,7 +319,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
-		.name = "stream_dump",
 		.term = __term,
 		.config = __config,
 		.usage = __usage,

--- a/ldms/src/store/stream_dump/stream_dump.c
+++ b/ldms/src/store/stream_dump/stream_dump.c
@@ -306,13 +306,26 @@ __commit(ldmsd_plug_handle_t handle, ldmsd_strgp_t strgp, ldms_set_t set, ldmsd_
 	return ENOTSUP;
 }
 
-static struct ldmsd_store stream_dump = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_store ldmsd_plugin_interface = {
 	.base = {
 		.name = "stream_dump",
 		.term = __term,
 		.config = __config,
 		.usage = __usage,
 		.type = LDMSD_PLUGIN_STORE,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.open = __open,
 	.store = __store,
@@ -320,15 +333,3 @@ static struct ldmsd_store stream_dump = {
 	.close = __close,
 	.commit = __commit,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	int rc;
-	mylog = ovis_log_register("store.stream_dump", "Log susbsystem of 'stream_dump' plugin");
-	if (!mylog) {
-		rc = errno;
-		ovis_log(NULL, OVIS_LWARN, "Failed to create the log subsystem "
-				"of 'stream_dump' plugin. Error %d\n", rc);
-	}
-	return &stream_dump.base;
-}

--- a/ldms/src/store/stream_dump/stream_dump.c
+++ b/ldms/src/store/stream_dump/stream_dump.c
@@ -68,6 +68,7 @@
 #include <ovis_log/ovis_log.h>
 #include "ldms.h"
 #include "ldmsd.h"
+#include "ldmsd_plug_api.h"
 
 #define LOG_(level, ...) do { \
 	ovis_log(mylog, level, __VA_ARGS__); \

--- a/ldms/src/third-plugins/my_plugin/src/my_plugin.c
+++ b/ldms/src/third-plugins/my_plugin/src/my_plugin.c
@@ -185,7 +185,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
-		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,

--- a/ldms/src/third-plugins/my_plugin/src/my_plugin.c
+++ b/ldms/src/third-plugins/my_plugin/src/my_plugin.c
@@ -171,24 +171,27 @@ static void term(ldmsd_plug_handle_t handle)
 	set = NULL;
 }
 
-static struct ldmsd_sampler clock_plugin = {
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	mylog = ldmsd_plug_log_get(handle);
+	set = NULL;
+
+        return 0;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.name = SAMP,
 		.type = LDMSD_PLUGIN_SAMPLER,
 		.term = term,
 		.config = config,
 		.usage = usage,
+		.constructor = constructor,
+		.destructor = destructor,
 	},
 	.sample = sample,
 };
-
-struct ldmsd_plugin *get_plugin()
-{
-	mylog = ovis_log_register("sampler."SAMP, "Messages for the "SAMP" plugin");
-	if (!mylog) {
-		ovis_log(NULL, OVIS_LWARN, "Failed to create " SAMP "' s "
-					"log subsystem. Error %d.\n", errno);
-	}
-	set = NULL;
-	return &clock_plugin.base;
-}

--- a/ldms/src/third-plugins/my_plugin/src/my_plugin.c
+++ b/ldms/src/third-plugins/my_plugin/src/my_plugin.c
@@ -161,16 +161,6 @@ static int sample(ldmsd_plug_handle_t handle)
 	return 0;
 }
 
-static void term(ldmsd_plug_handle_t handle)
-{
-	if (base)
-		base_del(base);
-	base = NULL;
-	if (set)
-		ldms_set_delete(set);
-	set = NULL;
-}
-
 static int constructor(ldmsd_plug_handle_t handle)
 {
 	mylog = ldmsd_plug_log_get(handle);
@@ -181,12 +171,17 @@ static int constructor(ldmsd_plug_handle_t handle)
 
 static void destructor(ldmsd_plug_handle_t handle)
 {
+	if (base)
+		base_del(base);
+	base = NULL;
+	if (set)
+		ldms_set_delete(set);
+	set = NULL;
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {
 	.base = {
 		.type = LDMSD_PLUGIN_SAMPLER,
-		.term = term,
 		.config = config,
 		.usage = usage,
 		.constructor = constructor,


### PR DESCRIPTION
This PR stack begins with a refactoring patch "[Compine generic plugin tacking, introduce unload_plugin()](https://github.com/ovis-hpc/ldms/commit/ef16aa95f54aa59af2fa9ac23d15fea484fea106)". It combines libpath and the generic base api pointer together into one struct to simplify what we need to remember in the cfgobj structs, and what we have to pass around. It also helps reduce duplication between the sampler and store code paths. It also give us a convenient, cleaner, generic struct (struct ldmsd_plugin_generic) to add more variables in the subsequent patches. Finally, it give us a cleanup function "unload_plugin() to match up with "unload_plugin()".

Next [dlclose() each handle we receive from dlopen()](https://github.com/ovis-hpc/ldms/commit/f3fdacd261a9ced76451f122b56467094a35ab55) employs the new struct lmsd_plugin_generic to remember the handle returned by dlopen(), and then calls dlclose() in unload_plugin().

Then [Replace get_plugin() with ldmsd_plugin_interface symbol](https://github.com/ovis-hpc/ldms/commit/eec9e3ecf8b09afff39e4744703382f8e7b6d355) makes a bolder API change by eliminating the "get_plugin()" call from the API entirely. More detail on the rationale in the commit message.

Finally, [Remove "name" from the plugin API structs](https://github.com/ovis-hpc/ldms/commit/0abd8d2c063d97c4242b522115602e63a5aa33b7) changes the API by removing the "name" field from the plugin api struct. "name" was, in practice, redundant. It gave opened up an opportunity for human error to have inconsistent plugin names (between the plugin naming of the .so file, and what the plugin internally reports), which would have confusing consequences for users. Removing the redundant "name" field removes that possibility for error, and makes one less thing that plugin authors need to think about.

Update (May 7, 2025):

A commit has been added to remove term() from the plugin API.

Update (May16, 2025):

Added minor cleanup commit named "Improve constructor call points".