### PR TITLE
ovis_log: Improve the default logging format

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -1907,7 +1907,10 @@ void log_init()
 	lt = getenv("OVIS_LOG_TIME_SEC");
 	if (lt)
 		log_mode = OVIS_LOG_M_TS;
-	lt = getenv("OVIS_LOG_DATE_TIME");
+	lt = getenv("LDMSD_LOG_TIME_SEC");
+	if (lt)
+		log_mode = OVIS_LOG_M_TS;
+	lt = getenv("LDMSD_LOG_DATE_TIME");
 	if (lt)
 		log_mode = OVIS_LOG_M_DT;
 	ret = ovis_log_init("ldmsd", log_level_thr, log_mode);

--- a/ldms/src/ldmsd/ldmsd.rst
+++ b/ldms/src/ldmsd/ldmsd.rst
@@ -69,6 +69,14 @@ LDMSD_UPDTR_OFFSET_INCR
    if the offset hint is 100000, the updater offset will be 100000 +
    LDMSD_UPDTR_OFFSET_INCR. The default is 100000 (100 milliseconds).
 
+LDMSD_LOG_DATE_TIME
+   When set, this environment variable tells ldmsd to prefix each line of
+   output with a timestamp in human readable form.
+
+LDMSD_LOG_TIME_SEC
+   When set, this environment variable tells ldmsd to prefix each line of
+   output with a timestamp in the form of seconds-since-epoch.
+
 CRAY Specific Environment variables for ugni transport
 ------------------------------------------------------
 

--- a/lib/src/ovis_log/ovis_log.h
+++ b/lib/src/ovis_log/ovis_log.h
@@ -111,9 +111,9 @@ typedef struct ovis_log_s {
  *
  * Available modes:
  *  OVIS_LOG_M_DT date-time format (%a %b %d %H:%M:%S %Y) is used to format
- *               message timestamps. (default)
+ *               message timestamps.
  *  OVIS_LOG_M TS timestamp (%lu) is used to format message timestamps.
- *  OVIS_LOG_M_TS_NONE Timestamps are not included in log messages.
+ *  OVIS_LOG_M_TS_NONE Timestamps are not included in log messages. (default)
  *
  * The \c ovis_log_init() call makes \c ovis_log_open, \c ovis_log_close,
  *  \c ovis_log, and \c ovis_vlog asynchronous.
@@ -135,7 +135,7 @@ typedef struct ovis_log_s {
  * Further on, we could extend the default mode to include other mode types
  * by using the bitwise-or operation.
  */
-#define OVIS_LOG_M_DEFAULT OVIS_LOG_M_DT
+#define OVIS_LOG_M_DEFAULT OVIS_LOG_M_TS_NONE
 
 int ovis_log_init(const char *default_subsys_name, int default_level, int modes);
 
@@ -307,6 +307,19 @@ int ovis_vlog(ovis_log_t log, int level, const char *fmt, va_list ap);
 int ovis_log_set_level_by_regex(const char *regex_s, int level);
 int ovis_log_set_level_by_name(const char *subsys_name, int level);
 int ovis_log_set_level(ovis_log_t mylog, int level);
+
+/**
+ * \brief Set the level of the default log.
+ *
+ * If \c level is OVIS_LDEFAULT, the subsystem is set to the default level.
+ *
+ * \param level           The log levels to be enabled. This could be
+ *                        the bitwise-or of multiple log levels.
+ *
+ * \return 0 on success. On error, an errno is returned.
+ *         EINVAL   \c level is invalid.
+ */
+int ovis_log_default_set_level(int level);
 
 /**
  * \brief Get the log level of a subsystem


### PR DESCRIPTION
The default logging level and default mode are probably not the best default values. Probably the two most common ways that folks will run ldmsd is: on the command line when they first start playing with ldms, from systemd when ldmsd is using in production. In neither of these cases do genearlly want a timestamp to be prefixed to the log messages. For instance systemd logs to journald by default, and journald does its own timestamping. So right now when I use journalctl to list the ldmsd log, I see double time stamps like so:

```
Jun 12 12:17:42 hetchy1 ldmsd[2815186]: Thu Jun 12 12:17:42 2025: INFO      : Listening on sock:411 using `sock` transport and `munge` authentication
```
this is because on the command line ldmsd is doing:
```
$ ldmsd -F -c ./samp.conf
Thu Jun 12 12:12:41 2025:  WARNING: : The option `-F` is deprecated. ldmsd now ALWAYS runs in the foreground.
```
After we get rid of the timestamp (by default, folks who want it can always set an option to get timestamps) we have:

```
$ ldmsd -F -c ./samp.conf
  WARNING: : The option `-F` is deprecated. ldmsd now ALWAYS runs in the foreground.
```
It is weird to have double colons, so the code is updated to have "name" be NULL by default instead of an empty string. That way we can easier check if name is unset, and then conditionally print the name:

```
$ ldmsd -F -c ./samp.conf
  WARNING: The option `-F` is deprecated. ldmsd now ALWAYS runs in the foreground.
```

And in the course of updating all of that a few other fixes were made:

Change the default logging mode to OVIS_LOG_M_TS_NONE (no time string).

Introduce the environment varable OVIS_LOG_DATE_TIME to enable logging mode OVIS_LOG_M_DT (the previous default).

Call ovis_log_init() much sooner to get "ldmsd" set as the name in the default log level. This allows the message to be:

```
$ ldmsd -F -c ./samp.conf
  WARNING: ldmsd: The option `-F` is deprecated. ldmsd now ALWAYS runs in the foreground.
```

Introduce the ovis_log_default_set_level() function to allow ldmsd to change the log level of the default log _after_ calling ovis_log_init().

Raise the default log level to include OVIS_LWARNING.
