### PR TITLE
add reproducer for sampler flapping test

### DIFF
--- a/ldms/scripts/examples/flapL0
+++ b/ldms/scripts/examples/flapL0
@@ -1,0 +1,37 @@
+# This tests simple sampler/l1 agg/l2 agg
+portbase=11000
+export storename=store_csv
+
+nsock=$(lscpu |grep ^Sock |sed -e 's/.*://' -e 's/ //g')
+ncore=$(lscpu |grep ^Core |sed -e 's/.*://' -e 's/ //g')
+pcores=$(($nsock * $ncore / 2))
+echo cores=$pcores
+maxdaemon=$pcores
+DAEMONS $(seq $maxdaemon)
+
+VGARGS="--tool=drd --time-stamp=yes --gen-suppressions=all"
+VGARGS="--track-origins=yes --leak-check=full --show-leak-kinds=definite --time-stamp=yes --gen-suppressions=all  --main-stacksize=256000000"
+
+vgon
+# L2
+VGTAG=.L2
+LDMSD 1
+# L1
+VGTAG=.L1
+LDMSD -P producer,`seq -s, 3 $maxdaemon` 2
+vgoff
+
+for loop in $(seq 10); do
+	LDMSD -s 1 -p prolog.sampler.many -c $(seq 3 $maxdaemon)
+	SLEEP 10
+	FILECNT_LDMSD $(seq 1 3)
+	LDMS_LS 1 -l
+	LDMS_STATUS 1
+	LDMS_LS 2 -l
+	LDMS_STATUS 2
+	KILL_LDMSD $(seq 3 $maxdaemon)
+	SLEEP 5
+done
+FILECNT_LDMSD $(seq 1 2)
+
+KILL_LDMSD 1 2

--- a/ldms/scripts/examples/flapL0.1
+++ b/ldms/scripts/examples/flapL0.1
@@ -1,0 +1,13 @@
+# l2 agg and stores
+load name=${storename}
+config name=${storename} path=${STOREDIR} altheader=0
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} reconnect=1000000
+prdcr_start name=localhost2
+
+updtr_add name=allhosts interval=1000000 offset=200000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=${testname} plugin=${storename} schema=${plugname} container=${storename}
+strgp_prdcr_add name=${testname} regex=.*
+strgp_start name=${testname}

--- a/ldms/scripts/examples/flapL0.2
+++ b/ldms/scripts/examples/flapL0.2
@@ -1,0 +1,4 @@
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts

--- a/ldms/scripts/examples/producer
+++ b/ldms/scripts/examples/producer
@@ -1,0 +1,2 @@
+prdcr_add name=localhost${j} host=localhost type=active xprt=${XPRT} port=${port${j}} reconnect=1000000
+prdcr_start name=localhost${j}

--- a/ldms/scripts/examples/prolog.sampler.many
+++ b/ldms/scripts/examples/prolog.sampler.many
@@ -1,0 +1,12 @@
+load name=meminfo
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i}
+start name=meminfo interval=1000000 offset=0
+load name=vmstat
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i}
+start name=vmstat interval=1000000 offset=0
+load name=clock
+config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i}
+start name=clock interval=1000000 offset=0
+load name=procstat
+config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} maxcpu=0
+start name=procstat interval=1000000 offset=0

--- a/ldms/scripts/ldms-static-test.sh.in
+++ b/ldms/scripts/ldms-static-test.sh.in
@@ -33,6 +33,9 @@ export LDMSD_PLUGIN_LIBPATH
 export LD_LIBRARY_PATH=${ovis_ldms_plugins_rpath}:${BUILDDIR}/lib:${exec_prefix}/lib:$ovis_ldms_plugins:$LD_LIBRARY_PATH
 export PYTHONPATH=${ovis_ldms_pythondir}:$PYTHONPATH
 
