### PR TITLE
Make the strgp configuration parameter "container" optional

### DIFF
--- a/ldms/man/ldmsd_controller.rst
+++ b/ldms/man/ldmsd_controller.rst
@@ -686,7 +686,7 @@ Create a Storage Policy and open/create the storage instance.
       |
       | The name of the storage backend.
 
-   **container** *container*
+   **[container** *container*\ **]**
       |
       | The storage backend container name.
 

--- a/ldms/src/contrib/store/timescale/store_timescale.c
+++ b/ldms/src/contrib/store/timescale/store_timescale.c
@@ -311,6 +311,14 @@ open_store(ldmsd_plug_handle_t handle, const char *container, const char *schema
         char *measurement_create;
         size_t cnt_create, off_create;
 
+        if (!container) {
+                ovis_log(mylog, OVIS_LERROR,
+                     "Plugin %s requires \"container=\" to be set in the "
+                     "strgp_add command\n",
+                     ldmsd_plug_name_get(handle));
+                goto out;
+        }
+
         is = malloc(sizeof(*is) + measurement_limit);
         if (!is)
                 goto out;

--- a/ldms/src/contrib/store/tutorial/store_tutorial.c
+++ b/ldms/src/contrib/store/tutorial/store_tutorial.c
@@ -133,6 +133,14 @@ open_store(ldmsd_plug_handle_t s, const char *container, const char* schema,
 	char* path = NULL;
 	char* dpath = NULL;
 
+        if (!container) {
+                ovis_log(mylog, OVIS_LERROR,
+                     "Plugin %s requires \"container=\" to be set in the "
+                     "strgp_add command\n",
+                     ldmsd_plug_name_get(s));
+                return NULL;
+        }
+
 	pthread_mutex_lock(&cfg_lock);
 	if (!root_path) {
 	     ovis_log(mylog, OVIS_LERROR, PNAME ": config not called. cannot open.\n");

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -2672,8 +2672,8 @@ static int strgp_add_handler(ldmsd_req_ctxt_t reqc)
 
 	attr_name = "container";
 	container = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_CONTAINER);
-	if (!container)
-		goto einval;
+        /* We allow container to be NULL. Some stores, like store_avro_kafka, can
+           configure their server settings in the store configuration. */
 
 	schema = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_SCHEMA);
 	regex = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_REGEX);
@@ -2763,9 +2763,13 @@ static int strgp_add_handler(ldmsd_req_ctxt_t reqc)
 			goto enomem;
 	}
 
-	strgp->container = strdup(container);
-	if (!strgp->container)
-		goto enomem;
+        if (container) {
+                strgp->container = strdup(container);
+                if (!strgp->container)
+                        goto enomem;
+        } else {
+                strgp->container = NULL;
+        }
 
 	strgp->flush_interval = flush_interval;
 

--- a/ldms/src/store/avro_kafka/ldms-store_avro_kafka.rst
+++ b/ldms/src/store/avro_kafka/ldms-store_avro_kafka.rst
@@ -111,9 +111,8 @@ store_avro_kafka as the plugin parameter.
 
 The *schema*, *instance*, *producer* and *flush* strgp_add parameters
 have no affect on how data is stored. If the *container* parameter is
-set to any value other than an empty string, it will override the
-bootstrap.servers Kafka configuration parameter in the kafka_conf file
-if present.
+set, it will override the bootstrap.servers Kafka configuration parameter
+in the kafka_conf file if present.
 
 JSON Mode
 =========
@@ -293,9 +292,7 @@ serdes_conf Example File
 
    ::
 
-      # Specify the location of the Avro Schema registry. This can be overridden
-      # on the strgp_add line with the "container" strgp_add option if it is
-      # set to anything other than an empty string
+      # Specify the location of the Avro Schema registry.
       serdes.schema.url=https://localhost:8081
 
 Example strg_add command
@@ -309,14 +306,13 @@ Example strg_add command
 Example strg_add command w/o container
 --------------------------------------
 
-In this example, the strgp_add parameter, container, is set to be
-ignored by store_avro_kafka. In this case, either the default,
-localhost:9092, or the value specified in the rd_kafka_conf file is
-used.
+In this example, the strgp_add parameter "container" is not set. In this case,
+either the default, localhost:9092, or the value specified in the rd_kafka_conf
+file is used.
 
    ::
 
