### PR TITLE
ldmsd_cfgobj_new_with_auth() shall return locked object

### DIFF
--- a/ldms/src/ldmsd/ldmsd_cfgobj.c
+++ b/ldms/src/ldmsd/ldmsd_cfgobj.c
@@ -235,6 +235,7 @@ ldmsd_cfgobj_t ldmsd_cfgobj_new_with_auth(const char *name,
 	obj->perm = perm;
 
 	pthread_mutex_init(&obj->lock, NULL);
+	pthread_mutex_lock(&obj->lock);
 	rbn_init(&obj->rbn, obj->name);
 	rbt_ins(cfgobj_trees[type], &obj->rbn);
 	ldmsd_cfgobj_get(obj, "cfgobj_tree");


### PR DESCRIPTION
Valgrind complained that cfgobj was unlocking a not-locked mutex on cfgobj. All callers of ldmsd_cfgobj_new_with_auth() do unlock the cfgobj. This patch locks the cfgobj when it is created.