### PR TITLE
Add a sampler of CXI telemetry and retry data

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -322,6 +322,7 @@ OPTION_DEFAULT_ENABLE([synthetic], [ENABLE_SYNTHETIC])
 OPTION_DEFAULT_ENABLE([varset], [ENABLE_VARSET])
 OPTION_DEFAULT_ENABLE([lnet_stats], [ENABLE_LNET_STATS])
 OPTION_DEFAULT_ENABLE([meminfo], [ENABLE_MEMINFO])
+OPTION_DEFAULT_ENABLE([cxi_sampler], [ENABLE_CXI_SAMPLER])
 OPTION_DEFAULT_DISABLE([gpumetrics], [ENABLE_GPU_METRICS])
 OPTION_DEFAULT_ENABLE([coretemp], [ENABLE_CORETEMP])
 OPTION_DEFAULT_ENABLE([filesingle], [ENABLE_FILESINGLE])
@@ -1059,6 +1060,7 @@ ldms/src/sampler/kgnilnd/Makefile
 ldms/src/sampler/tx2mon/Makefile
 ldms/src/sampler/msr_interlagos/Makefile
 ldms/src/sampler/meminfo/Makefile
+ldms/src/sampler/cxi_sampler/Makefile
 ldms/src/contrib/sampler/gpu_metrics_sampler/Makefile
 ldms/src/sampler/procinterrupts/Makefile
 ldms/src/sampler/procnetdev2/Makefile

--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -39,6 +39,7 @@ SUBDIRS += lustre_mdt
 SUBDIRS += lustre_ost
 SUBDIRS += lustre_mdc
 SUBDIRS += json
+SUBDIRS += cxi_sampler
 dist_man7_MANS += ldms_sampler_base.man
 if HAVE_DCGM
 SUBDIRS += dcgm_sampler

--- a/ldms/src/sampler/cxi_sampler/Makefile.am
+++ b/ldms/src/sampler/cxi_sampler/Makefile.am
@@ -1,0 +1,16 @@
+include $(top_srcdir)/ldms/rules.mk
+
+pkglib_LTLIBRARIES =
+lib_LTLIBRARIES =
+dist_man7_MANS =
+dist_man1_MANS =
+
+AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
+AM_LDFLAGS = @OVIS_LIB_ABS@
+COMMON_LIBADD = -lsampler_base -lldms -lovis_util -lcoll \
+		@LDFLAGS_GETTIME@
+
+libcxi_sampler_la_SOURCES = cxi_sampler.c
+libcxi_sampler_la_LIBADD = $(COMMON_LIBADD)
+pkglib_LTLIBRARIES += libcxi_sampler.la
+dist_man7_MANS += ldms-sampler_cxi_sampler.man

