### PR TITLE
Fix `as_is` decomposition SIGSEGV

### DIFF
--- a/ldms/src/decomp/as_is/decomp_as_is.c
+++ b/ldms/src/decomp/as_is/decomp_as_is.c
@@ -411,7 +411,7 @@ get_row_cfg(as_is_cfg_t dcfg, ldms_set_t set)
 	col_count = 1;
 
 	/* create other columns */
-	for (i = 1; i < set_card; i++) {
+	for (i = 0; i < set_card; i++) {
 		mtype = ldms_metric_type_get(set, i);
 		switch (mtype) {
 		case LDMS_V_CHAR:


### PR DESCRIPTION
`as_is` decomposition uses all metrics in the set, plus extra `timestamp` phony metric. Thus, it shall iterate through all metrics in the set when it builds (internal) cfg for the schema.