### PR TITLE
Fix the units in ldmsd_controller:store_time_stas

### DIFF
--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1557,18 +1557,18 @@ class LdmsdCmdParser(cmd.Cmd):
         print(f"   <   Minimum Value          -   Minimum Average value")
         print(f"   >   Maximum Value          +   Maximum Average value")
         print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
-        print(f"{' '*4} {'Schema':^20} {'Min (sec)':^15} {'Avg (sec)':^15} {'Max (sec)':^15} {'Min Timestamp':^20} {'Max Timestamp':^20} {'# of Sets':^10} {'Count':^10}")
+        print(f"{' '*4} {'Schema':^20} {'Min (us)':^15} {'Avg (us)':^15} {'Max (us)':^15} {'Min Timestamp':^20} {'Max Timestamp':^20} {'# of Sets':^10} {'Count':^10}")
         print(f"{'-'*4}-{'-'*20} {'-'*15} {'-'*15} {'-'*15} {'-'*20} {'-'*20} {'-'*10} {'-'*10}")
         schema_names = sorted(list(schema_tbl.keys()))
         for schema in schema_names:
             if schema == 'stats':
                 continue
             stats = schema_tbl[schema]['stats']
-            print(f"{self.__symbols(schema, schema_tbl['stats']):>4}   {schema:>18} {stats['min']:15.4f} {stats['avg']:15.4f} {stats['max']:15.4f} {stats['min_ts']:20.4f} {stats['max_ts']:20.4f} {len(set(stats['set_name'])):10} {stats['count']:10}")
+            print(f"{self.__symbols(schema, schema_tbl['stats']):>4}   {schema:>18} {stats['min']:15.4f} {stats['avg']:15.4f} {stats['max']:15.4f} {stats['min_ts']:20.0f} {stats['max_ts']:20.0f} {len(set(stats['set_name'])):10} {stats['count']:10}")
 
         # Thread Table
         print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
-        print(f"{' '*4}-{'Thread':^20} {'Min (sec)':^15} {'Avg (sec)':^15} {'Max (sec)':^15} {'Min Timestamp':^20} {'Max Timestamp':^20} {'# of Sets':^10} {'Count':^10}")
+        print(f"{' '*4}-{'Thread':^20} {'Min (us)':^15} {'Avg (us)':^15} {'Max (us)':^15} {'Min Timestamp':^20} {'Max Timestamp':^20} {'# of Sets':^10} {'Count':^10}")
         # print(f"{'-'*4} {'-'*20} {'-'*15} {'-'*15} {'-'*15} {'-'*20} {'-'*20} {'-'*10} {'-'*10}")
         threads = sorted(list(thread_tbl.keys()))
         for tid in threads:
@@ -1577,17 +1577,17 @@ class LdmsdCmdParser(cmd.Cmd):
             symbol_tid = list()
             stats = thread_tbl[tid]['stats']
             print(f"{'-'*4}-{'-'*20} {'-'*15} {'-'*15} {'-'*15} {'-'*20} {'-'*20} {'-'*10} {'-'*10}")
-            print(f"{self.__symbols(tid, thread_tbl['stats']):>4}   {tid:18} {stats['min']:15.4f} {stats['avg']:15.4f} {stats['max']:15.4f} {stats['min_ts']:20.4f} {stats['max_ts']:20.4f} {len(set(stats['set_name'])):10} {stats['count']:10}")
+            print(f"{self.__symbols(tid, thread_tbl['stats']):>4}   {tid:18} {stats['min']:15.4f} {stats['avg']:15.4f} {stats['max']:15.4f} {stats['min_ts']:20.0f} {stats['max_ts']:20.0f} {len(set(stats['set_name'])):10} {stats['count']:10}")
             schema_names = sorted([s for s in list(thread_tbl[tid].keys()) if s != 'stats'])
             print(f"{' '*4} {'-'*20} {'-'*15} {'-'*15} {'-'*15} {'-'*20} {'-'*20} {'-'*10} {'-'*10}")
             for schema in schema_names:
                 st = thread_tbl[tid][schema]['stats']
