### PR TITLE
Netlink / ldms-notify cherries

### DIFF
--- a/ldms/scripts/examples/linux_proc_sampler
+++ b/ldms/scripts/examples/linux_proc_sampler
@@ -67,12 +67,15 @@ cat << EOF > $LDMSD_RUN/metrics.input
 }
 EOF
 rm -f $LOGDIR/json*.log
-#valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.txt ${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked &
-#valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.txt ${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked &
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit &
+drd="valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.drd.txt --trace-cond=yes --trace-fork-join=yes"
+memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --keep-debuginfo=yes --malloc-fill=3b"
+#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked &
+
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 0 &
+
 # uncomment next one to test duplicate handling
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
-VGARGS="--tool=drd --suppressions=/scratch1/baallan/ovis/ldms/scripts/examples/linux_proc_sampler.drd.supp"
+VGARGS="--tool=drd --trace-cond=yes --trace-fork-join=yes"
 VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=definite --time-stamp=yes --keep-debuginfo=yes --malloc-fill=3b"
 #vgon
 LDMSD 1

--- a/ldms/scripts/examples/linux_proc_sampler
+++ b/ldms/scripts/examples/linux_proc_sampler
@@ -67,11 +67,16 @@ cat << EOF > $LDMSD_RUN/metrics.input
 }
 EOF
 rm -f $LOGDIR/json*.log
+for pi in $(seq 80 100); do
+	touch ${LDMSD_RUN}/ldms-netlink-tracked/$pi
+done
+/bin/rm $LOGDIR/nl.log
+
 drd="valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.drd.txt --trace-cond=yes --trace-fork-join=yes"
 memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --keep-debuginfo=yes --malloc-fill=3b"
-#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked &
+#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked --purge-track-dir &
 
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 0 &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 2 &
 
 # uncomment next one to test duplicate handling
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &

--- a/ldms/scripts/examples/linux_proc_sampler.job
+++ b/ldms/scripts/examples/linux_proc_sampler.job
@@ -1,0 +1,133 @@
+export plugname=linux_proc_sampler
+export dsname=$(ldms_dstat_schema_name mmalloc=1 io=1 fd=1 stat=1 auto-schema=1)
+export dstat_schema=$dsname
+export LDMSD_LOG_LEVEL=ERROR
+export LDMSD_LOG_TIME_SEC=1
+export LDMSD_EXTRA="-m 128m"
+
+function SUSLEEP () {
+	if test "$bypass" = "1"; then
+		echo skipping sleep
+		return 0
+	fi
+	echo -n sleep $1 ...
+	runuser -u $USER sleep $1
+	echo done
+}
+
+portbase=61060
+cat << EOF > $LDMSD_RUN/exclude_env
+^COLORTERM
+^DBU.*
+^DESKTOP_SESSION
+^DISPLAY
+^GDM.*
+^GNO.*
+^GUESTFISH.*
+^XDG.*
+^LS_COLORS
+^SESSION_MANAGER
+^SSH.*
+^XAU.*
+^BASH_FUNC_m
+"
+EOF
+ldms-gen-syscall-map > $LDMSD_RUN/syscalls.map
+cat << EOF > $LDMSD_RUN/metrics.input
+{ "stream" : "slurm",
+  "argv_sep":"\t",
+  "syscalls": "${LDMSD_RUN}/syscalls.map",
+  "argv_msg": 1,
+  "log_send": 1,
+  "env_msg": 1,
+  "env_exclude": "${LDMSD_RUN}/exclude_env",
+  "fd_msg": 1,
+  "fd_exclude": [
+        "^/dev/",
+        "^/run/",
+        "^/var/",
+        "^/etc/",
+        "^/sys/",
+        "^/tmp/",
+        "^/proc/",
+        "^/proc$",
+        "^/ram/tmp/",
+        "^/usr/lib",
+        "^/usr/share/",
+        "^/opt/ness",
+        "^/ram/opt/ness",
+        "^/ram/var/",
+	"/.nfs0"
+    ],
+  "published_pid_dir" : "${LDMSD_RUN}/ldms-netlink-tracked",
+  "metrics" : [
+    "status_real_user",
+    "status_eff_user",
+    "status_real_group",
+    "status_eff_group",
+    "stat_pid" ,
+    "stat_state",
+    "stat_rss",
+    "stat_utime",
+    "stat_stime",
+    "io_read_b",
+    "io_write_b",
+    "syscall_name"
+  ]
+}
+EOF
+rm -f $LOGDIR/json*.log
+for pi in $(seq 80 100); do
+	touch ${LDMSD_RUN}/ldms-netlink-tracked/$pi
+done
+/bin/rm $LOGDIR/nl.log
+
+JOBDATA $TESTDIR/job.data 1
+
+drd="valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.drd.txt --trace-cond=yes --trace-fork-join=yes"
+memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --keep-debuginfo=yes --malloc-fill=3b"
+#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked --purge-track-dir &
+
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 2 --jobid-file=$TESTDIR/job.data.1 &
+
+# uncomment next one to test duplicate handling
+#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+VGARGS="--tool=drd --trace-cond=yes --trace-fork-join=yes"
+VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=definite --time-stamp=yes --keep-debuginfo=yes --malloc-fill=3b"
+#vgon
+LDMSD -p prolog.jobid 1
+vgoff
+LDMSD 2
+LDMSD 3
+vgoff
+JOBDATA $TESTDIR/job.data 1
+SUSLEEP 2
+MESSAGE ldms_ls on host 1:
+#LDMS_LS 1 -v
+MESSAGE ldms_ls on host 2:
+JOBDATA $TESTDIR/job.data 1
+SUSLEEP 1
+LDMS_LS 2 -v
+JOBDATA $TESTDIR/job.data 1
+SUSLEEP 5
+#MESSAGE stream_client_dump on sampler daemon 1
+#for lc in $(seq 1); do
+#ldmsd_controller --auth none --port 61061 --cmd stream_client_dump
+#	SUSLEEP 1
+#done
+JOBDATA $TESTDIR/job.data 1
+SUSLEEP 5
+for lc in $(seq 1); do
+#LDMS_LS 1 -v
+	JOBDATA $TESTDIR/job.data 1
+	SUSLEEP 2
+done
+JOBDATA $TESTDIR/job.data 1
+SUSLEEP 20
+KILL_LDMSD 3 2 1
+file_created $STOREDIR/node/$plugname
+file_created $STOREDIR/node/$dsname
+rollover_created $STOREDIR/blobs/linux_proc_sampler_argv.DAT
+rollover_created $STOREDIR/blobs/linux_proc_sampler_files.DAT
+rollover_created $STOREDIR/blobs/linux_proc_sampler_env.DAT
+rollover_created $STOREDIR/blobs/slurm.DAT

