### PR TITLE
Fix parsing brittleness in lustre_client

### DIFF
--- a/ldms/scripts/examples/lustre_client
+++ b/ldms/scripts/examples/lustre_client
@@ -3,14 +3,19 @@ export LDMSD_EXTRA="-m 1G"
 portbase=61016
 DAEMONS $(seq 3)
 JOBDATA $TESTDIR/job.data 1 2 3
-LDMSD -p prolog.jobid -p prolog.jobid.sampler 1 2
+VGARGS="--track-origins=yes --leak-check=full --show-leak-kinds=definite"
+vgoff
+LDMSD -p prolog.jobid 1
+vgoff
+LDMSD -p prolog.jobid 2
 LDMSD -p prolog.jobid.store3 3
+SLEEP 3
 MESSAGE ldms_ls on host 1:
-LDMS_LS 1 -l
+LDMS_LS 1 -lv
 MESSAGE ldms_ls on host 2:
-LDMS_LS 2 -l
+LDMS_LS 2 -lv
 MESSAGE ldms_ls on host 3:
-LDMS_LS 3
+LDMS_LS 3 -lv
 SLEEP 5
 KILL_LDMSD $(seq 3)
 file_created $STOREDIR/node/lustre_client

--- a/ldms/scripts/examples/lustre_client.1
+++ b/ldms/scripts/examples/lustre_client.1
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} job_set=localhost${i}/jobid  extra215=1 extratimes=1 test_path=${HOME}/test-llite
+start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/lustre_client.2
+++ b/ldms/scripts/examples/lustre_client.2
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} job_set=localhost${i}/jobid
+start name=${plugname} interval=1000000 offset=0

--- a/ldms/src/sampler/lustre_client/ldms-sampler_lustre_client.rst
+++ b/ldms/src/sampler/lustre_client/ldms-sampler_lustre_client.rst
@@ -68,6 +68,20 @@ CONFIGURATION ATTRIBUTE SYNTAX
    perm=<octal number>
       |
       | Set the access permissions for the metric sets. (default 440).
+   extra215=1
+      |
+      | Enable lustre 2.15 new metrics; this appends a small number, unique
+        to the choice of extras, to the default schema name.
+   extratimes=1
+      |
+      | Enable start and elapsed time metrics (rounded to seconds). This
+        appends a small number, unique to the choice of extras, to the
+        default schema name.
+   test_path=<LLITE_DIR>
+      |
+      | This debugging option instructs the plugin to read data from a
+        directory containing a static snapshot of an llite directory
+        instead of from debugfs files.
 
 NOTES
 =====

--- a/ldms/src/sampler/lustre_client/lustre_client_general.c
+++ b/ldms/src/sampler/lustre_client/lustre_client_general.c
@@ -62,6 +62,23 @@ static char *llite_stats_uint64_t_entries[] = {
         NULL
 };
 
+
+/* the following get added to the schema if extra215 config option is present. */
+static const char *extra215_llite_stats_uint64_t_entries[] = {
+        "read",
+        "write",
+        "opencount",
+        "openclosetime",
+        NULL
+};
+
+/* the following exist at least as far back as 2.15 lustre clients */
+static const char *extratimes_llite_stats_uint64_t_entries[] = {
+	"start_time", /* this truncates the data to seconds; it's ok. */
+	"elapsed_time", /* this truncates the data to seconds; it's ok. */
+        NULL
+};
+
 int llite_general_schema_is_initialized()
 {
         if (llite_general_schema != NULL)
@@ -70,14 +87,19 @@ int llite_general_schema_is_initialized()
                 return -1;
 }
 
-int llite_general_schema_init(comp_id_t cid)
+int llite_general_schema_init(comp_id_t cid, int schema_extras)
 {
         ldms_schema_t sch;
         int rc;
         int i;
 
         ovis_log(lustre_client_log, OVIS_LDEBUG, SAMP ": llite_general_schema_init()\n");
-        sch = ldms_schema_new("lustre_client");
+	char schema_name[LDMS_SET_NAME_MAX];
+	if (schema_extras)
+		sprintf(schema_name,"lustre_client_%d", schema_extras);
+	else
+		sprintf(schema_name,"lustre_client");
+        sch = ldms_schema_new(schema_name);
         if (sch == NULL) {
 		ovis_log(lustre_client_log, OVIS_LERROR, SAMP ": lustre_llite_general schema new failed"
 			" (out of memory)\n");
@@ -113,6 +135,24 @@ int llite_general_schema_init(comp_id_t cid)
                         goto err2;
 		}
         }
