### PR TITLE
Fix ovis_thrstats_init() race bug

### DIFF
--- a/lib/src/ovis_event/ovis_event.c
+++ b/lib/src/ovis_event/ovis_event.c
@@ -298,6 +298,8 @@ ovis_scheduler_t ovis_scheduler_new()
 	if (rc != 0)
 		goto err;
 
+	ovis_thrstats_init(&m->stats, "ovis_scheduler");
+
 	goto out;
 
 err:
@@ -643,7 +645,6 @@ int ovis_scheduler_loop(ovis_scheduler_t m, int return_on_empty)
 	int rc = 0;
 	int cnt;
 
-	ovis_thrstats_init(&m->stats, m->name);
 	ovis_thrstats_thread_id_set(&m->stats);
 	ovis_scheduler_ref_get(m);
 	pthread_mutex_lock(&m->mutex);
@@ -803,6 +804,7 @@ int ovis_scheduler_name_set(ovis_scheduler_t s, const char *name)
 	s->name = strdup(name);
 	if (!s->name)
 		return ENOMEM;
+	ovis_thrstats_init(&s->stats, name);
 	return 0;
 }
 


### PR DESCRIPTION
ovis_thrstats_init() was called in ovis_scheduler_loop() which was called on the other thread. The find_least_busy_thread() function was called from the main thread and consequently called ovis_scheduler_thrstats_get() while the thrstats was not yet initialized (the other thread was still starting), and causing SIGFPE (divided by zero). This happened on a slow virtual machine.

This patch moved the ovis_thrstats_init() calls to ovis_scheduler_new() (initialize w/o specific name) and ovis_scheduler_name_set() (re-initialize when the name has set, usually by the main thread before the worker thread started).