### PR TITLE
cxi_sampler plugin fixes and enhancements

### DIFF
--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -35,7 +35,9 @@ ldmssamplerinclude_HEADERS = sampler_base.h
 
 SUBDIRS += netlink
 SUBDIRS += json
+if ENABLE_CXI_SAMPLER
 SUBDIRS += cxi_sampler
+endif
 dist_man7_MANS += ldms_sampler_base.man
 
 if ENABLE_LUSTRE

--- a/ldms/src/sampler/cxi_sampler/Makefile.am
+++ b/ldms/src/sampler/cxi_sampler/Makefile.am
@@ -14,3 +14,4 @@ libcxi_sampler_la_SOURCES = cxi_sampler.c
 libcxi_sampler_la_LIBADD = $(COMMON_LIBADD)
 pkglib_LTLIBRARIES += libcxi_sampler.la
 dist_man7_MANS += ldms-sampler_cxi_sampler.man
+CLEANFILES = $(dist_man7_MANS)

--- a/ldms/src/sampler/cxi_sampler/cxi_sampler.c
+++ b/ldms/src/sampler/cxi_sampler/cxi_sampler.c
@@ -662,6 +662,7 @@ static int get_cxi_interfaces(ldmsd_plug_handle_t handle, char *tel_path)
 			count++;
 		}
 	}
+        qsort_r(cxi->iface_names, count, sizeof(char *), qsort_strcmp, cxi->log);
 
 	closedir(dir);
 	return 0;