-                print(f"   {self.__symbols(schema, thread_tbl[tid]['stats']):>4} {schema:>18} {st['min']:15.4f} {st['avg']:15.4f} {st['max']:15.4f} {st['min_ts']:20.4f} {st['max_ts']:20.4f} {len(set(st['set_name'])):10} {stats['count']:10}")
+                print(f"   {self.__symbols(schema, thread_tbl[tid]['stats']):>4} {schema:>18} {st['min']:15.4f} {st['avg']:15.4f} {st['max']:15.4f} {st['min_ts']:20.0f} {st['max_ts']:20.0f} {len(set(st['set_name'])):10} {stats['count']:10}")
             # print(f"{'-'*(4+21+16+16+16+21+21+11+11)}")
 
         # Storage policy Table
         print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
-        print(f"{' '*4} {'Storage Policy':^20} {'Min (sec)':^15} {'Avg (sec)':^15} {'Max (sec)':^15} {'Min Timestamp':^20} {'Max Timestamp':^20} {'# of Sets':^10} {'Count':^10}")
+        print(f"{' '*4} {'Storage Policy':^20} {'Min (us)':^15} {'Avg (us)':^15} {'Max (us)':^15} {'Min Timestamp':^20} {'Max Timestamp':^20} {'# of Sets':^10} {'Count':^10}")
         print(f"{'-'*4}-{'-'*20} {'-'*15} {'-'*15} {'-'*15} {'-'*20} {'-'*20} {'-'*10} {'-'*10}")
         strgps = sorted(list(strgp_tbl.keys()))
         for strgp in strgps:
@@ -1596,19 +1596,19 @@ class LdmsdCmdParser(cmd.Cmd):
             stats = strgp_tbl[strgp]['stats']
             if 0 == len(stats['set_name']):
                 continue
-            print(f"{self.__symbols(strgp, strgp_tbl['stats']):>5}  {strgp:18} {stats['min']:15.4f} {stats['avg']:15.4f} {stats['max']:15.4f} {stats['min_ts']:20.4f} {stats['max_ts']:20.4f} {len(set(stats['set_name'])):10} {stats['count']:10}")
+            print(f"{self.__symbols(strgp, strgp_tbl['stats']):>5}  {strgp:18} {stats['min']:15.4f} {stats['avg']:15.4f} {stats['max']:15.4f} {stats['min_ts']:20.0f} {stats['max_ts']:20.0f} {len(set(stats['set_name'])):10} {stats['count']:10}")
             schemas = sorted([s for s in list(strgp_tbl[strgp].keys()) if s != 'stats'])
             for schema in schemas:
                 print(f"   {' '*2}{'-'*20} {'-'*15} {'-'*15} {'-'*15} {'-'*20} {'-'*20} {'-'*10} {'-'*10}")
                 sch_stats = strgp_tbl[strgp][schema]['stats']
                 print(f"   {self.__symbols(schema, strgp_tbl[strgp]['stats']):>5} {schema:16} {sch_stats['min']:15.4f} {sch_stats['avg']:15.4f} " \
-                      f"{sch_stats['max']:15.4f} {sch_stats['min_ts']:20.4f} {sch_stats['max_ts']:20.4f} " \
+                      f"{sch_stats['max']:15.4f} {sch_stats['min_ts']:20.0f} {sch_stats['max_ts']:20.0f} " \
                       f"{len(set(sch_stats['set_name'])):10} {stats['count']:10}")
                 threads = sorted([s for s in list(strgp_tbl[strgp][schema].keys()) if s != 'stats'])
                 for tid in threads:
                     st = strgp_tbl[strgp][schema][tid]['stats']
                     print(f"       {self.__symbols(tid, strgp_tbl[strgp][schema]['stats']):>5}{tid:>13} {st['min']:15.4f} {st['avg']:15.4f} " \
-                          f"{st['max']:15.4f} {st['min_ts']:20.4f} {st['max_ts']:20.4f} " \
+                          f"{st['max']:15.4f} {st['min_ts']:20.0f} {st['max_ts']:20.0f} " \
                           f"{len(set(st['set_name'])):10} {stats['count']:10}")
             print(f"{' '*5}  {'-'*18} {'-'*15} {'-'*15} {'-'*15} {'-'*20} {'-'*20} {'-'*10} {'-'*10}")
         print()


### PR DESCRIPTION
The statistics of min, max, and average in store_time_stats are in microseconds, but the column headers indicate that they are seconds. The patch fixes this.

The patch also changes the printed timestamp format from 4 decimal places to show only the second part.