### PR TITLE
Improve rst2man detection and build messages

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,7 @@ AC_ARG_VAR([RST2MAN], [rst2man command])
 AC_CHECK_PROG([RST2MAN], [rst2man], [rst2man], [no])
 AS_IF([test "x$RST2MAN" = "xno"],
       [AC_MSG_ERROR([rst2man not found. Please install python3-docutils package.])])
-AM_CONDITIONAL([HAVE_RST2MAN], [test "x$RST2MAN" = xrst2man])
+AM_CONDITIONAL([HAVE_RST2MAN], [test "x$RST2MAN" != "xno"])
 
 OVIS_PKGLIBDIR
 

--- a/ldms/rules.mk
+++ b/ldms/rules.mk
@@ -4,10 +4,14 @@
 # 	Ex: \fB\-a,\fP\fI\-\-default_auth\fP --> \fB-a,\fP\fI--default_auth\fP
 # 3. Remove lines with unnecessary rst2man output.
 # 	Ex: .de1 rstReportMargin, \\$1 \\n[an-margin], level \\n[rst2man-indent-level], .de1 INDENT,. RS \\$1, .de UNINDENT
+# The AM_V_P logic allows the output to be quiet when using "configure --enable-silent-rules"
+# or "make V=0" (default behavior), and be verbose when using "configure --disable-silent-rules"
+# or "make V=1".
 %.man: %.rst
-	@echo "Generating $@..."
-	@mkdir -p $(dir $@)
-	@sed -e 's/:ref:`\([^`]*\)<[^`]*>`/\1/g' $< | rst2man | sed -e 's/\\\([`'\''\-]\)/\1/g' \
+	@set -e; \
+	if $(AM_V_P); then set -x; else echo "  RST2MAN  $@"; fi; \
+	mkdir -p $(dir $@); \
+	sed -e 's/:ref:`\([^`]*\)<[^`]*>`/\1/g' $< | @RST2MAN@ | sed -e 's/\\\([`'\''\-]\)/\1/g' \
 		-e '/rst2man/d' \
 		-e '/rstR/d' \
 		-e '/. RS/d' \


### PR DESCRIPTION
Allow the RST2MAN variable to point to be used in rules.mk.

Add AM_V_P logic that allows both quiet and verbose output when generating man pages.

Fixes #1760