--- a/ldms/src/sampler/cxi_sampler/cxi_sampler.c
+++ b/ldms/src/sampler/cxi_sampler/cxi_sampler.c
@@ -701,9 +701,11 @@ static int config(ldmsd_plug_handle_t handle,
 		if (tel_counters_file != NULL) {
 			ovis_log(log, OVIS_LDEBUG, "We have telemetry counter file: %s\n", tel_counters_file);
 			tel_counters = get_counter_names_from_file(handle, tel_counters_file);
-			if (tel_counters != NULL) {
-				ovis_log(log, OVIS_LDEBUG, "We have telemetry counter filters: %s\n", tel_counters);
+			if (tel_counters == NULL) {
+				rc = EINVAL;
+				goto err;
 			}
+			ovis_log(log, OVIS_LDEBUG, "We have telemetry counter filters: %s\n", tel_counters);
 		}
 	}
 	if (!rh_counters) {
@@ -711,9 +713,11 @@ static int config(ldmsd_plug_handle_t handle,
 		if (rh_counters_file != NULL) {
 			ovis_log(log, OVIS_LDEBUG, "We have retry handler counter file: %s\n", rh_counters_file);
 			rh_counters = get_counter_names_from_file(handle, rh_counters_file);
-			if (rh_counters != NULL) {
-				ovis_log(log, OVIS_LDEBUG, "We have retry handler counter filters: %s\n", rh_counters);
+			if (rh_counters == NULL) {
+				rc = EINVAL;
+				goto err;
 			}
+			ovis_log(log, OVIS_LDEBUG, "We have retry handler counter filters: %s\n", rh_counters);
 		}
 	}
 

--- a/ldms/src/sampler/cxi_sampler/cxi_sampler.c
+++ b/ldms/src/sampler/cxi_sampler/cxi_sampler.c
@@ -254,7 +254,6 @@ static int get_cxi_metric_names(ldmsd_plug_handle_t handle, struct files_s *tel_
 {
 	ovis_log_t log = ldmsd_plug_log_get(handle);
 	const char *end_path_tel = "device/telemetry";
-        DIR *dir;
 
 	/* root_path "/" cxi_name "/" null terminator */
 	size_t path_len = strlen(root_path) + 1 + strlen(cxi_name) + 1 + strlen(end_path_tel) + 2;
@@ -439,7 +438,6 @@ static int get_rh_names(ldmsd_plug_handle_t handle, struct files_s *rh_files,
 			const char *cxi_name, char *root_path, char *patterns)
 {
 	ovis_log_t log = ldmsd_plug_log_get(handle);
-        int i;
 
 	/* +1 for "/" +2 for "/" and null terminator */
 	size_t path_len = strlen(root_path) + 1 + strlen(cxi_name) + 2;
@@ -461,7 +459,7 @@ static int get_rh_names(ldmsd_plug_handle_t handle, struct files_s *rh_files,
 
 static int create_metric_set(cxi_t cxi)
 {
-	int rc, i, j;
+	int rc, i;
 	ldms_record_t tel_rec;
 	ldms_record_t rh_rec;
 	int tel_rec_mid;

--- a/ldms/src/sampler/cxi_sampler/cxi_sampler.c
+++ b/ldms/src/sampler/cxi_sampler/cxi_sampler.c
@@ -480,11 +480,11 @@ static int create_metric_set(cxi_t cxi)
 		}
 	}
 	tel_rec_mid = ldms_schema_record_add(cxi->schema, tel_rec);
-    if (!tel_rec_mid){
-        ldms_record_delete(tel_rec);
-        rc = errno;
-        goto err1;
-    }
+	if (!tel_rec_mid){
+		ldms_record_delete(tel_rec);
+		rc = errno;
+		goto err1;
+	}
 
 	/* Per interface retry handler record */
 	rh_rec = ldms_record_create("rh_record");
@@ -519,11 +519,11 @@ static int create_metric_set(cxi_t cxi)
 
 	/* List of per interface retry handler records */
 	rh_rec_mid = ldms_schema_record_add(cxi->schema, rh_rec);
-    if (!rh_rec_mid){
-        ldms_record_delete(rh_rec);
-        rc = errno;
-        goto err1;
-    }
+	if (!rh_rec_mid){
+		ldms_record_delete(rh_rec);
+		rc = errno;
+		goto err1;
+	}
 	rc = ldms_schema_metric_list_add(cxi->schema, "rh_list", "rh_record",
 					 ldms_record_heap_size_get(rh_rec) * cxi->iface_count);
 	cxi->rh_list_mid = rc;
@@ -569,9 +569,9 @@ static int create_metric_set(cxi_t cxi)
 	}
 	return 0;
 err2:
-    if (cxi->set) {
-        base_set_delete(cxi->base);
-    }
+	if (cxi->set) {
+		base_set_delete(cxi->base);
+	}
 err1:
 	if (cxi->base)
 		base_schema_delete(cxi->base);
@@ -593,7 +593,7 @@ static int get_cxi_interfaces(ldmsd_plug_handle_t handle, char *tel_path)
 	DIR *dir = opendir(tel_path);
 	int count;
 
-  if (!dir) {
+	if (!dir) {
 		ovis_log(cxi->log, OVIS_LERROR,
 			 "Error %d opening directory '%s'\n",
 			 errno, tel_path);
@@ -796,6 +796,9 @@ static int constructor(ldmsd_plug_handle_t handle)
 static void destructor(ldmsd_plug_handle_t handle)
 {
 	cxi_t cxi = ldmsd_plug_ctxt_get(handle);
+	int i;
+	int j;
+
 	if (!cxi)
 		return;
 
@@ -806,8 +809,6 @@ static void destructor(ldmsd_plug_handle_t handle)
 	if (cxi->schema)
 		base_schema_delete(cxi->base);
 
-    int i;
-    int j;
 	/* Free interface names */
 	if (cxi->iface_names) {
 		for ( i = 0; i < cxi->iface_count; i++) {

--- a/ldms/src/sampler/cxi_sampler/cxi_sampler.c
+++ b/ldms/src/sampler/cxi_sampler/cxi_sampler.c
@@ -146,22 +146,23 @@ static int skip_name(char *name, char *counters, ovis_log_t log)
 
 		/* Compile and execute the regex */
 		regex_t regex;
-		int reti = regcomp(&regex, token, REG_NOSUB | REG_EXTENDED);
+		int reti = regcomp(&regex, token, REG_EXTENDED);
 		if (reti != 0) {
 			ovis_log(log, OVIS_LERROR, "Could not compile regex: %s\n", token);
 			token = strtok(NULL, ",");
 			continue;
 		}
 
-		reti = regexec(&regex, name, 0, NULL, 0);
+		regmatch_t pmatch;
+		reti = regexec(&regex, name, 1, &pmatch, 0);
 		regfree(&regex);
-
-		/* Test for match */
-		if (reti == 0) {
-			ovis_log(log, OVIS_LDEBUG, "Found Match: '%s'\n", token);
-			result = 0; /* Don't skip */
-			break;
-		}
+		/* Test for complete match */
+		if (reti == 0 && pmatch.rm_so == 0 && pmatch.rm_eo == strlen(name)) {
+                        ovis_log(log, OVIS_LDEBUG,
+                                 "Found Match: '%s', pattern '%s'\n", name, token);
+                        result = 0; /* Don't skip */
+                        break;
+                }
 		token = strtok(NULL, ",");
 	}
 

--- a/ldms/src/sampler/cxi_sampler/cxi_sampler.c
+++ b/ldms/src/sampler/cxi_sampler/cxi_sampler.c
@@ -571,10 +571,13 @@ static int create_metric_set(cxi_t cxi)
 err2:
 	if (cxi->set) {
 		base_set_delete(cxi->base);
+		cxi->set = NULL;
 	}
 err1:
-	if (cxi->base)
+	if (cxi->schema) {
 		base_schema_delete(cxi->base);
+		cxi->schema = NULL;
+	}
 	return rc;
 }
 

--- a/ldms/src/sampler/cxi_sampler/cxi_sampler.c
+++ b/ldms/src/sampler/cxi_sampler/cxi_sampler.c
@@ -80,11 +80,6 @@ struct files_s {
 	char *names[MAX_FILES];
 };
 
-typedef struct ifaces_s {
-	int count;
-	char *names[MAX_CXI_IFACES];
-} *cxi_iface_t;
-
 typedef struct cxi_s {
 	struct files_s rh_files;
 	struct files_s tel_files;

--- a/ldms/src/sampler/cxi_sampler/ldms-sampler_cxi_sampler.rst
+++ b/ldms/src/sampler/cxi_sampler/ldms-sampler_cxi_sampler.rst
@@ -115,6 +115,7 @@ Within ldmsd_controller or a configuration file:
    load name=cxi_sampler
    config name=cxi_sampler producer=${HOSTNAME} instance=${HOSTNAME}/cxi_sampler
    start name=cxi_sampler interval=1s
+
 or
 
 ::
@@ -124,6 +125,7 @@ or
    load name=cxi_sampler
    config name=cxi_sampler producer=${HOSTNAME} instance=${HOSTNAME}/cxi_sampler tel_counters=${CXI_COUNTERS} rh_counters=${RH_COUNTERS}
    start name=cxi_sampler interval=1s
+
 or
 
 ::


### PR DESCRIPTION
Various cxi_sampler plugin fixes and enhancements

    The regex matching was previously matching if the string appeared
    _anywhere_ in the file name. That is probably unintented behavior,
    so we change the logic to only determine there is a match when the
    regex matches the _entire_ file name string.

    Collapse the counter file parser to a single function.

    Other minor fixes and cleanup.

    Maintain a consistent ordering of counters based on the order of the supplied patterns.

    Sort the interfaces.

    Don't maintain redundant rh_files and tel_files lists.