--- a/ldms/scripts/examples/linux_proc_sampler.job
+++ b/ldms/scripts/examples/linux_proc_sampler.job
@@ -5,13 +5,14 @@ export LDMSD_LOG_LEVEL=ERROR
 export LDMSD_LOG_TIME_SEC=1
 export LDMSD_EXTRA="-m 128m"
 
+tuser=nobody
 function SUSLEEP () {
 	if test "$bypass" = "1"; then
 		echo skipping sleep
 		return 0
 	fi
 	echo -n sleep $1 ...
-	runuser -u $USER sleep $1
+	runuser -p -u $tuser sleep $1
 	echo done
 }
 
@@ -86,9 +87,12 @@ JOBDATA $TESTDIR/job.data 1
 
 drd="valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.drd.txt --trace-cond=yes --trace-fork-join=yes"
 memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --keep-debuginfo=yes --malloc-fill=3b"
+memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --malloc-fill=3b"
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked --purge-track-dir &
 
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 2 --jobid-file=$TESTDIR/job.data.1 &
+echo \
+"${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 1 --ProducerName=$(hostname) --purge-track-dir --format 3 --jobid-file=$TESTDIR/job.data.1 " > ${LDMSD_RUN}/start.netlink
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 1 --ProducerName=$(hostname) --purge-track-dir --format 3 --jobid-file=$TESTDIR/job.data.1 &
 
 # uncomment next one to test duplicate handling
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
@@ -109,14 +113,20 @@ JOBDATA $TESTDIR/job.data 1
 SUSLEEP 1
 LDMS_LS 2 -v
 JOBDATA $TESTDIR/job.data 1
+export LSB_JOBID=12345
 SUSLEEP 5
+unset LSB_JOBID
+export LSB_JOBID
 #MESSAGE stream_client_dump on sampler daemon 1
 #for lc in $(seq 1); do
 #ldmsd_controller --auth none --port 61061 --cmd stream_client_dump
 #	SUSLEEP 1
 #done
 JOBDATA $TESTDIR/job.data 1
+export SLURM_JOB_ID=54321
 SUSLEEP 5
+unset SLURM_JOB_ID
+export SLURM_JOB_ID
 for lc in $(seq 1); do
 #LDMS_LS 1 -v
 	JOBDATA $TESTDIR/job.data 1

--- a/ldms/scripts/examples/linux_proc_sampler.job.1
+++ b/ldms/scripts/examples/linux_proc_sampler.job.1
@@ -1,0 +1,7 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} schema=${plugname} instance=localhost${i}/${plugname} component_id=${i} perm=0644 cfg_file=${LDMSD_RUN}/metrics.input
+start name=${plugname} interval=1000000 offset=0
+
+# load name=dstat
+# config name=dstat producer=localhost${i} instance=localhost${i}/${dstat_schema} component_id=${i} mmalloc=1 io=1 fd=1 auto-schema=1 stat=1) perm=777
+# start name=dstat interval=1000000 offset=0

--- a/ldms/scripts/examples/linux_proc_sampler.job.2
+++ b/ldms/scripts/examples/linux_proc_sampler.job.2
@@ -1,0 +1,25 @@
+# blobs must be allowed by writer plugin and prdcr_subscribe by daemon
+load name=blob_stream_writer plugin=blob_stream_writer
+config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm stream=linux_proc_sampler_env stream=linux_proc_sampler_argv types=1 stream=linux_proc_sampler_files
+
+load name=dstat
+config name=dstat producer=localhost${i} instance=localhost${i}/${dstat_schema} component_id=${i} mmalloc=1 io=1 fd=1 auto-schema=1 stat=1) perm=777
+start name=dstat interval=1000000 offset=0
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_subscribe regex=.* stream=slurm
+prdcr_subscribe regex=.* stream=linux_proc_sampler_argv
+prdcr_subscribe regex=.* stream=linux_proc_sampler_env
+prdcr_subscribe regex=.* stream=linux_proc_sampler_files
+prdcr_start name=localhost1
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+strgp_add name=store_${testname} plugin=store_csv schema=linux_proc_sampler container=node
+strgp_prdcr_add name=store_${testname} regex=.*
+strgp_start name=store_${testname}

--- a/ldms/scripts/examples/linux_proc_sampler.job.3
+++ b/ldms/scripts/examples/linux_proc_sampler.job.3
@@ -1,0 +1,13 @@
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000
+prdcr_start name=localhost2
+
+updtr_add name=allhosts interval=1000000 offset=200000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+strgp_add name=store_dstat plugin=store_csv schema=${dstat_schema} container=node
+strgp_prdcr_add name=store_dstat regex=.*
+strgp_start name=store_dstat

--- a/ldms/src/sampler/netlink/netlink-notifier.c
+++ b/ldms/src/sampler/netlink/netlink-notifier.c
@@ -73,6 +73,7 @@
 #include <getopt.h>
 #include <sched.h>
 #include <pwd.h>
+#include <sys/inotify.h>
 
 #include <sys/ioctl.h>
 #include <sys/time.h>
@@ -97,6 +98,7 @@
 FILE *debug_log;
 #define DEBUG_EMITTER 0
 /* set 1 to trace which path emits the message by adding emitter field to messages */
+#define ARRAY_SIZE(a) (sizeof (a) / sizeof ((a)[0]))
 
 /* provide thread-safe io macros */
 //#define debug_err_lock 1
@@ -208,6 +210,7 @@ const char *rm_names[] = {
 	/* insert additional here when supported. */
 	NULL
 };
