### PR TITLE
Fix samp unlock a not-locked lock (by valgrind)

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -1017,13 +1017,15 @@ int ldmsd_sampler_start(char *cfg_name, char *interval, char *offset,
 		goto out;
 	}
 
+	ldmsd_sampler_lock(samp);
+
 	if (exclusive_thread) {
 		samp->use_xthread = atoi(exclusive_thread);
 	}
 
 	rc = ovis_time_str2us(interval, &sample_interval);
 	if (rc)
-		return rc;
+		goto out;
 
 	samp->sample_interval_us = sample_interval;
 	if (offset) {


### PR DESCRIPTION
Valgrind complained about unlocking a not-locked lock at `out:` of `ldmsd_sampler_start()`. `samp` should be locked before its attributes are modified in `ldmsd_sampler_start()` and later unlock at `out:`.