### PR TITLE
Fix empty usage string for store plugin (typo)

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -5595,7 +5595,7 @@ static int __plugn_usage_string(ldmsd_req_ctxt_t reqc)
 		reqc->errcode = ENOENT;
 	}
 	ldmsd_cfg_lock(LDMSD_CFGOBJ_STORE);
-	for (store = ldmsd_store_first(); samp;
+	for (store = ldmsd_store_first(); store;
 			store = ldmsd_store_next(store)) {
 		if (name && (0 != strcmp(name, store->cfg.name)))
 			continue;


### PR DESCRIPTION
This patch fixes a little typo when iterating over storage plugins, the condition of the loop checked on `samp` instead of `store`. The result of the typological error was that store plugin usages were not printed.