### PR TITLE
Use sampler name, rather than system hostname when generating v4 config file

### DIFF
--- a/ldms/python/ldmsd/parser_util.py
+++ b/ldms/python/ldmsd/parser_util.py
@@ -963,9 +963,9 @@ class YamlCfg(object):
                             if first:
                                 first = False
                                 if 'producer' not in cfg_args:
-                                    cfg_args['producer'] = f'{hostname}'
+                                    cfg_args['producer'] = f'{sname}'
                                 if 'instance' not in cfg_args:
-                                    cfg_args['instance'] = f'{hostname}/{plugin}'
+                                    cfg_args['instance'] = f'{sname}/{plugin}'
                             cfg_str = parse_to_cfg_str(cfg_args)
                         else:
                             cfg_str = cfg_


### PR DESCRIPTION
Updates the YAML parser to use the sampler name as the producer and instance names of a plugin when generating v4 configuration files with ldmsd_yaml_parser.

Before this patch if a user attempted to generate configuration files for multiple samplers on a single machine and failed to specify producer/instance names, the producer would be set to the hostname of the machine that generated the configuration file.