### PR TITLE
add a note about debugfs for lustre plugins.

### DIFF
--- a/ldms/src/sampler/lustre/ldms-sampler_lustre2_client.rst
+++ b/ldms/src/sampler/lustre/ldms-sampler_lustre2_client.rst
@@ -22,6 +22,10 @@ DESCRIPTION
 ===========
 
 The lustre2_client plugin provides Lustre metric information.
+The debugfs filesystem must be mounted for lustre
+data access, which is also usually restricted to the root user.
+
+
 
 CONFIGURATION ATTRIBUTE SYNTAX
 ==============================

--- a/ldms/src/sampler/lustre_client/ldms-sampler_lustre_client.rst
+++ b/ldms/src/sampler/lustre_client/ldms-sampler_lustre_client.rst
@@ -33,8 +33,9 @@ set to the hostname by default, and the metric set instance names are
 derived from the llite instance name. Any user-supplied configuration
 values not documented here will be ignored.
 
-This plugin should work with at least Lustre versions 2.8, 2.10, and
-2.12.
+This plugin should work with at least Lustre versions 2.8, 2.10,
+2.12 and 2.15. The debugfs filesystem must be mounted for lustre
+data access, which is also usually restricted to the root user.
 
 CONFIGURATION ATTRIBUTE SYNTAX
 ==============================

--- a/ldms/src/sampler/lustre_mdc/ldms-sampler_lustre_mdc.rst
+++ b/ldms/src/sampler/lustre_mdc/ldms-sampler_lustre_mdc.rst
@@ -30,8 +30,9 @@ access to the lustre files in ``/proc/fs/lustre/mdc/*/md_stats`` and
 ``/sys/kernel/debug/lustre/mdc/*/stats``. The metric sets will have instance
 names combining the producer name and the mdc name.
 
-This plugin will work with Lustre versions 2.12 and others which share
-these file locations and formats.
+This plugin should work with at least Lustre versions
+2.12 and 2.15. The debugfs filesystem must be mounted for lustre
+data access, which is also usually restricted to the root user.
 
 CONFIGURATION ATTRIBUTE SYNTAX
 ==============================

--- a/ldms/src/sampler/lustre_mdt/ldms-sampler_lustre_mdt.rst
+++ b/ldms/src/sampler/lustre_mdt/ldms-sampler_lustre_mdt.rst
@@ -43,8 +43,9 @@ This plugin currently employs zero configuration. Any user-supplied
 configuration values will be ignored. Future versions may add
 configuration options.
 
-This plugin should work with at least Lustre versions 2.8, 2.10, and
-2.12.
+This plugin should work with at least Lustre versions 2.8, 2.10,
+2.12 and 2.15. The debugfs filesystem must be mounted for lustre
+data access, which is also usually restricted to the root user.
 
 CONFIGURATION ATTRIBUTE SYNTAX
 ==============================

--- a/ldms/src/sampler/lustre_ost/ldms-sampler_lustre_ost.rst
+++ b/ldms/src/sampler/lustre_ost/ldms-sampler_lustre_ost.rst
@@ -43,8 +43,9 @@ This plugin currently employs zero configuration. Any user-supplied
 configuration values will be ignored. Future versions may add
 configuration options.
 
-This plugin should work with at least Lustre versions 2.8, 2.10, and
-2.12.
+This plugin should work with at least Lustre versions 2.8, 2.10,
+2.12 and 2.15. The debugfs filesystem must be mounted for lustre
+data access, which is also usually restricted to the root user.
 
 CONFIGURATION ATTRIBUTE SYNTAX
 ==============================


### PR DESCRIPTION
This adds a reminder of the need for debugfs and root when using the lustre plugins to the related man pages.