### PR TITLE
`prdcr_subscribe/unsubscribe` command to `stream` and `message_channel` separation

### DIFF
--- a/ldms/man/ldmsd_controller.rst
+++ b/ldms/man/ldmsd_controller.rst
@@ -463,23 +463,52 @@ Disable the LDMS Message Service subscription and publication in this daemon.
 Once this is disabled, all LDMS Messages will be dropped. The LDMS Message
 Service cannot be re-enabled without restarting the daemon.
 
+Subscribe to a stream or LDMS message service on matching producers
+-------------------------------------------------------------------
 
-Subscribe for stream and/or message data from all matching producers
---------------------------------------------------------------------
+**prdcr_subscribe** attr=<value>
 
-**prdcr_subsribe** attr=<value>
-
-   **regex** *regex*
+   **regex** *PRDCR_REGEX*
       |
-      | The regular expression matching producer name
+      | A regular expression matching PRODUCER names
 
-   **stream** *stream*
+   **stream** *STREAM_NAME*
       |
-      | The stream name
+      | For ldmsd stream subscription, this is the ldmsd stream name. This is
+      | mutually exclusive to **message_channel** attribute.
 
-   **message_channel** *NAME_REGEX*
+   **message_channel** *CHANNEL_NAME_OR_REGEX*
       |
-      | The message channel name or regular expression of message channels
+      | For LDMS message subscription, this is the message channel name or
+      | a regular expression matching the message channel name. This is
+      | mutually exclusive to **stream** attribute.
+
+   **[rx_rate** *BYTES_PER_SECOND*\ **]**
+      |
+      | The recv rate (bytes/sec) limit for the matching message channels. The
+      | default is -1 (unlimited).
+
+
+Unsubscribe a stream or message service
+---------------------------------------
+
+**prdcr_subscribe** attr=<value>
+
+   **regex** *PRDCR_REGEX*
+      |
+      | A regular expression matching PRODUCER names
+
+   **stream** *STREAM_NAME*
+      |
+      | For ldmsd stream unsubscription, this is the ldmsd stream name. This is
+      | mutually exclusive to **message_channel** attribute.
+
+   **message_channel** *CHANNEL_NAME_OR_REGEX*
+      |
+      | For LDMS message unsubscription, this is the message channel name or
+      | a regular expression matching the message channel name previously
+      | specified in the **prdcr_subscription** command. This is mutually
+      | exclusive to **stream** attribute.
 
 
 UPDATER COMMAND SYNTAX
@@ -822,8 +851,8 @@ Publish data to the named stream
       |
       | The data to publish
 
-Subscribe to a stream on matching producers
--------------------------------------------
+Subscribe to a stream or LDMS message service on matching producers
+-------------------------------------------------------------------
 
 **prdcr_subscribe** attr=<value>
 
@@ -831,14 +860,42 @@ Subscribe to a stream on matching producers
       |
       | A regular expression matching PRODUCER names
 
-   **stream** *STREAM_NAME_OR_REGEX*
+   **stream** *STREAM_NAME*
       |
-      | The stream name or regular expression
+      | For ldmsd stream subscription, this is the ldmsd stream name. This is
+      | mutually exclusive to **message_channel** attribute.
+
+   **message_channel** *CHANNEL_NAME_OR_REGEX*
+      |
+      | For LDMS message subscription, this is the message channel name or
+      | a regular expression matching the message channel name. This is
+      | mutually exclusive to **stream** attribute.
 
    **[rx_rate** *BYTES_PER_SECOND*\ **]**
       |
-      | The recv rate (bytes/sec) limit for the matching streams. The
-        default is -1 (unlimited).
+      | The recv rate (bytes/sec) limit for the matching message channels. The
+      | default is -1 (unlimited).
+
+Unsubscribe a stream or message service
+---------------------------------------
+
+**prdcr_subscribe** attr=<value>
+
+   **regex** *PRDCR_REGEX*
+      |
+      | A regular expression matching PRODUCER names
+
+   **stream** *STREAM_NAME*
+      |
+      | For ldmsd stream unsubscription, this is the ldmsd stream name. This is
+      | mutually exclusive to **message_channel** attribute.
+
+   **message_channel** *CHANNEL_NAME_OR_REGEX*
+      |
+      | For LDMS message unsubscription, this is the message channel name or
+      | a regular expression matching the message channel name previously
+      | specified in the **prdcr_subscription** command. This is mutually
+      | exclusive to **stream** attribute.
 
 LDMS DAEMON COMMAND SYNTAX
 ==========================

