### PR TITLE
Fix stream_client_dump_handler

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -8407,7 +8407,7 @@ static int stream_client_dump_handler(ldmsd_req_ctxt_t reqc)
 		free(reset_s);
 	}
 
-	s = ldmsd_stream_dir_dump();
+	s = ldmsd_stream_client_dump();
 	if (!s) {
 		reqc->errcode = errno;
 		rc = snprintf(reqc->line_buf, reqc->line_len,


### PR DESCRIPTION
The handler calls the wrong API to get the client list. The patch fixes the function to call the correct API.