+	if (schema_extras & EXTRA215) {
+		for (i = 0; extra215_llite_stats_uint64_t_entries[i] != NULL; i++) {
+			field = extra215_llite_stats_uint64_t_entries[i];
+			rc = ldms_schema_metric_add(sch, field, LDMS_V_U64);
+			if (rc < 0) {
+				goto err2;
+			}
+		}
+	}
+	if (schema_extras & EXTRATIMES) {
+		for (i = 0; extratimes_llite_stats_uint64_t_entries[i] != NULL; i++) {
+			field = extratimes_llite_stats_uint64_t_entries[i];
+			rc = ldms_schema_metric_add(sch, field, LDMS_V_U64);
+			if (rc < 0) {
+				goto err2;
+			}
+		}
+	}
 
         llite_general_schema = sch;
 
@@ -215,21 +255,31 @@ static int llite_stats_sample(const char *stats_path,
                             str1, &val1, &val2);
                 if (rc == 2) {
                         index = ldms_metric_by_name(general_metric_set, str1);
-                        if (index == -1) {
+                        if (index != -1) {
+                                ldms_metric_set_u64(general_metric_set, index, val1);
+			} /*else {
+				// this is a normal case as lustre evolves reporting.
                                 ovis_log(lustre_client_log, OVIS_LWARNING, SAMP ": llite stats metric not found: %s\n",
                                        str1);
-                        } else {
-                                ldms_metric_set_u64(general_metric_set, index, val1);
-                        }
+                        } */
                         continue;
                 } else if (rc == 3) {
                         int base_name_len = strlen(str1);
                         sprintf(str1+base_name_len, ".sum"); /* append ".sum" */
                         index = ldms_metric_by_name(general_metric_set, str1);
                         if (index == -1) {
-                                ovis_log(lustre_client_log, OVIS_LWARNING, SAMP ": llite stats metric not found: %s\n",
-                                       str1);
-                        } else {
+				/* non-sum metric, possibly */
+				str1[base_name_len] = '\0';
+				index = ldms_metric_by_name(general_metric_set, str1);
+				if (index != -1) {
+					ldms_metric_set_u64(general_metric_set, index, val1);
+				}/* else {
+				// this is a normal case as lustre evolves reporting
+	                                ovis_log(lustre_client_log, OVIS_LWARNING, SAMP ": llite stats metric not found: %s\n",
+                                                 str1);
+				} */
+			} else {
+				/* sum metric */
                                 ldms_metric_set_u64(general_metric_set, index, val2);
                         }
                         continue;

--- a/ldms/src/sampler/lustre_client/lustre_client_general.c
+++ b/ldms/src/sampler/lustre_client/lustre_client_general.c
@@ -69,7 +69,18 @@ static const char *extra215_llite_stats_uint64_t_entries[] = {
         "write",
         "opencount",
         "openclosetime",
-        NULL
+	"fallocate",
+	"pcc_attach",
+	"pcc_detach",
+	"pcc_auto_attach",
+	"pcc_hit_bytes",
+	"pcc_attach_bytes",
+	"hybrid_noswitch",
+	"hybrid_writesize_switch",
+	"hybrid_readsize_switch",
+	"hybrid_read_bytes.sum",
+	"hybrid_write_bytes.sum",
+	NULL
 };
 
 /* the following exist at least as far back as 2.15 lustre clients */

--- a/ldms/src/sampler/lustre_client/lustre_client_general.h
+++ b/ldms/src/sampler/lustre_client/lustre_client_general.h
@@ -12,8 +12,18 @@
 #include "comp_id_helper.h"
 #include "sampler_base.h"
 
+
 int llite_general_schema_is_initialized();
-int llite_general_schema_init(comp_id_t cid);
+
+#define EXTRA215 0x1
+#define EXTRATIMES 0x2
+/*
+ * \param schema_extras is composed of the bit flags EXTRA* above
+ * to enable extra items. Fixed names for the schema variants
+ * are defined as lustre_client_%d, with the value of schema_extras,
+ * unless schema_extras==0.
+ */
+int llite_general_schema_init(comp_id_t cid, int schema_extras);
 void llite_general_schema_fini();
 ldms_set_t llite_general_create(const char *producer_name,
                                 const char *fs_name,


### PR DESCRIPTION
This adds a test mode option for reading fake sample data without root access and two options to include new/supplementary data in the schema.

Forward port to main of PR #1692.