### PR TITLE
Fix zap fabric build

### DIFF
--- a/lib/src/zap/fabric/Makefile.am
+++ b/lib/src/zap/fabric/Makefile.am
@@ -3,6 +3,6 @@ pkglib_LTLIBRARIES = libzap_fabric.la
 AM_CFLAGS = -I$(srcdir)/../.. -I$(srcdir)/.. -I$(top_srcdir) -I../..
 
 libzap_fabric_la_SOURCES = zap_fabric.c zap_fabric.h
-libzap_fabric_la_CFLAGS = @LIBFABRIC_INCDIR_FLAG@ $(AM_CFLAGS)
-libzap_fabric_la_LIBADD = -lfabric ../libzap.la \
+libzap_fabric_la_CFLAGS = @LIBFABRIC_CFLAGS@ $(AM_CFLAGS)
+libzap_fabric_la_LIBADD = -lfabric @LIBFABRIC_LDFLAGS@ ../libzap.la \
 			  ../../ovis_log/libovis_log.la

--- a/m4/options.m4
+++ b/m4/options.m4
@@ -217,7 +217,9 @@ AS_CASE( x$withval,
 	[
 		check=y
 		err_exi=y
-		$2_CFLAGS="$withval/include"
+		$2_INCDIR="$withval/include"
+		$2_INCDIR_FLAG="-I$withval/include"
+		$2_CFLAGS="-I$withval/include"
 		havelibdir=""
 		havelib64dir=""
 		AS_IF([ test -d "$withval/lib64" ], [


### PR DESCRIPTION
This pull request addressed the issue of zap fabric failed to build when libfabric was installed in a location that is not in the library lookup path. The build failed due to the following reasons:

- `@LIBFABRIC_LDFLAGS@` was not added to zap fabric LIBADD.
- `@LIBFABRIC_INCDIR_FLAGG@` was not set in the `OPTION_WITH_CHECK` macro.
- `@LIBFABRIC_CFLAGS@` was also incorrect (missing `-I` in front of the include path).

NOTE: If `libfabric` was installed in the default lookup locations (e.g. /usr or /usr/local), we will not see the issues. 