### PR TITLE
Undeprecate `stream_status` and `prdcr_stream_status`

### DIFF
--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -588,9 +588,6 @@ class LdmsdCmdParser(cmd.Cmd):
         Parameters:
         regex=     A regular expression matching producer names
         """
-        print("prdcr_stream_status is deprecated")
-        return
-        # DEPRECATED
         FIRST = "first_ts"
         LAST = "last_ts"
         RATE = "bytes/sec"
@@ -2530,9 +2527,6 @@ class LdmsdCmdParser(cmd.Cmd):
         [reset=]     If true, reset the statistics of all streams after returning the values.
                      The default is false.
         """
-        print("stream_status is deprecated")
-        return
-        # DEPRECATED
         FIRST = "first_ts"
         LAST = "last_ts"
         RATE = "bytes/sec"


### PR DESCRIPTION
Undeprecate `stream_status` and `prdcr_stream_status` commands.

This has passed the updated test: https://github.com/ovis-hpc/ldms-test/blob/main-dev/ldmsd_stream_status_test