--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -2418,13 +2418,14 @@ class Communicator(object):
         - status is an errno from the errno module
         - data is an error message if status != 0 or None
         """
-        req = LDMSD_Request(command_id = LDMSD_Request.PRDCR_SUBSCRIBE,
-                attrs = [
-                    LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.REGEX, value=regex),
-                    LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.STREAM, value=stream),
-                    LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.MSG_CHAN, value=msg_chan),
-                    LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.RX_RATE, value=str(int(rx_rate)))
-                ])
+        attrs = [ LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.REGEX, value=regex) ]
+        if stream is not None:
+            attrs.append(LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.STREAM, value=stream))
+        if msg_chan is not None:
+            attrs.append(LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.MSG_CHAN, value=msg_chan))
+        if rx_rate is not None:
+            attrs.append(LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.RX_RATE, value=str(int(rx_rate))))
+        req = LDMSD_Request(command_id = LDMSD_Request.PRDCR_SUBSCRIBE, attrs = attrs)
         try:
             req.send(self)
             resp = req.receive(self)

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -546,9 +546,11 @@ class LdmsdCmdParser(cmd.Cmd):
 
         Parameters:
         regex=     A regular expression matching PRODUCER names
-        [stream=]    The stream name
+        [stream=]  The stream name. This attribute cannot be specified at the
+                   same time with `message_channel`.
         [message_channel=]
-                   The message channel name or regular expression
+                   The message channel name or regular expression. This
+                   attribute cannot be specified at the same time with `stream`.
         [rx_rate=] The recv rate (bytes/sec) limit for the matching streams. The
                    default is -1 (unlimited).
         """
@@ -567,10 +569,15 @@ class LdmsdCmdParser(cmd.Cmd):
 
     def do_prdcr_unsubscribe(self, arg):
         """
-        Subscribe for stream data from all matching producers
+        Unsubscribe the stream or message service from all matching producers
         Parameters:
         regex=     A regular expression matching producer names
-        stream=    The stream name
+        [stream=]  The stream name. This attribute cannot be specified at the
+                   same time with `message_channel`.
+        [message_channel=]
+                   The message channel name or regular expression previously
+                   specified in the `prdcr_subscribe` command. This attribute
+                   cannot be specified at the same time with `stream`.
         """
         arg = self.handle_args('prdcr_unsubscribe', arg)
         if arg:

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -2160,7 +2160,14 @@ static int prdcr_subscribe_regex_handler(ldmsd_req_ctxt_t reqc)
 	if (!stream_name && !msg) {
 		reqc->errcode = EINVAL;
 		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
-				"One of the 'stream' or `msg` attributes is required by prdcr_subscribe_regex (can specify both).");
+				"One of the 'stream' or `msg` attributes is required.");
+		goto send_reply;
+	}
+
+	if (stream_name && msg) {
+		reqc->errcode = EINVAL;
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+				"Only one of the 'stream' or `msg` attributes can be specified.");
 		goto send_reply;
 	}
 
@@ -2202,10 +2209,18 @@ static int prdcr_unsubscribe_regex_handler(ldmsd_req_ctxt_t reqc)
 
 	stream_name = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_STREAM);
 	msg = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_MSG_CHAN);
+
 	if (!stream_name && !msg) {
 		reqc->errcode = EINVAL;
 		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
-				"One of the 'stream' or `msg` attributes is required by prdcr_unsubscribe_regex (can specify both).");
+				"One of the 'stream' or `msg` attributes is required.");
+		goto send_reply;
+	}
+
+	if (stream_name && msg) {
+		reqc->errcode = EINVAL;
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+				"Only one of the 'stream' or `msg` attributes can be specified.");
 		goto send_reply;
 	}
 


### PR DESCRIPTION
Separate `stream` and `message_channel` subscription/unsubscription request for clarity (also easier to manage internally). Also update documentation to reflect this change.