+export LDMSD_LOG_DATE_TIME=1
+export LDMSD_LOG_TIME_SEC=1
+
 function clusage {
 cat << EOF
 $0: usage:
@@ -324,12 +327,17 @@ function LDMSD {
 			fi
 		fi
 		# assume gnu sleep and bc exist, because usleep deprecated
-		sleep $(echo "0.000001 * $startwait" |bc)
-		if ! test -f $LDMSD_PIDFILE.$i; then
-			echo FAIL: failed to start $i. check ${LOGDIR}/$i.txt
-			bypass=1
-			break;
-		fi
+		#sleep $(echo "0.000001 * $startwait" |bc)
+		nwait=0
+		while ! test -f $LDMSD_PIDFILE.$i; do
+			((nwait++))
+			sleep 0.1
+			if test $nwait -gt 100; then
+				echo FAIL: failed to start $i. check ${LOGDIR}/$i.txt
+				bypass=1
+				break;
+			fi
+		done
 	done
 }
 
@@ -378,6 +386,66 @@ function LDMS_LS {
 		$wrap ldms_ls  -h $HOST -x $XPRT -p $iport $*
 	done
 }
+
+#
+function LDMS_STATUS {
+	if test "$bypass" = "1"; then
+		return 0
+	fi
+	nodes=$1
+	shift
+	for i in $nodes; do
+		if test "$usevg" = "1"; then
+			if test -z "$VG"; then
+				XVG=valgrind
+			else
+				XVG=$VG
+			fi
+			if test -n "LDMSNET"; then
+				XVGSUFF=".$LDMSNET"
+			fi
+			if test -z "$VGARGS"; then
+				VGARGS="-v --log-file=${LOGDIR}/vgls.$i$VGTAG.%p"
+			else
+				XVGARGS="-v --log-file=${LOGDIR}/vgls.$i$VGTAG.%p$XVGSUFF $VGARGS"
+			fi
+			wrap="$XVG $XVGARGS"
+		else
+			wrap=""
+		fi
+		if ! test -f "$LDMSD_PIDFILE.$i"; then
+			echo FAIL: $i: ls of missing daemon $i skipped. check ${LOGDIR}/$i.txt
+			bypass=1
+			break;
+		fi
+		if test -n "$PORT"; then
+			iport=$PORT
+		else
+			iport=${ports[$i]}
+		fi
+		ihost=localhost
+		echo "$i: echo status | $wrap ldmsd_controller -h $ihost -x $XPRT -p $iport"
+		echo status | $wrap ldmsd_controller  -h $ihost -x $XPRT -p $iport
+	done
+}
+
+# FILECNT_LDMSD num list
+function FILECNT_LDMSD {
+	for i in $*; do
+		if test -f $LDMSD_PIDFILE.$i; then
+			dpid=$(cat $LDMSD_PIDFILE.$i)
+			dts=$(date +%s)
+			/bin/ls /proc/$dpid/fd -l > $LDMSD_PIDFILE.$i.cnt.$dts
+			filecnt=$(wc -l $LDMSD_PIDFILE.$i.cnt.$dts | sed -e 's/ .*//')
+			echo "$i: FileCount=$filecnt"
+			egrep '(Threads|VmRSS|VmSize)' /proc/$dpid/status |sed -e 's/:[[:space:]]*/=/' -e "s/^/$i: /"
+			mv $LDMSD_PIDFILE.$i.cnt.$dts $LDMSD_PIDFILE.$i.cnt.$dts.$filecnt
+		else
+			echo $i: filecnt cannot find pidfile for $i
+		fi
+	done
+}
+
 # KILL_LDMSD num list
 function KILL_LDMSD {
 	for i in $*; do


### PR DESCRIPTION
This adds a test of L0 flapping sufficient for demonstrating bugs with/without valgrind memcheck or drd.

If configured as below under toss4, the test can be launched with

```
script -c '$prefix/bin/ldms-static-test.sh flapL0'
```
after it completes:

```
grep RSS typescript
```
and the valgrind output will be in 
```
ldmstest/flapL0/logs/vg.1.* (the L2 valgrind log)
ldmstest/flapL0/logs/vg.2.* (the L1 valgrind log)
```
All the inputs and outputs for the daemons are in the usual locations documented per the ldms-static-test man page.
Most of the sampler related options are optional.
```
configure \
	--disable-atasmart \
	--disable-gpumetrics \
	--disable-perfevent \
	--disable-rabbitv3 \
	--disable-switchx \
	--disable-amqp \
	--prefix=$INSTALL_DIR \
	--disable-aries_gpcdr \
	--disable-aries_linkstatus \
	--disable-aries_mmr \
	--disable-cray_hss_devel \
	--disable-cray_nvidia \
	--disable-cray_nvidia_inc \
	--disable-cray_system_sampler \
	--disable-darshan \
	--disable-doc \
	--disable-doc_graph \
	--disable-doc_html \
	--disable-doc_latex \
	--disable-etc \
	--disable-gemini_gpcdr \
	--disable-gpcdlocal \
	--disable-ibm_occ \
	--disable-influx \
	--disable-kokkos \
	--disable-mpi_noprofile \
	--disable-mpi_sampler \
	--disable-msr_interlagos \
	--disable-sos \
	--disable-store_app \
	--disable-third-plugins \
	--disable-ugni \
	--enable-app_sampler \
	--enable-appinfo \
	--enable-array_example \
	--enable-blob_stream \
	--enable-clock \
	--enable-coretemp \
	--enable-cray_power_sampler \
	--enable-csv \
	--enable-csv_check \
	--enable-developer \
	--enable-doc_man \
	--enable-dstat \
	--enable-filesingle \
	--enable-flatfile \
	--enable-fptrans \
	--enable-generic_sampler \
	--enable-grptest \
	--enable-hello_stream \
	--enable-ipmireader \
	--enable-jobid \
	--enable-jobinfo_sampler \
	--enable-kgnilnd \
	--enable-ldms-test \
	--enable-ldms_test \
	--enable-list_sampler \
	--enable-llnl_edac \
	--enable-lnet_stats \
	--enable-loadavg \
	--enable-lustre \
	--enable-meminfo \
	--enable-mmalloc \
	--enable-mmap \
	--enable-nola \
	--enable-ovis_auth \
	--enable-ovis_ctrl \
	--enable-ovis_ev_test \
	--enable-ovis_event \
	--enable-ovis_event_test \
	--enable-perf \
	--enable-proc_streams \
	--enable-procdiskstats \
	--enable-procinterrupts \
	--enable-procnet \
	--enable-procnetdev \
	--enable-procnfs \
	--enable-procstat \
	--enable-rabbitkw \
	--enable-rdma \
	--enable-readline \
	--enable-record_sampler \
	--enable-sampler \
	--enable-scripts \
	--enable-slurmtest \
	--enable-sock \
	--enable-spaceless_names \
	--enable-store \
	--enable-synthetic \
	--enable-test_sampler \
	--enable-tsampler \
	--enable-tutorial_sampler \
	--enable-tutorial_store \
	--enable-varset \
	--enable-vmstat \
	--enable-yaml \
	--enable-zap \
	--enable-zaptest 
```