### PR TITLE
Fix `--with-munge` configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -543,8 +543,7 @@ OPTION_WITH([cray-hss-devel], [CRAY_HSS_DEVEL],[/usr])
 OPTION_ARIES_MMR
 
 dnl munge
-OPTION_DEFAULT_DISABLE([munge], [ENABLE_MUNGE])
-OPTION_WITH([munge], [MUNGE])
+OPTION_WITH_CHECK([munge], [MUNGE], [munge.h], [munge], [munge_encode])
 
 LDMSD_PLUGIN_LIBPATH=${pkglibdir}
 AC_SUBST(LDMSD_PLUGIN_LIBPATH)
@@ -638,15 +637,6 @@ AM_COND_IF([ENABLE_DAOS_SAMPLER],[
 ])
 AC_MSG_CHECKING([for DAOS telemetry support])
 AC_MSG_RESULT([$have_daos])
-
-dnl Munge library check
-if test -z "$ENABLE_MUNGE_TRUE"; then
-	AC_CHECK_LIB(munge, munge_encode, [], AC_MSG_ERROR([libmunge not found]))
-	dnl Reset LIBS variable.
-	LIBS=""
-
-	AC_CHECK_HEADER(munge.h, [], AC_MSG_ERROR([munge.h not found]))
-fi
 
 AC_ARG_WITH([slurm],
 	[AS_HELP_STRING([--with-slurm],

--- a/ldms/src/auth/Makefile.am
+++ b/ldms/src/auth/Makefile.am
@@ -32,7 +32,7 @@ libldms_auth_ovis_la_LIBADD = ../core/libldms.la \
 			      $(top_builddir)/lib/src/ovis_log/libovis_log.la
 lib_LTLIBRARIES += libldms_auth_ovis.la
 
-if ENABLE_MUNGE
+if HAVE_MUNGE
 libldms_auth_munge_la_SOURCES = ldms_auth_munge.c
 libldms_auth_munge_la_CFLAGS = @MUNGE_INCDIR_FLAG@
 libldms_auth_munge_la_LIBADD = ../core/libldms.la \

--- a/m4/options.m4
+++ b/m4/options.m4
@@ -211,7 +211,7 @@ AS_CASE( x$withval,
 	],
 	[xyes], [
 		check=y
-		err_exi=y
+		err_exit=y
 	],
 	dnl default-case: $withval is PREFIX_PATH
 	[


### PR DESCRIPTION
- Remove `--enable-munge` and `--disable-munge` (the default was --disable-munge)

- Without specifying anything, the configure script will default to "check", and build the dependant (currently only `ldms_auth_munge`) if `libmunge` is present. If `libmunge` is not present, the dependent will not be built.

- `--with-munge=no` will skip munge check and disable the build of the dependent.

- `--with-munge=yes` will check libmunge and exited with an error if libmunge is not found.

- `--with-munge=<MUNGE_PREFIX>` will build the dependent with libmunge in the munge installation prefix (e.g. /opt/munge).