--- a/ldms/src/sampler/cxi_sampler/cxi_sampler.c
+++ b/ldms/src/sampler/cxi_sampler/cxi_sampler.c
@@ -1,0 +1,599 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2025 Lawrence Berkley National Lab, All rights reserved.
+ * Copyright (c) 2025 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \file meminfo.c
+ * \brief /proc/meminfo data provider
+ */
+#define _GNU_SOURCE
+#include <inttypes.h>
+#include <unistd.h>
+#include <sys/errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <sys/types.h>
+#include <time.h>
+#include <pthread.h>
+#include <dirent.h>
+#include <fnmatch.h>
+#include "ldms.h"
+#include "ldmsd.h"
+#include "ldmsd_plug_api.h"
+#include "sampler_base.h"
+
+#define MAX_CXI_IFACES 256
+#define MAX_FILES 2000
+#define MAX_FILENAME_LENGTH 256
+#define TEL_PATH_CXI "ldms_cxi/cxi"  // Real Path: /sys/kernel/debug/cxi
+#define RH_PATH_CXI "ldms_cxi/rh_cxi/cxi"  // Real Path:  /var/run/cxi
+
+typedef struct files_s {
+	int count;
+	int midx[MAX_FILES];
+	char *names[MAX_FILES];
+} *files_t;
+
+typedef struct ifaces_s {
+	int count;
+	char *names[MAX_CXI_IFACES];
+} *cxi_iface_t;
+
+typedef struct cxi_s {
+	struct files_s *rh_files;
+	struct files_s *tel_files;
+	int iface_count;
+	char **iface_names;
+	char *tel_path;
+	char *rh_path;
+
+	ovis_log_t log;
+	ldms_schema_t schema;
+	ldms_record_t tel_rec;
+	ldms_record_t rh_rec;
+	int iface_mid;
+	int tel_rec_mid;
+	int rh_rec_mid;
+	base_data_t base;
+	int metric_offset;
+	ldms_set_t set;
+	int rh_list_mid;
+	int tel_list_mid;
+	ldms_mval_t rh_list_mval;
+	ldms_mval_t tel_list_mval;
+} *cxi_t;
+
+static int skip_name(char *name)
+{
+	/* Skip special files and directories */
+	if (strcmp(name, ".") == 0
+	    || strcmp(name, "..") == 0
+	    || strcmp(name, "ALL-in-binary") == 0
+	    || strcmp(name, "config") == 0
+	    || strcmp(name, "reset_counters") == 0) {
+		return 1;
+	}
+	return 0;
+}
+
+static int get_cxi_metric_names(ldmsd_plug_handle_t handle,
+				files_t tel_files,
+				const char *cxi_name, char *root_path)
+{
+	ovis_log_t log = ldmsd_plug_log_get(handle);
+	const char *end_path_tel = "device/telemetry";
+	/* root_path "/" cxi_name "/" null terminator */
+	char *s_path = malloc(strlen(root_path) + 1 + strlen(cxi_name) + 1
+			      + strlen(end_path_tel) + 2);
+	if (!s_path) {
+		ovis_log(log, OVIS_LERROR,
+			 "Memory allocation failed for path '%s'\n",
+			 root_path);
+		return 1;
+	}
+
+	sprintf(s_path, "/%s/%s/%s", root_path, cxi_name, end_path_tel);
+	DIR *dir = opendir(s_path);
+	if (!dir) {
+		ovis_log(log, OVIS_LERROR,
+			 "Error %d opening '%s'\n",
+			 errno, s_path);
+		free(s_path);
+		return 1;
+	}
+
+	struct dirent *ent;
+	while ((ent = readdir(dir)) != NULL
+	       && tel_files->count < MAX_FILES) {
+		/* Skip special files and directories */
+		if (skip_name(ent->d_name))
+			continue;
+
+		/* Allocate and copy the file name */
+		tel_files->names[tel_files->count] = strdup(ent->d_name);
+		if (!tel_files->names[tel_files->count]) {
+			ovis_log(log, OVIS_LERROR,
+				 "Memory allocation failed for file name '%s'\n",
+				 ent->d_name);
+			closedir(dir);
+			free(s_path);
+			return 1;
+		}
+		tel_files->count++;
+	}
+	closedir(dir);
+	free(s_path);
+	return 0;
+}
+
+static double parse_value_before_at(cxi_t cxi, const char *filename)
+{
+	char buffer[1024];
+	FILE *file = fopen(filename, "r");
+	if (!file) {
+		ovis_log(cxi->log, OVIS_LERROR,
+			 "Error opening file '%s'\n", filename);
+		return 0;
+	}
+
+	if (!fgets(buffer, sizeof(buffer), file)) {
+		ovis_log(cxi->log, OVIS_LERROR,
+			 "Error reading from file '%s'\n", filename);
+		fclose(file);
+		return 0;
+	}
+	fclose(file);
+
+	return atof(buffer);
+}
+
+static int get_cxi_metric_values(cxi_t cxi)
+{
+	int iface, file;
+	static char path[PATH_MAX];
+	enum ldms_value_type typ;
+	size_t len;
+	ldms_mval_t tel_rec = ldms_list_first(cxi->set, cxi->tel_list_mval, &typ, &len);
+	for (iface = 0; iface < cxi->iface_count; iface++) {
+		ldms_record_array_set_str(tel_rec,
+					  cxi->iface_mid,
+					  cxi->iface_names[iface]);
+		for (file = 0; file < cxi->tel_files[iface].count; file++) {
+			sprintf(path, "%s/%s/device/telemetry/%s",
+				cxi->tel_path, cxi->iface_names[iface],
+				cxi->tel_files[iface].names[file]);
+			double value = parse_value_before_at(cxi, path);
+			ldms_record_set_double(tel_rec,
+					       cxi->tel_files[iface].midx[file],
+					       value);
+		}
+		tel_rec = ldms_list_next(cxi->set, tel_rec, &typ, &len);
+	}
+	return 0;
+}
+
+static int read_integer_from_file(cxi_t cxi, const char *filename)
+{
+	FILE *file = fopen(filename, "r");
+	if (!file) {
+		ovis_log(cxi->log, OVIS_LERROR,
+			 "Error %d opening file '%s\n", errno, filename);
+		return 0;
+	}
+
+	int value;
+	if (fscanf(file, "%d", &value) != 1) {
+		ovis_log(cxi->log, OVIS_LERROR,
+			 "Error %d reading integer from file '%s'\n",
+			 errno, filename);
+		fclose(file);
+		return 0;
+	}
+
+	fclose(file);
+	return value;
+}
+
+static int get_rh_metric_values(cxi_t cxi)
+{
+	int iface, file;
+	static char path[PATH_MAX];
+	enum ldms_value_type typ;
+	size_t len;
+	ldms_mval_t rh_rec = ldms_list_first(cxi->set, cxi->rh_list_mval, &typ, &len);
+	for (iface = 0; iface < cxi->iface_count; iface++) {
+		ldms_record_array_set_str(rh_rec,
+					  cxi->iface_mid,
+					  cxi->iface_names[iface]);
+		for (file = 0; file < cxi->rh_files[iface].count; file++) {
+			sprintf(path, "%s/%s/%s", cxi->rh_path, cxi->iface_names[iface],
+				cxi->rh_files[iface].names[file]);
+			int64_t value = read_integer_from_file(cxi, path);
+			ldms_record_set_s64(rh_rec,
+					    cxi->rh_files[iface].midx[file],
+					    value);
+		}
+		rh_rec = ldms_list_next(cxi->set, rh_rec, &typ, &len);
+	}
+	return 0;
+}
+
+static int get_rh_names(ldmsd_plug_handle_t handle, files_t rh_files,
+			const char *cxi_name, char *root_path)
+{
+	ovis_log_t log = ldmsd_plug_log_get(handle);
+
+	/* +1 for "/" +2 for "/" and null terminator */
+	char *s_path = malloc(strlen(root_path) + 1 + strlen(cxi_name) + 2);
+	if (!s_path) {
+		ovis_log(log,
+			 OVIS_LERROR,
+			 "Memory allocation failed for path in '%s'\n",
+			 root_path);
+		return 1;
+	}
+
+	sprintf(s_path, "/%s/%s", root_path, cxi_name);
+	DIR *dir = opendir(s_path);
+	if (!dir) {
+		ovis_log(log, OVIS_LERROR,
+			 "Error %d opening directory '%s'\n",
+			 errno, s_path);
+		free(s_path);
+		return 1;
+	}
+
+	struct dirent *ent;
+	while ((ent = readdir(dir)) != NULL) {
+		/* Skip some files and directories */
+		if (skip_name(ent->d_name)) {
+			continue;
+		}
+		/* Allocate and copy the file name */
+		rh_files->names[rh_files->count] = strdup(ent->d_name);
+		if (!rh_files->names[rh_files->count]) {
+			ovis_log(log, OVIS_LERROR,
+				 "Memory allocation failed for file name '%s'\n",
+				 ent->d_name);
+			closedir(dir);
+			free(s_path);
+			return 1;
+		}
+		rh_files->count++;
+	}
+	closedir(dir);
+	free(s_path);
+	return 0;
+}
+
+static int create_metric_set(cxi_t cxi)
+{
+	int rc, i, j;
+
+	cxi->schema = base_schema_new(cxi->base);
+	if (!cxi->schema) {
+		ovis_log(cxi->log, OVIS_LERROR,
+		       "%s: The schema '%s' could not be created, errno=%d.\n",
+		       __FILE__, cxi->base->schema_name, errno);
+		rc = errno;
+		goto err;
+	}
+	cxi->metric_offset = ldms_schema_metric_count_get(cxi->schema);
+
+	/* Per interface telemetry record */
+	cxi->tel_rec = ldms_record_create("tel_record");
+	cxi->iface_mid = ldms_record_metric_add(cxi->tel_rec,
+						"iface_name", "",
+						LDMS_V_CHAR_ARRAY, 32);
+	for (i = 0; i < cxi->tel_files[0].count; i++) {
+		rc = ldms_record_metric_add(cxi->tel_rec, cxi->tel_files[0].names[i],
+					    "", LDMS_V_D64, 0);
+		if (rc < 0) {
+			ovis_log(cxi->log, OVIS_LERROR,
+				 "Error %d creating metric '%s'\n",
+				 -rc, cxi->tel_files[0].names[i]);
+			rc = errno;
+			goto err;
+		}
+		/* Cache the record metric index in tel_files */
+		for (j = 0; j < cxi->iface_count; j++) {
+			cxi->tel_files[j].midx[i] = rc;
+		}
+	}
+	cxi->tel_rec_mid = ldms_schema_record_add(cxi->schema, cxi->tel_rec);
+
+	/* Per interface retry handler record */
+	cxi->rh_rec = ldms_record_create("rh_record");
+	rc = ldms_record_metric_add(cxi->rh_rec,
+				    "iface_name", "",
+				    LDMS_V_CHAR_ARRAY, 32);
+	for (i = 0; i < cxi->rh_files[0].count; i++) {
+		rc = ldms_record_metric_add(cxi->rh_rec, cxi->rh_files[0].names[i],
+					    "", LDMS_V_D64, 0);
+		if (rc < 0) {
+			rc = errno;
+			goto err;
+		}
+		/* Cache the record metric index in rh_files */
+		for (j = 0; j < cxi->iface_count; j++) {
+			cxi->rh_files[j].midx[i] = rc;
+		}
+	}
+	/* List of per interface telemetry records */
+	rc = ldms_schema_metric_list_add(cxi->schema, "tel_list", "tel_record",
+			ldms_record_heap_size_get(cxi->tel_rec) * cxi->iface_count);
+	cxi->tel_list_mid = rc;
+	if (rc < 0) {
+		ovis_log(cxi->log, OVIS_LERROR,
+			 "Error %d creating tel_list.\n", errno);
+	}
+	/* List of per interface retry handler records */
+	cxi->rh_rec_mid = ldms_schema_record_add(cxi->schema, cxi->rh_rec);
+	rc = ldms_schema_metric_list_add(cxi->schema, "rh_list", "rh_record",
+			ldms_record_heap_size_get(cxi->rh_rec) * cxi->iface_count);
+	cxi->rh_list_mid = rc;
+	if (rc < 0 ) {
+		ovis_log(cxi->log, OVIS_LERROR,
+			 "Error %d creating rh_list.\n", errno);
+	}
+	size_t size = ldms_record_heap_size_get(cxi->tel_rec) +
+		ldms_record_heap_size_get(cxi->rh_rec);
+	size = size * cxi->iface_count;
+	cxi->set = base_set_new_heap(cxi->base, size);
+	if (!cxi->set) {
+		rc = errno;
+		goto err;
+	}
+	ldms_mval_t rh_rec;
+	ldms_mval_t tel_rec;
+	for (i = 0; i < cxi->iface_count; i++) {
+		cxi->rh_list_mval = ldms_metric_get(cxi->set, cxi->rh_list_mid);
+		cxi->tel_list_mval = ldms_metric_get(cxi->set, cxi->tel_list_mid);
+		rh_rec = ldms_record_alloc(cxi->set, cxi->rh_rec_mid);
+		tel_rec = ldms_record_alloc(cxi->set, cxi->tel_rec_mid);
+		rc = ldms_list_append_record(cxi->set, cxi->rh_list_mval, rh_rec);
+		if (rc) {
+			ovis_log(cxi->log, OVIS_LERROR,
+				 "Error %d appending record to rh_list.\n",
+				 rc);
+		}
+		rc = ldms_list_append_record(cxi->set, cxi->tel_list_mval, tel_rec);
+		if (rc) {
+			ovis_log(cxi->log, OVIS_LERROR,
+				 "Error %d appending record to tel_list.\n",
+				 rc);
+		}
+	}
+	return 0;
+
+ err:
+	if (cxi->base)
+		base_schema_delete(cxi->base);
+	return rc;
+}
+
+static const char *usage(ldmsd_plug_handle_t handle)
+{
+	static char help_str[PATH_MAX];
+	sprintf(help_str, "config name=%s %s [tel_path=PATH] [rh_path=PATH]",
+		ldmsd_plug_name_get(handle), BASE_CONFIG_USAGE);
+	return  help_str;
+}
+
+int get_cxi_interfaces(ldmsd_plug_handle_t handle, char *tel_path)
+{
+	cxi_t cxi = ldmsd_plug_ctxt_get(handle);
+	const char *pattern = "cxi*";
+	DIR *dir = opendir(tel_path);
+	int count;
+	if (!dir) {
+		ovis_log(cxi->log, OVIS_LERROR,
+			 "Error %d opening directory '%s'\n",
+			 errno, tel_path);
+		return 1;
+	}
+
+	struct dirent *ent;
+	count = 0;
+	while ((ent = readdir(dir)) != NULL) {
+		if (fnmatch(pattern, ent->d_name, 0) == 0) {
+			count++;
+		}
+	}
+	closedir(dir);
+	dir = opendir(tel_path);
+	cxi->iface_count = count;
+	cxi->iface_names = calloc(count, sizeof(char*));
+	if (!cxi->iface_names) {
+		ovis_log(cxi->log,
+			 OVIS_LERROR,
+			 "Memory allocation failed");
+		closedir(dir);
+		return 1;
+	}
+
+	count = 0;
+	while ((ent = readdir(dir)) != NULL) {
+		if (fnmatch(pattern, ent->d_name, 0) == 0) {
+			cxi->iface_names[count] = strdup(ent->d_name);
+			if (!cxi->iface_names[count]) {
+				ovis_log(cxi->log,
+					 OVIS_LERROR,
+					 "Memory allocation failed");
+				closedir(dir);
+				return 1;
+			}
+			count ++;
+		}
+	}
+	cxi->tel_files = calloc(count, sizeof(struct files_s));
+	if (!cxi->tel_files) {
+		ovis_log(cxi->log,
+			 OVIS_LERROR,
+			 "Memory allocation failed");
+		closedir(dir);
+		return 1;
+	}
+	cxi->rh_files = calloc(count, sizeof(struct files_s));
+	if (!cxi->rh_files) {
+		ovis_log(cxi->log,
+			 OVIS_LERROR,
+			 "Memory allocation failed");
+		closedir(dir);
+		return 1;
+	}
+	closedir(dir);
+	return 0;
+}
+
+static int config(ldmsd_plug_handle_t handle,
+		  struct attr_value_list *kwl, struct attr_value_list *avl)
+{
+	cxi_t cxi = ldmsd_plug_ctxt_get(handle);
+	ovis_log_t log = ldmsd_plug_log_get(handle);
+	int rc;
+	char *tel_path;
+	char *rh_path;
+
+	if (cxi->set) {
+		ovis_log(log, OVIS_LERROR, "Set already created.\n");
+		return EBUSY;
+	}
+
+	cxi->base = base_config(avl,
+				ldmsd_plug_cfg_name_get(handle),
+				ldmsd_plug_name_get(handle), log);
+	if (!cxi->base) {
+		rc = errno;
+		goto err;
+	}
+
+	tel_path = av_value(avl, "tel_path");
+	if (!tel_path) {
+		tel_path = "/sys/kernel/debug/cxi";
+	}
+	cxi->tel_path = strdup(tel_path);
+
+	rh_path = av_value(avl, "rh_path");
+	if (!rh_path) {
+		rh_path = "/var/run/cxi";
+	}
+	cxi->rh_path = strdup(rh_path);
+
+	/* Count CXI interfaces and allocate file name arrays */
+	if (get_cxi_interfaces(handle, tel_path) != 0) {
+		return 1;
+	}
+
+	/* Process telemetry and retry handler files for each CXI interface */
+	int i;
+	for (i = 0; i < cxi->iface_count; i++) {
+		if (get_cxi_metric_names(handle, &cxi->tel_files[i], cxi->iface_names[i],
+					 tel_path) != 0) {
+			return 1;
+		}
+		if (get_rh_names(handle, &cxi->rh_files[i], cxi->iface_names[i], rh_path) != 0) {
+			return 1;
+		}
+	}
+
+	rc = create_metric_set(cxi);
+	return 0;
+ err:
+	return rc;
+}
+
+static int sample(ldmsd_plug_handle_t handle)
+{
+	cxi_t cxi = ldmsd_plug_ctxt_get(handle);
+	int i;
+
+	if (!cxi->base) {
+		ovis_log(ldmsd_plug_log_get(handle),
+			 OVIS_LERROR,
+			 "The sampler '%s' is not configured.\n",
+			 ldmsd_plug_cfg_name_get(handle));
+		return 1;
+	}
+	base_sample_begin(cxi->base);
+	/* Process telemetry and retry handler files for each CXI interface */
+	for (i = 0; i < cxi->iface_count; i++) {
+		if (get_cxi_metric_values(cxi) != 0) {
+			return 1;
+		}
+		if (get_rh_metric_values(cxi) != 0) {
+			return 1;
+		}
+	}
+	base_sample_end(cxi->base);
+	return 0;
+}
+
+static int constructor(ldmsd_plug_handle_t handle)
+{
+	cxi_t cxi = calloc(1, sizeof(*cxi));
+	if (cxi) {
+		ldmsd_plug_ctxt_set(handle, cxi);
+		return 0;
+	}
+	return ENOMEM;
+}
+
+static void destructor(ldmsd_plug_handle_t handle)
+{
+}
+
+struct ldmsd_sampler ldmsd_plugin_interface = {
+	.base.type = LDMSD_PLUGIN_SAMPLER,
+	.base.flags = LDMSD_PLUGIN_MULTI_INSTANCE,
+	.base.config = config,
+	.base.usage = usage,
+	.base.constructor = constructor,
+	.base.destructor = destructor,
+
+	.sample = sample,
+};