-      strgp_add name=aks plugin=store_avro_kafka container= decomposition=aks-decomp.conf
+      strgp_add name=aks plugin=store_avro_kafka decomposition=aks-decomp.conf
       strgp_start name=aks
 
 Example plugin configuration

--- a/ldms/src/store/influx/store_influx.c
+++ b/ldms/src/store/influx/store_influx.c
@@ -208,6 +208,14 @@ open_store(ldmsd_plug_handle_t s, const char *container, const char *schema,
 {
 	struct influx_store *is = NULL;
 
+        if (!container) {
+                ovis_log(ldmsd_plug_log_get(handle), OVIS_LERROR,
+                     "Plugin %s requires \"container=\" to be set in the "
+                     "strgp_add command\n",
+                     ldmsd_plug_name_get(s));
+                goto out;
+        }
+
 	is = malloc(sizeof(*is) + measurement_limit);
 	if (!is)
 		goto out;

--- a/ldms/src/store/papi/store_papi.c
+++ b/ldms/src/store/papi/store_papi.c
@@ -454,7 +454,17 @@ static ldmsd_store_handle_t
 open_store(ldmsd_plug_handle_t s, const char *container, const char *schema,
 	   struct ldmsd_strgp_metric_list *metric_list)
 {
-	struct sos_instance *si = calloc(1, sizeof(*si));
+	struct sos_instance *si;
+
+        if (!container) {
+                LOG_(OVIS_LERROR,
+                     "Plugin %s requires \"container=\" to be set in the "
+                     "strgp_add command\n",
+                     ldmsd_plug_name_get(s));
+                goto out;
+        }
+
+	si = calloc(1, sizeof(*si));
 	if (!si)
 		goto out;
 	si->container = strdup(container);

--- a/ldms/src/store/slurm/store_slurm.c
+++ b/ldms/src/store/slurm/store_slurm.c
@@ -485,6 +485,14 @@ open_store(ldmsd_plug_handle_t s, const char *container, const char *schema,
 {
 	struct sos_instance *si = NULL;
 
+        if (!container) {
+                LOG_(OVIS_LERROR,
+                     "Plugin %s requires \"container=\" to be set in the "
+                     "strgp_add command\n",
+                     ldmsd_plug_name_get(s));
+                goto out;
+        }
+
 	si = calloc(1, sizeof(*si));
 	if (!si)
 		goto out;

--- a/ldms/src/store/store_amqp.c
+++ b/ldms/src/store/store_amqp.c
@@ -425,6 +425,13 @@ open_store(ldmsd_plug_handle_t s, const char *container, const char *schema,
 	struct rbn *rbn;
 	amqp_rpc_reply_t qrc;
 
+        if (!container) {
+                LERR("Plugin %s requires \"container=\" to be set in the "
+                     "strgp_add command\n",
+                     ldmsd_plug_name_get(s));
+                return NULL;
+        }
+
 	pthread_mutex_lock(&cfg_lock);
 	rbn = rbt_find(&amqp_rbt, container);
 	if (!rbn) {

--- a/ldms/src/store/store_csv.c
+++ b/ldms/src/store/store_csv.c
@@ -1012,6 +1012,14 @@ open_store(ldmsd_plug_handle_t handle, const char *container, const char* schema
 	store_csv_t sc = ldmsd_plug_ctxt_get(handle);
 	struct csv_store_handle *s_handle = NULL;
 
+        if (!container) {
+                ovis_log(mylog, OVIS_LERROR,
+                     "Plugin %s requires \"container=\" to be set in the "
+                     "strgp_add command\n",
+                     ldmsd_plug_name_get(handle));
+                return NULL;
+        }
+
 	if (!sc->pa) {
 		ovis_log(mylog, OVIS_LERROR, "config not called. cannot open.\n");
 		return NULL;

--- a/ldms/src/store/store_flatfile/store_flatfile.c
+++ b/ldms/src/store/store_flatfile/store_flatfile.c
@@ -142,6 +142,14 @@ static ldmsd_store_handle_t
 	char *key = NULL;
 	size_t len;
 
+        if (!container) {
+                ovis_log(mylog, OVIS_LERROR,
+                     "Plugin %s requires \"container=\" to be set in the "
+                     "strgp_add command\n",
+                     ldmsd_plug_name_get(scfg));
+                return NULL;
+        }
+
 	len = strlen(container) + strlen(schema) + 2;
 	key = malloc(len);
 	if (!key) {

--- a/ldms/src/store/store_function_csv.c
+++ b/ldms/src/store/store_function_csv.c
@@ -1293,6 +1293,14 @@ open_store(ldmsd_plug_handle_t scfg, const char *container, const char* schema,
 	int rc = 0;
 	int i;
 
+        if (!container) {
+                ovis_log(mylog, OVIS_LERROR,
+                     "Plugin %s requires \"container=\" to be set in the "
+                     "strgp_add command\n",
+                     ldmsd_plug_name_get(scfg));
+                return NULL;
+        }
+
 	pthread_mutex_lock(&cfg_lock);
 	skey = allocStoreKey(container, schema);
 	if (skey == NULL){

--- a/ldms/src/store/store_rabbitkw.c
+++ b/ldms/src/store/store_rabbitkw.c
@@ -913,6 +913,14 @@ open_store(ldmsd_plug_handle_t s, const char *container, const char *schema,
 {
 	struct rabbitkw_store_instance *si;
 
+        if (!container) {
+                ovis_log(mylog, OVIS_LERROR,
+                     "Plugin %s requires \"container=\" to be set in the "
+                     "strgp_add command\n",
+                     ldmsd_plug_name_get(s));
+                return NULL;
+        }
+
 	pthread_mutex_lock(&cfg_lock);
 	dsinit(ds);
 	dscat(ds,container);

--- a/ldms/src/store/store_rabbitv3.c
+++ b/ldms/src/store/store_rabbitv3.c
@@ -952,6 +952,14 @@ open_store(ldmsd_plug_handle_t handle, const char *container, const char *schema
 	struct rabbitv3_store_instance *si;
 	struct rabbitv3_metric_store *ms;
 
+        if (!container) {
+                ovis_log(mylog, OVIS_LERROR,
+                     "Plugin %s requires \"container=\" to be set in the "
+                     "strgp_add command\n",
+                     ldmsd_plug_name_get(handle));
+                return NULL;
+        }
+
 	pthread_mutex_lock(&cfg_lock);
 	dsinit(ds);
 	dscat(ds,container);

--- a/ldms/src/store/store_sos.c
+++ b/ldms/src/store/store_sos.c
@@ -620,7 +620,15 @@ open_store(ldmsd_plug_handle_t handle, const char *container, const char *schema
         store_sos_t ss = ldmsd_plug_ctxt_get(handle);
 	struct sos_instance *si = NULL;
 
-	si = calloc(1, sizeof(*si));
+        if (!container) {
+                LOG_(OVIS_LERROR,
+                     "Plugin %s requires \"container=\" to be set in the "
+                     "strgp_add command\n",
+                     ldmsd_plug_name_get(handle));
+                goto out;
+        }
+
+        si = calloc(1, sizeof(*si));
 	if (!si)
 		goto out;
 	rbt_init(&si->schema_rbt, row_schema_rbn_cmp);
@@ -1450,6 +1458,15 @@ static int init_store_instance(ldmsd_plug_handle_t handle, ldmsd_strgp_t strgp)
 	struct sos_instance *si;
 	store_sos_t ss = ldmsd_plug_ctxt_get(handle);
 	int len, rc;
+
+        if (!strgp->container) {
+                LOG_(OVIS_LERROR,
+                     "Plugin %s requires \"container=\" to be set in the "
+                     "strgp_add command\n",
+                     ldmsd_plug_name_get(handle));
+                rc = EINVAL;
+                goto err_0;
+        }
 
 	si = calloc(1, sizeof(*si));
 	if (!si) {


### PR DESCRIPTION
Make the strgp configuration parameter "container" optional so that store_avro_kafka can use its internally configured server information.

Add checks to the rest of the stores to make sure that container is not NULL.
