### PR TITLE
Return error message on plugin load for use case

### DIFF
--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -366,6 +366,11 @@ int ldmsd_load_plugin(char* cfg_name, char *plugin_name,
 					 "Plugin %s does not support multiple "
 					 "configurations, but the name specified "
 					 "was %s.\n", plugin_name, cfg_name);
+				Snprintf(&errstr, &errlen,
+					"Plugin %s does not support multiple "
+					"configurations, but the name specified "
+					"was %s. \n", plugin_name, cfg_name);
+				errno = EINVAL;
 				goto err;
 			}
 		}


### PR DESCRIPTION
Return an error message, as well as write to log, when a plugin that doesn't support multi-instance is loaded with an instance name other than the plugin name