### PR TITLE
fix base pointer misuse in dcgm_sampler no use_base configuration

### DIFF
--- a/ldms/scripts/examples/dcgm1
+++ b/ldms/scripts/examples/dcgm1
@@ -1,15 +1,18 @@
 export plugname=dcgm
 portbase=61073
-VGARGS="--leak-check=full --track-origins=yes --trace-children=yes"
+VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=definite"
 JOBDATA $TESTDIR/job.data 1 2
+#vgon
+LDMSD -p  prolog.jobid 1
+SLEEP 2
 vgoff
-LDMSD -p prolog.jobid 1 2
-vgoff
+LDMSD -p prolog.jobid  2
+SLEEP 5
 MESSAGE ldms_ls on host 1:
 LDMS_LS 1 -lv
 SLEEP 1
 MESSAGE ldms_ls on host 2:
-LDMS_LS 2 -l
+LDMS_LS 2 -v
 SLEEP 5
 KILL_LDMSD 1 2
 file_created $STOREDIR/node/$testname

--- a/ldms/scripts/examples/dcgm1.1
+++ b/ldms/scripts/examples/dcgm1.1
@@ -1,3 +1,3 @@
 load name=dcgm_sampler
-config name=dcgm_sampler producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} interval=1000000 perm=757 uid=3556 gid=3556 job_set=localhost${i}/jobid use_base=1
+config name=dcgm_sampler producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} interval=1000000 perm=757 uid=3556 gid=3556 job_set=localhost${i}/jobid use_base=0
 start name=dcgm_sampler interval=1000000 offset=0

--- a/ldms/scripts/examples/dcgm_nobase
+++ b/ldms/scripts/examples/dcgm_nobase
@@ -1,0 +1,16 @@
+export plugname=dcgm
+portbase=61073
+VGARGS="--leak-check=full --show-leak-kinds=definite  --track-origins=yes --trace-children=yes"
+JOBDATA $TESTDIR/job.data 1 2
+#vgon
+LDMSD -p prolog.jobid 1
+vgoff
+LDMSD -p prolog.jobid 2
+SLEEP 20
+vgoff
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -lv
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -v
+KILL_LDMSD $(seq 2)
+file_created $STOREDIR/node/nobase_$testname

--- a/ldms/scripts/examples/dcgm_nobase.1
+++ b/ldms/scripts/examples/dcgm_nobase.1
@@ -1,0 +1,3 @@
+load name=dcgm_sampler
+config name=dcgm_sampler producer=localhost${i} schema=nobase_${testname} instance=localhost${i}/${testname} component_id=${i} interval=1000000 perm=757 uid=3556 gid=3556 job_set=localhost${i}/jobid
+start name=dcgm_sampler interval=1000000 offset=0

--- a/ldms/scripts/examples/dcgm_nobase.2
+++ b/ldms/scripts/examples/dcgm_nobase.2
@@ -1,0 +1,23 @@
+# cannot load sampler instance on same node.
+
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} reconnect=2000000
+prdcr_start name=localhost1
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=store_${testname} plugin=store_csv schema=base_${testname} container=node
+strgp_prdcr_add name=store_${testname} regex=.*
+strgp_start name=store_${testname}
+
+strgp_add name=store_nobase${testname} plugin=store_csv schema=nobase_${testname} container=node
+strgp_prdcr_add name=store_nobase${testname} regex=.*
+strgp_start name=store_nobase${testname}
+
+strgp_add name=jobid.csv plugin=store_csv schema=jobid container=node
+strgp_prdcr_add name=jobid.csv regex=.*
+strgp_start name=jobid.csv

--- a/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
+++ b/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
@@ -188,7 +188,7 @@ static int dcgm_init()
                 return -1;
         }
 
-        /* Group tpye DCGM_GROUP_DEFAULT means all GPUs on the system */
+        /* Group type DCGM_GROUP_DEFAULT means all GPUs on the system */
         rc = dcgmGroupCreate(dcgm_handle, DCGM_GROUP_DEFAULT,
                              (char *)"ldmsd_group", &gpu_group_id);
         if (rc != DCGM_ST_OK){
@@ -364,10 +364,13 @@ static int gpu_sample()
         int i;
         int rc = DCGM_ST_OK;
 
-	ldms_set_t set_old = base->set; /* this should be null */
-
         for (i = 0; i < gpu_ids_count; i++) {
+		if (!gpu_sets[gpu_ids[i]]) {
+			ovis_log(mylog, OVIS_LERROR, "sets not created\n");
+			return -1;
+		}
 		if (base) {
+			ldms_set_t set_old = base->set; /* this should be null */
 			base->set = gpu_sets[gpu_ids[i]];
 			base_sample_begin(base);
 			base->set = set_old;
@@ -379,11 +382,12 @@ static int gpu_sample()
         rc = dcgmGetLatestValues(dcgm_handle, gpu_group_id, field_group_id,
                                  &sample_cb, NULL);
         if (rc != DCGM_ST_OK){
-                ovis_log(mylog, OVIS_LERROR, SAMP" failed dcgmGetLatestValues(): %d\n", rc);
+                ovis_log(mylog, OVIS_LERROR, "failed dcgmGetLatestValues(): %d\n", rc);
                 rc = -1;
         }
         for (i = 0; i < gpu_ids_count; i++) {
 		if (base) {
+			ldms_set_t set_old = base->set; /* this should be null */
 			base->set = gpu_sets[gpu_ids[i]];
 			base_sample_end(base);
 			base->set = set_old;


### PR DESCRIPTION
this also adds the simple integration test case for the no sampler_base configuration of dcgm_sampler.