### PR TITLE
Prevent use-after-free in stream publisher RBN key

### DIFF
--- a/ldms/src/ldmsd/ldmsd_stream.c
+++ b/ldms/src/ldmsd/ldmsd_stream.c
@@ -122,7 +122,7 @@ static struct ldmsd_stream_publisher_s *__new_publisher(const char *name)
 	p->p_name = strdup(name);
 	if (!p->p_name)
 		goto err;
-	rbn_init(&p->p_ent, (char*)name);
+	rbn_init(&p->p_ent, (char*)p->p_name);
 	return p;
 err:
 	__free_publisher(p);


### PR DESCRIPTION
The pull request ports https://github.com/ovis-hpc/ldms/commit/71bc6c6b2be06d95c96bae6ec19e333ac05ee4b3 from `b4.4`.