### PR TITLE
https://github.com/ovis-hpc/ldms/issues/1846

### DIFF
--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -4353,7 +4353,11 @@ cdef class MsgData(object):
         uid = ev.recv.cred.uid
         gid = ev.recv.cred.gid
         perm = ev.recv.perm
-        tid = threading.get_native_id()
+        # https://github.com/ovis-hpc/ldms/issues/1846
+        if sys.version_info >= (3, 8):
+            tid = threading.get_native_id()
+        else:
+            tid = threading.get_ident()
         obj = MsgData(name, src, tid, uid, gid, perm, is_json, data,
                          raw_data,
                          ldms.ldms_msg_type_e(ev.recv.type))


### PR DESCRIPTION
ldms/python/ldms.pyx requires the threading.get_native_id() function, which is available in Python 3.8 and newer.

For older Python versions (e.g., 3.6 on SLES15sp5), use threading.get_ident() instead.

This patch adds compatibility for these older Python versions.