+#define UID_MIN 1000 /* least regular uid value */
 
 /* /proc info cache */
 typedef struct proc_info {
@@ -325,6 +328,9 @@ typedef struct forkstat {
 	unsigned long format;			/* stream formatting version to use */
 	int heartbeat;				/* approximate seconds between heartbeats */
 	time_t lastbeat;			/* time of last beat */
+	char *jobid_variable_name;			/* variable for for jobid */
+	char *jobid_file_name;			/* where to look for jobid variable data */
+	char *host_jobid;			/* jobid from host file; fallback for proc_info jobid */
 } forkstat_t;
 
 
@@ -411,6 +417,7 @@ static const int signals[] = {
 };
 
 /* add several structures related to filtering. */
+#define default_jobid_file NULL
 #define default_format "2" /* this is also the max format known */
 #define default_heartbeat NULL /* none by default*/
 #define default_component_id NULL
@@ -422,6 +429,24 @@ static const int signals[] = {
 #define default_exclude_dirs "/sbin"
 #define default_short_path "/bin:/usr"
 #define default_short_time "1"
+
+/* where we find jobid data if not given.*/
+#define jfsearch "/search"
+const char *jobid_file_names[] = {
+	"/var/run/ldms_jobinfo.data"
+	"/var/run/ldms.slurm.jobinfo",
+	"/var/run/ldms.jobinfo"
+};
+
+/* what the jobid data might be called. */
+const char *jobid_variable_names[] = {
+	"JOBID",
+	"JOB_ID",
+	"LSB_JOBID",
+	"PBS_JOBID",
+	"SLURM_JOBID",
+	"SLURM_JOB_ID",
+};
 
 struct path_name {
 	char *n; /* single file or dir name with trailing / */
@@ -627,6 +652,11 @@ struct monitor_args {
 	pthread_t tid;	/* thread of the monitoring; set in forkstat_monitor.*/
 	forkstat_t *ft; /* data handle of the monitor from forkstat_create. */
 };
+
+/*
+ * thread to check on jobid data file updates.
+ */
+pthread_t jobid_thread;
 
 /* after configuration, init ma and hook forkstat handle to kernel. */
 static int forkstat_connect(forkstat_t *ft, struct monitor_args *ma);
@@ -2366,6 +2396,7 @@ static struct exclude_arg excludes[] = {
 	{default_format, VT_SCALAR, 0, "NOTIFIER_FORMAT", NULL, 0, PLINIT},
 	{default_heartbeat, VT_SCALAR, 0, "NOTIFIER_HEARTBEAT", NULL, 0, PLINIT},
 	{default_purge, VT_NONE, 0, "NOTIFIER_PURGE_TRACK_DIR", NULL, 0, PLINIT},
+	{default_jobid_file, VT_FILE, 0, "NOTIFIER_JOBID_FILE", NULL, 0, PLINIT},
 };
 static struct exclude_arg *bin_exclude = &excludes[0];
 static struct exclude_arg *dir_exclude = &excludes[1];
@@ -2385,6 +2416,7 @@ static struct exclude_arg *compid_arg = &excludes[14];
 static struct exclude_arg *format_arg = &excludes[15];
 static struct exclude_arg *heartbeat_arg = &excludes[16];
 static struct exclude_arg *purge_track_dir_arg = &excludes[17];
+static struct exclude_arg *jobid_file_arg = &excludes[18];
 
 static struct option long_options[] = {
 	{"exclude-programs", optional_argument, 0, 0},
@@ -2405,6 +2437,7 @@ static struct option long_options[] = {
 	{"format", required_argument, 0, 0},
 	{"heartbeat", required_argument, 0, 0},
 	{"purge-track-dir", no_argument, 0, 0},
+	{"jobid-file", required_argument, 0, 0},
 	{0, 0, 0, 0}
 };
 
@@ -2432,7 +2465,7 @@ static struct env_attr lsf_env_start_default[] = {
 	{ "task_pid", "LS_JOBPID", NULL_STEP_ID, 0 }
 };
 
-static int nlongopt = sizeof(excludes)/sizeof(excludes[0]) ;
+static int nlongopt = ARRAY_SIZE(excludes);
 
 /*
  *  show_help()
@@ -2599,6 +2632,194 @@ static int set_format(char *optarg, forkstat_t *ft)
 		return EINVAL;
 	}
 	return 0;
+}
+
+#define JOB_FILES_RETRY 10
+#define JOB_MAX_ENV 512
+static int update_host_jobid(forkstat_t *ft)
+{
+	if (!ft->jobid_variable_name || !ft->jobid_file_name)
+		return 0;
+	FILE *f = fopen(ft->jobid_file_name, "r");
+	if (!f) {
+		free(ft->host_jobid);
+		ft->host_jobid = NULL;
+		return 0;
+	}
+	char *s = NULL;
+	char *p = NULL;
+	char *name = NULL;
+	char *value = NULL;
+	char buf[JOB_MAX_ENV];
+	int rc = 0;
+	while (NULL != (s = fgets(buf, sizeof(buf), f))) {
+		name = strtok_r(s, "=", &p);
+		if (!name || strcmp(name, ft->jobid_variable_name))
+			continue;
+		value = strtok_r(NULL, "=", &p);
+		if (!value) {
+			free(ft->host_jobid);
+			ft->host_jobid = NULL;
+			break;
+		}
+		free(ft->host_jobid);
+		ft->host_jobid = strdup(value);
+		if (!ft->host_jobid) {
+			rc = ENOMEM;
+		}
+		break;
+	}
+	fclose(f);
+	return rc;
+}
+
+/* find variable from list in file. */
+static int set_jobid_variable(forkstat_t *ft)
+{
+	if (ft->jobid_variable_name)
+		return 0;
+	if (!ft->jobid_file_name)
+		return 0;
+	int missing_warned = 0;
+	while (1) {
+		FILE *f = fopen(ft->jobid_file_name, "r");
+		int rc = 0;
+		if (!f) {
+			sleep(JOB_FILES_RETRY);
+			continue;
+		}
+		int k;
+		char *s = NULL;
+		char *p = NULL;
+		char *name = NULL;
+		char buf[JOB_MAX_ENV];
+		while (NULL != (s = fgets(buf, sizeof(buf), f))) {
+			name = strtok_r(s, "=", &p);
+			if (!name)
+				continue;
+			for (k = 0; k < ARRAY_SIZE(jobid_variable_names); k++) {
+				if (! strcmp(name, jobid_variable_names[k])) {
+					ft->jobid_variable_name = strdup(name);
+					if (!ft->jobid_variable_name) {
+						rc = ENOMEM;
+					}
+					fclose(f);
+					return rc;
+				}
+			}
+			if (!missing_warned) {
+				missing_warned = 1;
+				printf("warning: job id file %s"
+				" initially without any job id variable.\n",
+				ft->jobid_file_name);
+			}
+		}
+		fclose(f);
+		sleep(JOB_FILES_RETRY);
+	}
+}
+
+/* set file from option or search loop until file found among expected files.
+ * ft->jobid_file_name will remain NULL if user wants no jobid from /var.
+ * (default is user wants no jobid from /var)
+ */
+static int set_jobid_file(forkstat_t *ft)
+{
+	struct exclude_arg *jfa = jobid_file_arg;
+	if (!jfa->parsed && !getenv(jfa->env))
+		return 0;
+	if (!jfa->paths[0].n)
+		return 0;
+	if (strcmp(jfa->paths[0].n, jfsearch) != 0) {
+		ft->jobid_file_name = strdup(jfa->paths[0].n);
+		if (!ft->jobid_file_name)
+			return ENOMEM;
+		return 0;
+	}
+	while (1) {
+		int i = 0;
+		for (; i < ARRAY_SIZE(jobid_file_names); i++) {
+			FILE *f = fopen(jobid_file_names[i], "r");
+			if (f) {
+				fclose(f);
+				ft->jobid_file_name = strdup(jobid_file_names[i]);
+				if (!ft->jobid_file_name)
+					return ENOMEM;
+				return 0;
+			}
+		}
+		sleep(JOB_FILES_RETRY);
+	}
+}
+/*
+ * Wait for changes to the jobinfo file and update the metrics.
+ */
+void *
+jobid_thread_check(void *arg)
+{
+	forkstat_t *ft = (forkstat_t *)arg;
+	if (!arg )
+		return NULL;
+	int rc;
+	int nd;
+	int wd = -1;
+	struct inotify_event ev;
+	int mask = IN_CLOSE_WRITE | IN_CREATE | IN_DELETE | IN_DELETE_SELF;
+
+	// this loops until file is known if file is expected
+	rc = set_jobid_file(ft);
+	if (rc) {
+		printf("out of memory setting job id input file\n");
+		return NULL;
+	}
+	if (!ft->jobid_file_name)
+		return NULL;
+
+	// get var and value from file
+	rc = set_jobid_variable(ft);
+	if (rc) {
+		printf("out of memory setting job id variable\n");
+		return NULL;
+	}
+	if (!ft->jobid_variable_name)
+		return NULL;
+
+	update_host_jobid(ft);
+	/* watch for changes to value found at
+	 * jobid_file_name:jobid_variable_name
+	 */
+	nd = inotify_init();
+	while (1) {
+		/*
+		 * The file may not exist at the time this daemon is started.
+		 * By the time we get here, it existed for set_jobid_file,
+		 * so we expect it to reappear.
+		 */
+		if (wd < 0 && ft->jobid_file_name != NULL) {
+			wd = inotify_add_watch(nd, ft->jobid_file_name, mask);
+			if (wd < 0) {
+				/* try again later. may be briefly gone */
+				sleep(1);
+				continue;
+			}
+		}
+
+		rc = read(nd, &ev, sizeof(ev));
+		if (rc < sizeof(ev) ||
+			(ev.mask & (IN_CREATE | IN_DELETE | IN_DELETE_SELF))) {
+			printf("Error %d reading from the inotify descriptor.\n",
+			       errno);
+			inotify_rm_watch(nd, wd);
+			wd = -1;
+			continue;
+		}
+		update_host_jobid(ft);
+	}
+
+	inotify_rm_watch(nd, wd);
+	close(nd);
+
+	return NULL;
 }
 
 static int set_duration_min(char *optarg, forkstat_t *ft)
@@ -3080,7 +3301,9 @@ err:
 /* /////////// end of functions to get env var from a pid ///////////////// */
 #include "ovis_json/ovis_json.h"
 
-#define info_jobid_str(info) info->jobid ? info->jobid : "0"
+/* get jobid string from pid environ if present, or if uid > UID_MIN,
+ * get host_jobid */
+#define info_jobid_str(info, ft) info->jobid ? info->jobid : ( (info->uid >= UID_MIN && ft->host_jobid) ? ft->host_jobid : "0")
 
 static int add_env_attr(struct env_attr *a, jbuf_t *jb, const struct proc_info *info, forkstat_t *ft)
 {
@@ -3144,7 +3367,7 @@ static jbuf_t make_process_start_data_linux(forkstat_t *ft, const struct proc_in
 			ft->prod_field, ft->compid_field,
 			info->start.tv_sec, info->start.tv_usec,
 			info->start_tick,
-			info_jobid_str(info),
+			info_jobid_str(info, ft),
 			info->serno,
 			(int64_t)info->pid,
 			(int64_t)info->uid,
@@ -3190,7 +3413,7 @@ static jbuf_t make_process_end_data_linux(forkstat_t *ft, const struct proc_info
 				ft->prod_field, ft->compid_field,
 				info->start.tv_sec, info->start.tv_usec,
 				info->start_tick,
-				info_jobid_str(info),
+				info_jobid_str(info, ft),
 				info->serno,
 				(int64_t)info->pid,
 				(int)info->pid);
@@ -3221,7 +3444,7 @@ static jbuf_t make_process_end_data_linux(forkstat_t *ft, const struct proc_info
 				ft->prod_field, ft->compid_field,
 				info->start.tv_sec, info->start.tv_usec,
 				info->start_tick,
-				info_jobid_str(info),
+				info_jobid_str(info, ft),
 				info->serno,
 				(int64_t)info->pid,
 				(int)info->pid,
@@ -3254,7 +3477,7 @@ static jbuf_t make_process_end_data_linux(forkstat_t *ft, const struct proc_info
 				ft->prod_field, ft->compid_field,
 				info->start.tv_sec, info->start.tv_usec,
 				info->start_tick,
-				info_jobid_str(info),
+				info_jobid_str(info, ft),
 				info->serno,
 				(int64_t)info->pid,
 				(int)info->pid,
@@ -3291,13 +3514,13 @@ static jbuf_t make_process_start_data_lsf(forkstat_t *ft, const struct proc_info
 		time(NULL),
 			ft->prod_field, ft->compid_field,
 			info->start.tv_sec, info->start.tv_usec,
-			info_jobid_str(info),
+			info_jobid_str(info, ft),
 			info->serno,
 			(int64_t)info->pid);
 	if (!jb)
 		goto out_1;
 	size_t i, iend;
-	iend = sizeof(lsf_env_start_default)/sizeof(lsf_env_start_default[0]);
+	iend = ARRAY_SIZE(lsf_env_start_default);
 	for (i = 0 ; i < iend; i++)
 		if (add_env_attr(&lsf_env_start_default[i], &jb, info, ft))
 			goto out_1;
@@ -3342,7 +3565,7 @@ static jbuf_t make_process_end_data_lsf(forkstat_t *ft, const struct proc_info *
 			time(NULL),
 				ft->prod_field, ft->compid_field,
 				info->start.tv_sec, info->start.tv_usec,
-				info_jobid_str(info),
+				info_jobid_str(info, ft),
 				info->serno,
 				(int64_t)info->pid);
 	else if (ft->format == 1)
@@ -3365,7 +3588,7 @@ static jbuf_t make_process_end_data_lsf(forkstat_t *ft, const struct proc_info *
 			time(NULL),
 				ft->prod_field, ft->compid_field,
 				info->start.tv_sec, info->start.tv_usec,
-				info_jobid_str(info),
+				info_jobid_str(info, ft),
 				info->serno,
 				(int64_t)info->pid,
 				info->duration
@@ -3391,7 +3614,7 @@ static jbuf_t make_process_end_data_lsf(forkstat_t *ft, const struct proc_info *
 			time(NULL),
 				ft->prod_field, ft->compid_field,
 				info->start.tv_sec, info->start.tv_usec,
-				info_jobid_str(info),
+				info_jobid_str(info, ft),
 				info->serno,
 				(int64_t)info->pid,
 				info->duration,
@@ -3402,7 +3625,7 @@ static jbuf_t make_process_end_data_lsf(forkstat_t *ft, const struct proc_info *
 	if (!jb)
 		goto out_1;
 	size_t i, iend;
-	iend = sizeof(lsf_env_start_default)/sizeof(lsf_env_start_default[0]);
+	iend = ARRAY_SIZE(lsf_env_start_default);
 	for (i = 0 ; i < iend; i++)
 		if (add_env_attr(&lsf_env_start_default[i], &jb, info, ft))
 			goto out_1;
@@ -3448,11 +3671,11 @@ static jbuf_t make_process_start_data_slurm(forkstat_t *ft, const struct proc_in
 		type,
 #endif
 			ft->prod_field, ft->compid_field,
-			info_jobid_str(info),
+			info_jobid_str(info, ft),
 			info->serno,
 			(int64_t)info->pid);
 	size_t i, iend;
-	iend = sizeof(slurm_env_start_default)/sizeof(slurm_env_start_default[0]);
+	iend = ARRAY_SIZE(slurm_env_start_default);
 	for (i = 0 ; i < iend; i++) {
 		if (add_env_attr(&slurm_env_start_default[i], &jb, info, ft))
 			goto out_1;
@@ -3497,7 +3720,7 @@ static jbuf_t make_process_end_data_slurm(forkstat_t *ft, const struct proc_info
 			forkstat_get_serial(ft),
 			time(NULL),
 				ft->prod_field, ft->compid_field,
-				info_jobid_str(info),
+				info_jobid_str(info, ft),
 				info->serno,
 				(int64_t)info->pid);
 	else if (ft->format == 1)
@@ -3519,7 +3742,7 @@ static jbuf_t make_process_end_data_slurm(forkstat_t *ft, const struct proc_info
 			forkstat_get_serial(ft),
 			time(NULL),
 				ft->prod_field, ft->compid_field,
-				info_jobid_str(info),
+				info_jobid_str(info, ft),
 				info->start.tv_sec, info->start.tv_usec,
 				info->serno,
 				(int64_t)info->pid,
@@ -3544,7 +3767,7 @@ static jbuf_t make_process_end_data_slurm(forkstat_t *ft, const struct proc_info
 			forkstat_get_serial(ft),
 			time(NULL),
 				ft->prod_field, ft->compid_field,
-				info_jobid_str(info),
+				info_jobid_str(info, ft),
 				info->start.tv_sec, info->start.tv_usec,
 				info->serno,
 				(int64_t)info->pid,
@@ -3556,7 +3779,7 @@ static jbuf_t make_process_end_data_slurm(forkstat_t *ft, const struct proc_info
 	if (!jb)
 		goto out_1;
 	int i, iend;
-	iend = sizeof(slurm_env_end_default)/sizeof(slurm_env_end_default[0]);
+	iend = ARRAY_SIZE(slurm_env_end_default);
 	for (i = 0 ; i < iend; i++)
 		if (add_env_attr(&slurm_env_end_default[i], &jb, info, ft))
 			goto out_1;
@@ -3970,7 +4193,7 @@ int main(int argc, char * argv[])
 	}
 	if (argc < 2) {
 		args = default_args;
-		argc = sizeof(default_args) / sizeof(default_args[0]);
+		argc = ARRAY_SIZE(default_args);
 	}
 
 	while (1) {
@@ -4100,6 +4323,20 @@ int main(int argc, char * argv[])
 		}
 		normalize_exclude(&excludes[c]);
 	}
+	int rc = set_jobid_file(ft);
+	switch (rc) {
+	case ENOENT:
+		fprintf(stderr, "Warning: Found no file for %s with %s.\n",
+			 jobid_file_arg->paths[0].n, "jobid-file");
+		/* this may be resolved later for some daemon startup orders */
+		break;
+	case ENOMEM:
+		fprintf(stderr, "out of memory configuring %s.\n", "jobid-file");
+		ret = EXIT_FAILURE;
+		goto abort_sock;
+	default:
+		break;
+	}
 	if (set_format(format_arg->paths[0].n, ft)) {
 		fprintf(stderr, "Bad value %s for %s (>=0 & <= %s).\n",
 			 format_arg->paths[0].n, "format", format_arg[0].defval);
@@ -4178,6 +4415,9 @@ int main(int argc, char * argv[])
 		forkstat_option_dump(ft, excludes);
 
 /* netlink/ldms threaded region */
+	pthread_t jtid = pthread_create(&jobid_thread, NULL,
+			jobid_thread_check, ft); /* thread for jobid file */
+
 	forkstat_init_ldms_stream(ft);
 	int start_err = forkstat_monitor(ft, &ma); // thread to follow kernel netlink sock
 	if (start_err)
@@ -4199,6 +4439,7 @@ int main(int argc, char * argv[])
 	pthread_join(ma.tid, &res);
 	if (ft->opt_trace)
 		PRINTF("JOIN done w/%p\n", res);
+	pthread_cancel(jtid); /* this will 'fail' if thread already stopped */
 	forkstat_finalize_ldms_stream(ft);
 /* resume unthreaded region */
 	if (ft->opt_trace)

--- a/ldms/src/sampler/netlink/netlink-notifier.man
+++ b/ldms/src/sampler/netlink/netlink-notifier.man
@@ -95,7 +95,7 @@ The 'short' options do not override the exclude entirely options.
 .fi
 
 .SH ENVIRONMENT
-The following variables override defaults if a command line option is not present, as describe in the options section.
+The following variables override defaults if a command line option is not present, as described in the options section.
 .nf
 NOTIFIER_EXCLUDE_PROGRAMS="(nullexe):<unknown>"
 NOTIFIER_EXCLUDE_DIRS=/sbin
@@ -109,11 +109,11 @@ NOTIFIER_LDMS_XPRT=sock
 NOTIFIER_LDMS_HOST=localhost
 NOTIFIER_LDMS_PORT=411
 NOTIFIER_LDMS_AUTH=munge
-NOTIFIER_FORMAT=1
+NOTIFIER_FORMAT=2
 NOTIFIER_HEARTBEAT=(none)
 .fi
 Omitting (nullexe):<unknown> from NOTIFIER_EXCLUDE_PROGRAMS may cause incomplete output
-related to processes no longer present. In exotic circumstances, this may be desirable anyway.
+related to processes no longer present. In exotic circumstances, this may be desirable.
 
 .SH FILES
 
@@ -139,6 +139,8 @@ ProducerName and component_id. The version of the tuned formats is specified by 
 Format 0 omits the start time from slurm process end messages (since it is only sometimes known) and omits process duration, which depend on the start time.
 .PP
 Format 1 includes the start time for slurm process or the dummy value 0 when unknown) and includes process duration for all end messages. When the start time is unavailable, duration of -1.0 is published. Merging data from other sources may allow durations flagged as -1 to be computed in some later data cleanup step.
+.PP
+Format 2 extends process end messages with the executable name in field 'exe'. When this is not available, exe of '/no-exe-data' is published. Merging data from other sources may allow exe flagged as /no-exe-data to be computed in some later data cleanup step.
 
 
 .SH NOTES
@@ -152,22 +154,23 @@ to add a node identifier to the messages. Normally a process-following sampler t
 will add the node identifier automatically.
 .PP
 When the daemon is started after a process is started, the process start time and therefore process
-duration may not be available. In message formats which report start time, 0 indicates
+duration may not be available. Similarly exe may not be available. In message formats which report
+start time, 0 indicates
 data was unavailable. For processes without completely known time bounds, the duration is reported
-as -1.0.
+as -1.0. For processes without known program paths, exe is reported as /no-exe-data.
 .PP
 Options are still in development. Several options affect only the trace output.
 
 .SH EXAMPLES
 .PP
-Run for 30 seconds with screen and json.log test output connecting to the ldmsd from 'ldms-static-test.sh blobwriter' test:
+To run for 30 seconds with screen and json.log test output connecting to the ldmsd from 'ldms-static-test.sh blobwriter' test:
 .nf
 netlink-notifier -t -D 30 -g -u 1 -x  -e exec,clone,exit  \\
 	-j json.log --exclude-dir-path=/bin:/sbin:/usr \\
 	--port=61061 --auth=none --reconnect=1"
 .fi
 .PP
-Run in a typical deployment (sock, munge, port 411, localhost, forever, 10 minute reconnect):
+To run in a typical deployment (sock, munge, port 411, localhost, forever, 10 minute reconnect):
 .nf
 netlink-notifier
 .fi

--- a/ldms/src/sampler/netlink/netlink-notifier.man
+++ b/ldms/src/sampler/netlink/netlink-notifier.man
@@ -95,6 +95,9 @@ The 'short' options do not override the exclude entirely options.
 	 If not set, the ProducerName field is not included in the stream formats produced.
 --format=N           change the format of messages to version N.
          If not set, the highest available format is used. See MESSAGE FORMATS.
+--jobid_file=FILE	look for job_id numbers in FILE. The default is not to look
+	for a job id file if this option is not given nor NOTIFIER_JOBID_FILE is defined.
+	See JOB ID FILES for details.
 .fi
 
 .SH ENVIRONMENT
@@ -115,6 +118,7 @@ NOTIFIER_LDMS_AUTH=munge
 NOTIFIER_FORMAT=2
 NOTIFIER_HEARTBEAT=(none)
 NOTIFIER_PURGE_TRACK_DIR
+NOTIFIER_JOBID_FILE=(none)
 .fi
 Omitting (nullexe):<unknown> from NOTIFIER_EXCLUDE_PROGRAMS may cause incomplete output
 related to processes no longer present. In exotic circumstances, this may be desirable.
@@ -137,6 +141,14 @@ Client applications may validate a file by checking the contents
 against the /proc/$pid/stat content, if it exists.
 Invalid files should be removed by clients or system scripts; the purge option
 is provided to optionally do this on start.
+
+.SH JOB ID FILES
+The job id file given must contain a list of KEY=VALUE pairs, one per line. Lines starting with # are ignored.
+If the filename given is "/search", a list of default locations is checked
+("/var/run/ldms_jobinfo.data", "/var/run/ldms.slurm.jobinfo", "/var/run/ldms.jobinfo").
+A list of variables in the jobid file is checked for, with the first found being used.
+The variable names checked are:
+"JOBID", "JOB_ID", "LSB_JOBID", "PBS_JOBID", "SLURM_JOBID", "SLURM_JOB_ID".
 
 .SH MESSAGE FORMATS
 Message formats tuned to SLURM, LSF, and Linux without a batch scheduler

--- a/ldms/src/sampler/netlink/netlink-notifier.man
+++ b/ldms/src/sampler/netlink/netlink-notifier.man
@@ -1,0 +1,189 @@
+.\" Manpage for netlink-notifier ldms-netlink-notifier
+.\" Contact ovis-help@ca.sandia.gov to correct errors or typos.
+.TH man 8 "25 June 2021" "v4.3" "netlink-notifier man page"
+
+.SH NAME
+ldms-netlink-notifier  \- Transmit Linux kernel netlink process life messages to ldmsd streams.
+
+ldms-notify            \- systemd service
+
+
+.SH SYNOPSIS
+ldms-netlink-notifier [OPTION...]
+
+.SH DESCRIPTION
+The netlink-notifier generates JSON message for ldmsd and JSON aware LDMS samplers.
+Its messages are mostly compatible with those from the slurm spank based notifier.
+
+.SH OPTIONS
+.nf
+-c	use task comm field for process name.
+-d	strip off directory path from process name.
+-D	specify run duration in seconds. If unspecified, run forever.
+-e	select which events to monitor.
+-E	equivalent to -e all.
+-g	show glyphs for event types in debug mode.
+-h	show this help.
+-i seconds	 time (float) to sleep between checks for processes exceeding the short dir filter time.
+		 If the -i value > the -m value, -i may effectively filter out additional processes.
+-j file	 file to log json messages and transmission status.
+-l	force stdout line buffering.
+-L file	log to file instead of stdout.
+-r	run with real time FIFO scheduler (available on some kernels).
+-s	show short process name in debugging.
+-S	suppress stream message publication.
+-t	show debugging trace messages.
+-u umin	ignore processes with uid < umin
+-v lvl  log level for stream library messages. Higher is quieter. Error messages are >= 3.
+-q	run quietly
+-x	show extra process information.
+-X	equivalent to -Egrx.
+The ldmsd connection and commonly uninteresting or short-lived processes may be specified with the options or environment variables below.
+The 'short' options do not override the exclude entirely options.
+--exclude-programs[=]<path>	 change the default value of exclude-programs
+	 When repeated, all values are concatenated.
+	 If given with no value, the default (nullexe):<unknown> is removed.
+	 If not given, the default is used unless
+	 the environment variable NOTIFIER_EXCLUDE_PROGRAMS is set.
+--exclude-dir-path[=]<path>	 change the default value of exclude-dir-path
+	 When repeated, all values are concatenated.
+	 If given with no value, the default /sbin is removed.
+	 If not given, the default is used unless
+	 the environment variable NOTIFIER_EXCLUDE_DIR_PATH is set.
+--exclude-short-path[=]<path>	 change the default value of exclude-short-path
+	 When repeated, all values are concatenated.
+	 If given with no value, the default /bin:/usr is removed.
+	 If not given, the default is used unless
+	 the environment variable NOTIFIER_EXCLUDE_SHORT_PATH is set.
+--exclude-short-time[=][val]	 change the default value of exclude-short-time.
+	 If repeated, the last value given wins.
+	 If given with no value, the default 1 becomes 0 unless
+	 the environment variable NOTIFIER_EXCLUDE_SHORT_TIME is set.
+--stream[=]<val>	 change the default value of stream.
+	 If repeated, the last value given wins.
+	 The default slurm is used if env NOTIFIER_LDMS_STREAM is not set.
+--xprt[=]<val>	 change the default value of xprt.
+	 If repeated, the last value given wins.
+	 The default sock is used if env NOTIFIER_LDMS_XPRT is not set.
+--host[=]<val>	 change the default value of host.
+	 If repeated, the last value given wins.
+	 The default localhost is used if env NOTIFIER_LDMS_HOST is not set.
+--port[=]<val>	 change the default value of port.
+	 If repeated, the last value given wins.
+	 The default 411 is used if env NOTIFIER_LDMS_PORT is not set.
+--auth[=]<val>	 change the default value of auth.
+	 If repeated, the last value given wins.
+	 The default munge is used if env NOTIFIER_LDMS_AUTH is not set.
+--reconnect[=]<val>	 change the default value of reconnect.
+	 If repeated, the last value given wins.
+	 The default 600 is used if env NOTIFIER_LDMS_RECONNECT is not set.
+--timeout[=]<val>	 change the default value of timeout.
+	 If repeated, the last value given wins.
+	 The default 1 is used if env NOTIFIER_LDMS_TIMEOUT is not set.
+--track-dir[=]<path>     change the pids published directory.
+	 The default is used if env NOTIFIER_TRACK_DIR is not set.
+	 The path given should be on a RAM-based file system for efficiency,
+	 and it should not contain any files except those created by
+	 this daemon. When enabled, track-dir will be populated even if
+	 -S is used to suppress the stream output.
+--component_id=<U64>     set the value of component_id.
+	 If not set, the component_id field is not included in the stream formats produced.
+--ProducerName=<name>    set the value of ProducerName
+	 If not set, the ProducerName field is not included in the stream formats produced.
+--format=N           change the format of messages to version N.
+         If not set, the highest available format is used. See MESSAGE FORMATS.
+.fi
+
+.SH ENVIRONMENT
+The following variables override defaults if a command line option is not present, as describe in the options section.
+.nf
+NOTIFIER_EXCLUDE_PROGRAMS="(nullexe):<unknown>"
+NOTIFIER_EXCLUDE_DIRS=/sbin
+NOTIFIER_EXCLUDE_SHORT_PATH=/bin:/usr
+NOTIFIER_EXCLUDE_SHORT_TIME=1
+NOTIFIER_TRACK_DIR=/var/run/ldms-netlink-tracked
+NOTIFIER_LDMS_RECONNECT=600
+NOTIFIER_LDMS_TIMEOUT=1
+NOTIFIER_LDMS_STREAM=slurm
+NOTIFIER_LDMS_XPRT=sock
+NOTIFIER_LDMS_HOST=localhost
+NOTIFIER_LDMS_PORT=411
+NOTIFIER_LDMS_AUTH=munge
+NOTIFIER_FORMAT=1
+NOTIFIER_HEARTBEAT=(none)
+.fi
+Omitting (nullexe):<unknown> from NOTIFIER_EXCLUDE_PROGRAMS may cause incomplete output
+related to processes no longer present. In exotic circumstances, this may be desirable anyway.
+
+.SH FILES
+
+Users or other processes may discover which processes are the subject of notifications
+by examining the files in
+
+/NOTIFIER_TRACK_DIR/*
+
+For each pid started event which would be emitted to an LDMS stream, a temporary
+file with the name of the pid is created in NOTIFIER_TRACK_DIR. The file
+will contain the json event attempted. The temporary file will
+be removed when the corresponding pid stopped event is sent.
+These files are not removed when the notifier daemon exits.
+Client applications may validate a file by checking the contents
+against the /proc/$pid/stat content, if it exists.
+Invalid files should be removed by clients or system scripts.
+
+.SH MESSAGE FORMATS
+Message formats tuned to SLURM, LSF, and Linux without a batch scheduler
+are published, based on what the notifier detects and the users choice of
+ProducerName and component_id. The version of the tuned formats is specified by number.
+.PP
+Format 0 omits the start time from slurm process end messages (since it is only sometimes known) and omits process duration, which depend on the start time.
+.PP
+Format 1 includes the start time for slurm process or the dummy value 0 when unknown) and includes process duration for all end messages. When the start time is unavailable, duration of -1.0 is published. Merging data from other sources may allow durations flagged as -1 to be computed in some later data cleanup step.
+
+
+.SH NOTES
+.PP
+The core of this utility is derived from forkstat(8).
+.PP
+The output of this utility, if used to drive a sampler, usually needs to be consumed on the same node.
+.PP
+If not used with a sampler, the --component_id or --ProducerName options are needed
+to add a node identifier to the messages. Normally a process-following sampler that creates sets
+will add the node identifier automatically.
+.PP
+When the daemon is started after a process is started, the process start time and therefore process
+duration may not be available. In message formats which report start time, 0 indicates
+data was unavailable. For processes without completely known time bounds, the duration is reported
+as -1.0.
+.PP
+Options are still in development. Several options affect only the trace output.
+
+.SH EXAMPLES
+.PP
+Run for 30 seconds with screen and json.log test output connecting to the ldmsd from 'ldms-static-test.sh blobwriter' test:
+.nf
+netlink-notifier -t -D 30 -g -u 1 -x  -e exec,clone,exit  \\
+	-j json.log --exclude-dir-path=/bin:/sbin:/usr \\
+	--port=61061 --auth=none --reconnect=1"
+.fi
+.PP
+Run in a typical deployment (sock, munge, port 411, localhost, forever, 10 minute reconnect):
+.nf
+netlink-notifier
+.fi
+.PP
+Run in a systemd .service wrapper, excluding root owned processes.
+.nf
+EnvironmentFile=-/etc/sysconfig/ldms-netlink-notifier.conf
+ExecStart=/usr/sbin/ldms-netlink-notifier -u 1 -x -e exec,clone,exit
+.fi
+.PP
+Run in a systemd .service wrapper, excluding root owned processes, with debugging files
+.nf
+EnvironmentFile=-/etc/sysconfig/ldms-netlink-notifier.conf
+ExecStart=/usr/sbin/ldms-netlink-notifier -u 1 -x -e exec,clone,exit -j /home/user/nl.json -L /home/user/nl.log -t --ProducerName=%H
+.fi
+
+
+.SH SEE ALSO
+forkstat(8), ldmsd(8), ldms-static-test(8)

--- a/ldms/src/sampler/netlink/netlink-notifier.man
+++ b/ldms/src/sampler/netlink/netlink-notifier.man
@@ -27,6 +27,7 @@ Its messages are mostly compatible with those from the slurm spank based notifie
 -i seconds	 time (float) to sleep between checks for processes exceeding the short dir filter time.
 		 If the -i value > the -m value, -i may effectively filter out additional processes.
 -j file	 file to log json messages and transmission status.
+-J file	 file to dump json messages format examples to.
 -l	force stdout line buffering.
 -L file	log to file instead of stdout.
 -r	run with real time FIFO scheduler (available on some kernels).
@@ -115,7 +116,7 @@ NOTIFIER_LDMS_XPRT=sock
 NOTIFIER_LDMS_HOST=localhost
 NOTIFIER_LDMS_PORT=411
 NOTIFIER_LDMS_AUTH=munge
-NOTIFIER_FORMAT=2
+NOTIFIER_FORMAT=3
 NOTIFIER_HEARTBEAT=(none)
 NOTIFIER_PURGE_TRACK_DIR
 NOTIFIER_JOBID_FILE=(none)
@@ -154,12 +155,16 @@ The variable names checked are:
 Message formats tuned to SLURM, LSF, and Linux without a batch scheduler
 are published, based on what the notifier detects and the users choice of
 ProducerName and component_id. The version of the tuned formats is specified by number.
+If started with the -J option, an example of each available message format it dumped to the
+specified file.
 .PP
 Format 0 omits the start time from slurm process end messages (since it is only sometimes known) and omits process duration, which depend on the start time.
 .PP
 Format 1 includes the start time for slurm process or the dummy value 0 when unknown) and includes process duration for all end messages. When the start time is unavailable, duration of -1.0 is published. Merging data from other sources may allow durations flagged as -1 to be computed in some later data cleanup step.
 .PP
 Format 2 extends process end messages with the executable name in field 'exe'. When this is not available, exe of '/no-exe-data' is published. Merging data from other sources may allow exe flagged as /no-exe-data to be computed in some later data cleanup step.
+.PP
+Format 3 harmonizes schemas across linux, slurm, and lsf task types so that all may be stored in common tables for task_exit and task_init events if slurm specific fields are omitted from the storage.
 
 
 .SH NOTES
@@ -178,7 +183,9 @@ start time, 0 indicates
 data was unavailable. For processes without completely known time bounds, the duration is reported
 as -1.0. For processes without known program paths, exe is reported as /no-exe-data.
 .PP
-Options are still in development. Several options affect only the trace output.
+Several options affect only the trace output.
+.PP
+The check for sufficient privilege occurs after -J and --help options are processed.
 
 .SH EXAMPLES
 .PP

--- a/ldms/src/sampler/netlink/netlink-notifier.man
+++ b/ldms/src/sampler/netlink/netlink-notifier.man
@@ -86,6 +86,9 @@ The 'short' options do not override the exclude entirely options.
 	 and it should not contain any files except those created by
 	 this daemon. When enabled, track-dir will be populated even if
 	 -S is used to suppress the stream output.
+--purge-track-dir	if track-dir is set, purge any files there
+	 which do not correspond to current processes.
+	 Equivalently, NOTIFIER_PURGE_TRACK_DIR may be set.
 --component_id=<U64>     set the value of component_id.
 	 If not set, the component_id field is not included in the stream formats produced.
 --ProducerName=<name>    set the value of ProducerName
@@ -111,9 +114,11 @@ NOTIFIER_LDMS_PORT=411
 NOTIFIER_LDMS_AUTH=munge
 NOTIFIER_FORMAT=2
 NOTIFIER_HEARTBEAT=(none)
+NOTIFIER_PURGE_TRACK_DIR
 .fi
 Omitting (nullexe):<unknown> from NOTIFIER_EXCLUDE_PROGRAMS may cause incomplete output
 related to processes no longer present. In exotic circumstances, this may be desirable.
+The value of NOTIFIER_PURGE_TRACK_DIR is not used to enable purge, just its presence.
 
 .SH FILES
 
@@ -126,10 +131,12 @@ For each pid started event which would be emitted to an LDMS stream, a temporary
 file with the name of the pid is created in NOTIFIER_TRACK_DIR. The file
 will contain the json event attempted. The temporary file will
 be removed when the corresponding pid stopped event is sent.
-These files are not removed when the notifier daemon exits.
+These files are not removed when the notifier daemon exits, so that
+they will be found after a restart.
 Client applications may validate a file by checking the contents
 against the /proc/$pid/stat content, if it exists.
-Invalid files should be removed by clients or system scripts.
+Invalid files should be removed by clients or system scripts; the purge option
+is provided to optionally do this on start.
 
 .SH MESSAGE FORMATS
 Message formats tuned to SLURM, LSF, and Linux without a batch scheduler

--- a/ldms/src/sampler/netlink/netlink-notifier.man
+++ b/ldms/src/sampler/netlink/netlink-notifier.man
@@ -95,7 +95,7 @@ The 'short' options do not override the exclude entirely options.
 	 If not set, the ProducerName field is not included in the stream formats produced.
 --format=N           change the format of messages to version N.
          If not set, the highest available format is used. See MESSAGE FORMATS.
---jobid_file=FILE	look for job_id numbers in FILE. The default is not to look
+--jobid-file=FILE	look for job_id numbers in FILE. The default is not to look
 	for a job id file if this option is not given nor NOTIFIER_JOBID_FILE is defined.
 	See JOB ID FILES for details.
 .fi


### PR DESCRIPTION
This cannot be tested and then merged until #1718 lands.

This pulls in (with some minor deconfliction) from b4.4

6a47d3
aabe40
2fb89
6c87bf
2d13
324e64
caeebe
92e524
9dd76c

At present, it is also still carrying the latest .man version of its documentation; this will have to be fixed with use of the appropriate conversion stack from @spwalto .