--- a/ldms/src/sampler/cxi_sampler/ldms-sampler_cxi_sampler.rst
+++ b/ldms/src/sampler/cxi_sampler/ldms-sampler_cxi_sampler.rst
@@ -1,0 +1,86 @@
+.. _cxi_sampler:
+
+==============
+cxi_sampler
+==============
+
+----------------------------------------
+Man page for the LDMS cxi_sampler plugin
+----------------------------------------
+
+:Date:   04 May 2025
+:Manual section: 7
+:Manual group: LDMS sampler
+
+SYNOPSIS
+========
+
+| Within ldmsd_controller or a configuration file:
+| config name=cxi_sampler [ sys_path=<PATH> ] [ rh_path=<PATH> ]
+
+DESCRIPTION
+===========
+
+With LDMS (Lightweight Distributed Metric Service), plugins for the
+ldmsd (ldms daemon) are configured via ldmsd_controller or a
+configuration file. The cxi_sampler plugin provides interface
+telemetry information from /sys/kernel/debug/cxi and /var/run/cxi.
+
+There are two classes of information returned: CXI Telementry
+information, retry handler information. This data is organized into
+two lists of records.  One list contains the telemetry information,
+called 'tel_list', and 'rh_list' respectively.
+
+Each record schema is contructed by searching the directories above
+skipping sub-directories and special files used to reset the counter
+values. The remaining files each become a metric value in the
+associated recored.
+
+Each list contains one record for each interface.
+
+CONFIGURATION ATTRIBUTE SYNTAX
+==============================
+
+The cxi_sampler plugin uses the sampler_base base class. This man page
+covers only the configuration attributes specific to the this plugin;
+see :ref:`ldms_sampler_base(7) <ldms_sampler_base>` for the attributes
+of the base class.
+
+**config**
+   | name=INST_NAME [ tel_path=PATH ] [ rh_path=PATH ]
+
+   name=INST_NAME
+      |
+      | The configuration instance name.
+
+   tel_path=<PATH>
+      |
+      | Optional path to the directory containing the CXI interface telemetry files.
+        The default PATH is /sys/kernel/debug/cxi. This option is primarily for
+        testing on systems that lack the actual interface.
+
+   rh_path=PATH
+      | Optional path to the directory containing the CXI retry handler files.
+        The default PATH is /var/run/cxi. This option is primarily for
+        testing on systems that lack the actual interface.
+
+BUGS
+====
+
+No known bugs.
+
+EXAMPLES
+========
+
+Within ldmsd_controller or a configuration file:
+
+::
+
+   load name=cxi_sampler
+   config name=cxi_sampler producer=${HOSTNAME} instance=${HOSTNAME}/cxi_sampler
+   start name=cxi_sampler interval=1s
+
+SEE ALSO
+========
+
+:ref:`ldmsd(8) <ldmsd>`, :ref:`ldms_quickstart(7) <ldms_quickstart>`, :ref:`ldmsd_controller(8) <ldmsd_controller>`, :ref:`ldms_sampler_base(7) <ldms_sampler_base>`


### PR DESCRIPTION
This sampler parses data contained in files in the /sys/kernel/debug/cxi and /var/run/cxi directories and stores this data in a metric set.