### PR TITLE
Fix the sq_depth section of xprt_stats output

### DIFF
--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -2388,7 +2388,9 @@ class LdmsdCmdParser(cmd.Cmd):
         sorted_rails = sort_rails_stats(stats['rails'])
 
         for r in sorted_rails:
-            print(f"{r.get('remote_host', 'No remote host'):20}")
+            if 'remote_host' not in r or not r['remote_host']:
+                continue
+            print(f"{r['remote_host']:20}")
             if 'endpoints' in r and r['endpoints']:
                 for ep_host, _d in r['endpoints'].items():
                     print(f"   {ep_host:20} {_d['sq_sz']:10}")

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -7128,8 +7128,7 @@ static char *__xprt_stats_as_json(size_t *json_sz, int reset, int level)
 
 			ep_res = &rent->rail.eps_stats[i];
 			if (ep_res->state == LDMS_XPRT_STATS_S_CONNECT) {
-				__APPEND("    %s\"%s:%s\":{", ((!first_ep)?",":""),
-						ep_res->rhostname, ep_res->rport_no);
+				__APPEND("    %s\"ep%d\":{", ((!first_ep)?",":""), i);
 				__APPEND("     \"sq_sz\":%ld", ep_res->ep.sq_sz);
 				__APPEND("  }");
 				first_ep = 0;


### PR DESCRIPTION
Without the patch, ldmsd creates duplicated keys of hostname of the endpoints in a rail, so ldmsd_controller only receives the send queue depth of the last endpoint in a rail. The patch fixes this. It also changes ldmsd_controller:display_xprt_stats() such that it reports the send queue depth of connected connections and skip the disconnected ones. Before the patch, the disconnected connection is represented by "No remote hostname", which confuses the readers.