### PR TITLE
Address bugs in the prdcr_listen path in parser_util.py

### DIFF
--- a/ldms/python/ldmsd/parser_util.py
+++ b/ldms/python/ldmsd/parser_util.py
@@ -110,6 +110,8 @@ def check_opt(attr, spec):
             attr = 'name'
         if 'auth' in spec:
             spec = spec['auth']
+        else:
+            return None
     if attr in spec:
         if attr in INT_ATTRS:
             return check_intrvl_str(spec[attr])
@@ -416,7 +418,8 @@ class YamlCfg(object):
             reconnect = check_opt('reconnect', pl)
             adv_xprt = check_opt('advertiser_xprt', pl)
             adv_port = check_opt('advertiser_port', pl)
-            adv_auth = check_opt('advertiser_auth', pl)
+            # adv_auth = check_opt('advertiser_auth', pl)
+            auth_name, plugin, auth_opt = check_auth(pl)
             node_listen[pl['name']] = { 'reconnect'     : reconnect,
                                         'disable_start' : dstart,
                                         'ip'            : ip,
@@ -427,7 +430,7 @@ class YamlCfg(object):
                                         'type'          : prdcr_type,
                                         'advertiser_xprt': adv_xprt,
                                         'advertiser_port': adv_port,
-                                        'advertiser_auth': adv_auth
+                                        'advertiser_auth': auth_name
             }
             self.prdcr_listeners[spec['daemons']] = node_listen
 

--- a/ldms/python/ldmsd/parser_util.py
+++ b/ldms/python/ldmsd/parser_util.py
@@ -1000,6 +1000,7 @@ class YamlCfg(object):
                     dstr, auth_list = self.write_listeners(dstr, group_name, dmn, auth_list)
                     dstr, auth_list = self.write_producers(dstr, group_name, dmn, auth_list)
                     dstr = self.write_prdcr_listeners(dstr, group_name)
+                    dstr, auth_list = self.write_advertisers(dstr, group_name, dmn, auth_list)
                     dstr = self.write_stream_subscribe(dstr, group_name, dmn)
                     dstr = self.write_agg_plugins(dstr, group_name, dmn)
                     dstr = self.write_updaters(dstr, group_name, dmn)


### PR DESCRIPTION
Without this change, parser_util.py omits the advertiser section when generating aggregator configurations, causing incomplete output.