### PR TITLE
Update systemd files to run ldmsd as exec

### DIFF
--- a/ldms/etc/systemd/ldmsd.aggregator.service.in
+++ b/ldms/etc/systemd/ldmsd.aggregator.service.in
@@ -3,7 +3,7 @@ Description = LDMS Daemon
 Documentation = http://ovis.ca.sandia.gov
 
 [Service]
-Type = forking
+Type = exec
 LimitNOFILE = ${LDMSD_ULIMIT_NOFILE}
 EnvironmentFile = @sysconfdir@/ldms/ldmsd.aggregator.env
 Environment = HOSTNAME=%H
@@ -15,7 +15,6 @@ ExecStart = @sbindir@/ldmsd \
 		-v ${LDMSD_VERBOSE} \
 		-m ${LDMSD_MEM} \
 		$LDMSD_LOG_OPTION \
-		-P ${LDMSD_NUM_THREADS} \
 		-r @localstatedir@/run/ldmsd/aggregator.pid
 
 [Install]

--- a/ldms/etc/systemd/ldmsd.kokkos.service.in
+++ b/ldms/etc/systemd/ldmsd.kokkos.service.in
@@ -3,7 +3,7 @@ Description = LDMS Kokkos Daemon
 Documentation = http://ovis.ca.sandia.gov
 
 [Service]
-Type = forking
+Type = exec
 EnvironmentFile = @sysconfdir@/ldms/ldmsd.kokkos.env
 LimitNOFILE = ${LDMSD_ULIMIT_NOFILE}
 Environment = HOSTNAME=%H

--- a/ldms/etc/systemd/ldmsd.sampler.service.in
+++ b/ldms/etc/systemd/ldmsd.sampler.service.in
@@ -3,7 +3,7 @@ Description = LDMS Sampler Daemon
 Documentation = http://ovis.ca.sandia.gov
 
 [Service]
-Type = forking
+Type = exec
 EnvironmentFile = @sysconfdir@/ldms/ldmsd.sampler.env
 Environment = HOSTNAME=%H
 ExecStartPre = /bin/mkdir -p @localstatedir@/run/ldmsd

--- a/ldms/etc/systemd/papi-sampler.service.in
+++ b/ldms/etc/systemd/papi-sampler.service.in
@@ -3,7 +3,7 @@ Description = LDMS PAPI Daemon
 Documentation = http://ovis.ca.sandia.gov
 
 [Service]
-Type = forking
+Type = exec
 EnvironmentFile = /opt/ovis/etc/ldms/papi-sampler.env
 Environment=HOSTNAME=%H
 ExecStartPre = /bin/mkdir -p /opt/ovis/var/run/ldmsd


### PR DESCRIPTION
LDMSD now runs in the foreground by default and will not start properly with systemd service type 'forking' Remove deprecated "-P" option from ldmsd.aggregator.service.in file