### PR TITLE
add 'plugin_keywords' to yaml config dictionary

### DIFF
--- a/ldms/python/ldmsd/parser_util.py
+++ b/ldms/python/ldmsd/parser_util.py
@@ -187,9 +187,21 @@ def parse_to_cfg_str(cfg_obj):
     cfg_str = ''
     for key in cfg_obj:
         if key not in INT_ATTRS:
-            if len(cfg_str) > 1:
-                cfg_str += ' '
-            cfg_str += key + '=' + str(cfg_obj[key])
+            if key == "plugin_keywords":
+                words = cfg_obj[key]
+                if isinstance(words, str):
+                    if len(cfg_str) > 1:
+                        cfg_str += ' '
+                    cfg_str += words
+                else:
+                    for w in words:
+                        if len(cfg_str) > 1:
+                            cfg_str += ' '
+                        cfg_str += str(w)
+            else:
+                if len(cfg_str) > 1:
+                    cfg_str += ' '
+                cfg_str += key + '=' + str(cfg_obj[key])
     return cfg_str
 
 def parse_yaml_bool(bool_):


### PR DESCRIPTION
This lets the user specify yaml congruent with the keyword (as opposed to attr/val pair) syntax in the ldmsd plugin configuration script language. A single keyword or a list of keywords (as a string array) is allowed.
```
config:
  foo: bar
  plugin_keywords: ["timing", "bob"]
or
config:
  foo: bar
  plugin_keywords: timing
```
to support the existing ldmsd configuration language which allows keywords (as distinct from attr=value pairs).
The results of the above would be
config ... foo=bar timing bob
or
config ... foo=bar timing

The attribute name 'plugin_keywords' is reserved for ldmsd yaml use, as it seems unlikely to be used by future plugins. It seems, on the other hand, that some future plugin writer could easily come up with a parameter 'keywords'.