### PR TITLE
Make the default quota option name consistent 

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -111,7 +111,7 @@ struct option long_opts[] = {
 	{ "kernel_file",           required_argument, 0,  's' },
 	{ "log_level",             required_argument, 0,  'v' },
 	{ "log_config",            required_argument, 0,  'L' },
-	{ "quota",                 required_argument, 0,  'C' },
+	{ "default_quota",         required_argument, 0,  'C' },
 	{ 0,                       0,                 0,  0 }
 };
 


### PR DESCRIPTION
Without the patch, 'quota' must be used to set the default quota in YAML configuration files, but 'default_quota' must be used in ldmsd configuration file.