### PR TITLE
Fix static string size bug in store_timescale

### DIFF
--- a/ldms/src/contrib/store/timescale/store_timescale.c
+++ b/ldms/src/contrib/store/timescale/store_timescale.c
@@ -325,7 +325,7 @@ open_store(ldmsd_plug_handle_t handle, const char *container, const char *schema
         is->job_mid = -1;
         is->comp_mid = -1;
 
-        char str[128];
+        char str[256];
         snprintf(str, sizeof(str), "user=%s password=%s hostaddr=%s port=%s dbname=%s",
 		 strdup(user), password, strdup(hostaddr), strdup(port), strdup(dbname));
 


### PR DESCRIPTION
There is a compile error when built with -Wall -Werror. The host in the format is a static string that is 100 bytes. That with the other elements of the format couuld exceed 128 resulting in truncated output.