### PR TITLE
Fix double-initialization of thrstats in ovis_scheduler

### DIFF
--- a/lib/src/ovis_event/ovis_event.c
+++ b/lib/src/ovis_event/ovis_event.c
@@ -804,7 +804,7 @@ int ovis_scheduler_name_set(ovis_scheduler_t s, const char *name)
 	s->name = strdup(name);
 	if (!s->name)
 		return ENOMEM;
-	ovis_thrstats_init(&s->stats, name);
+	ovis_thrstats_name_set(&s->stats, name);
 	return 0;
 }
 


### PR DESCRIPTION
`ovis_thrstats_init()` was already called in ovis_scheduler. The `ovis_scheduler_name_set()` should call `ovis_thrstats_name_set()`, not `ovis_thrstats_init()`.