### PR TITLE
Add some reserved space in struct ldmsd_plugin

### DIFF
--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -981,6 +981,8 @@ typedef struct ldmsd_plugin {
 
 	/* Deprecated, use destructor() */
 	void (*term)(ldmsd_plug_handle_t handle);
+
+	void *reserved[8]; /* reserved for future use */
 } *ldmsd_plugin_t;
 
 /* This struct is owned by the plugin. ldmsd should never modify the contents. */


### PR DESCRIPTION
Adding some reserved space to struct ldmsd_plugin will allow us to add furture calls without breaking backwards compatibility.

