### PR TITLE
Standardize error response in three request handlers

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -4389,9 +4389,9 @@ static int updtr_task_status_handler(ldmsd_req_ctxt_t reqc)
 	if (name) {
 		updtr = ldmsd_updtr_find(name);
 		if (!updtr) {
+			reqc->errcode = ENOENT;
 			cnt = snprintf(reqc->line_buf, reqc->line_len, "updtr '%s' not found", name);
-			ldmsd_send_error_reply(reqc->xprt, reqc->key.msg_no, ENOENT,
-							reqc->line_buf, cnt);
+			ldmsd_send_req_response(reqc, reqc->line_buf);
 			free(name);
 			return 0;
 		}
@@ -4444,8 +4444,8 @@ static int updtr_task_status_handler(ldmsd_req_ctxt_t reqc)
 	goto out;
 
 err:
-	ldmsd_send_error_reply(reqc->xprt, reqc->key.msg_no, rc,
-						"internal error", 15);
+	reqc->errcode = rc;
+	ldmsd_send_req_response(reqc, "Internal error.");
 out:
 	free(name);
 	if (updtr)
@@ -4605,8 +4605,8 @@ static int prdcr_hint_tree_status_handler(ldmsd_req_ctxt_t reqc)
 	goto out;
 
 intr_err:
-	ldmsd_send_error_reply(reqc->xprt, reqc->key.msg_no, EINTR,
-				"interval error", 14);
+	reqc->errcode = rc;
+	ldmsd_send_req_response(reqc, "Internal error");
 out:
 	free(name);
 	ldmsd_prdcr_put(prdcr, "find");
@@ -5572,8 +5572,8 @@ static int plugn_sets_handler(ldmsd_req_ctxt_t reqc)
 	return ldmsd_append_reply(reqc, (char *)&attr.discrim,
 				sizeof(uint32_t), LDMSD_REQ_EOM_F);
 err:
-	ldmsd_send_error_reply(reqc->xprt, reqc->key.msg_no, rc,
-				"internal error", 15);
+	reqc->errcode = rc;
+	ldmsd_send_req_response(reqc, "Internal error.");
 	return rc;
 }
 


### PR DESCRIPTION
Modify updtr_task, prdcr_hint, and set_route handlers to use ldmsd_send_req_response() for sending error messages back to requesters. This function automatically handles message length calculation, removing the need for manual length calculations in these handlers.