### PR TITLE
Multi instance support for YAML parser

### DIFF
--- a/ldms/python/ldmsd/ldmsd_yaml_parser
+++ b/ldms/python/ldmsd/ldmsd_yaml_parser
@@ -9,13 +9,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='LDMS Monitoring YAML Cluster Configuration Parser')
     required = parser.add_argument_group('required arguments')
-    required.add_argument('--ldms-config', metavar='FILE', required=True,
+    required.add_argument('--ldms_config', metavar='FILE', required=True,
                         help='Path to LDMSD YAML configuration file. ')
-    parser.add_argument('--generate-config-path', metavar="STRING", required=False,
+    parser.add_argument('--generate_config_path', metavar="STRING", required=False,
                         help='Path to directory to store generated v4 configuration files for an entire LDMS cluster. '
                              'Samplers with similar configurations share a single configuration file. ',
                         default=False)
-    parser.add_argument('--daemon-name', metavar='STRING', required=False,
+    parser.add_argument('--daemon_name', metavar='STRING', required=False,
                         default=False,
                         help='Daemon name to generate configuration from YAML file')
     parser.add_argument('--debug', action='store_true',
@@ -30,9 +30,9 @@ if __name__ == "__main__":
     cluster = YamlCfg(None, None, conf_spec, args)
 
     if args.daemon_name and args.generate_config_path:
-        print(f'Parameters "daemon-name" and "generate-config-path" are mutually exclusive.\n'
+        print(f'Parameters "daemon_name" and "generate_config_path" are mutually exclusive.\n'
               f'Specifying the "daemon-name" parameter will generate the configuration for a single ldmsd\n'
-              f'Specifying the "generate-config-path" parameter will generate an entire cluster\'s v4 configuration files in the path provided.\n')
+              f'Specifying the "generate_config_path" parameter will generate an entire cluster\'s v4 configuration files in the path provided.\n')
         sys.exit(0)
 
     if args.daemon_name:

--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -2238,6 +2238,7 @@ int main(int argc, char *argv[])
 					snprintf(errstr, sizeof(errstr),
 					"Error %d processing configuration file '%s'",
 					ret, ypath);
+					cleanup(ret, errstr);
 				}
 				TAILQ_REMOVE(&yamlfile_list, conf_str, entry);
 				ldmsd_str_ent_free(conf_str);

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -1085,7 +1085,7 @@ char *__process_yaml_config_file(const char *path, const char *dname)
 	char command[512];
 	size_t buf_sz = 4096;
 	char *cfg_str = malloc(buf_sz);
-	snprintf(command, sizeof(command), "ldmsd_yaml_parser --ldms-config %s --daemon-name %s", path, dname);
+	snprintf(command, sizeof(command), "ldmsd_yaml_parser --ldms_config %s --daemon_name %s", path, dname);
 	fp = popen(command, "r");
 	if (!fp) {
 		ovis_log(config_log, OVIS_LERROR, "Error opening pipe to ldmsd_yaml_parser.\n");


### PR DESCRIPTION
Support for multi-instance plugins in YAML.
Normalize parameter names to use underscores.
Bug fix for LDMSD continuing to run after an error is encountered in a configuration file.