### PR TITLE
Fix prdcr_listen's acc bit

### DIFF
--- a/ldms/man/ldmsd_peer_daemon_advertisement.rst
+++ b/ldms/man/ldmsd_peer_daemon_advertisement.rst
@@ -38,7 +38,7 @@ advertiser_status
 \**Aggregator Side Commands*\*
 
 prdcr_listen_add
-   name=\ *NAME*" [regex=\ *REGEX*] [ip=\ *CIDR*]
+   name=\ *NAME*" [perm=\ *PERM*] [regex=\ *REGEX*] [ip=\ *CIDR*]
    [disable_start=\ *TRUE|FALSE*] [quota=\ *QUOTA*]
    [rx_rate=\ *RX_RATE*] [type=\ *passive|active*]
    [advertiser_port=\ *PORT*] [advertiser_xprt=\ *XPRT*]
@@ -166,6 +166,9 @@ optional parameter is:**
 
    name=NAME
       String of the prdcr_listen name
+
+   [perm=PERM]
+      Permission to modify the prdcr_listen
 
    [regex=REGEX]
       Regular expression to match with hostnames of peer daemons

--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -229,7 +229,7 @@ LDMSD_CTRL_CMD_MAP = {'usage': {'req_attr': [], 'opt_attr': ['name']},
                                            'opt_attr': ['rail', 'ip', 'quota', 'rx_rate',
                                                         'regex', 'disable_start', 'reconnect',
                                                         'advertiser_xprt', 'advertiser_port', 'type',
-                                                        'advertiser_auth']},
+                                                        'advertiser_auth', 'perm']},
                       'prdcr_listen_del': {'req_attr': ['name'], 'opt_attr': []},
                       'prdcr_listen_start': {'req_attr': ['name'], 'opt_attr': []},
                       'prdcr_listen_stop': {'req_attr': ['name'], 'opt_attr': []},
@@ -2679,8 +2679,9 @@ class Communicator(object):
             self.close()
             return errno.ENOTCONN, str(e)
 
-    def prdcr_listen_add(self, name, reconnect=None, disable_start=None, regex=None, ip=None, rail=None, quota=None, rx_rate=None,
-                        type="passive", advertiser_xprt=None, advertiser_port=None, advertiser_auth=None):
+    def prdcr_listen_add(self, name, perm=None, disable_start=None, regex=None, ip=None, quota=None, rx_rate=None,
+                        type="passive", advertiser_xprt=None, advertiser_port=None, advertiser_auth=None,
+                        reconnect=None, rail=None):
         """
         Tell an aggregator to wait for advertisements from samplers
 
@@ -2692,6 +2693,7 @@ class Communicator(object):
          - Name of the producer listen
 
         Keyword Parameters:
+         perm - Permission of prdcr_listen configuration object
          regex - Regular expression to match sampler hostnames
          ip - IP range in the CIDR format
          disable_start - True if prdcr_listen should only create advertised producers.
@@ -2731,6 +2733,8 @@ class Communicator(object):
             attr_list.append(LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.AUTH, value=advertiser_auth))
         if reconnect is not None:
             attr_list.append(LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.INTERVAL, value=reconnect))
+        if perm is not None:
+            attr_list.append(LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.PERM, value=perm))
 
         req = LDMSD_Request(command_id=LDMSD_Request.PRDCR_LISTEN_ADD,
                             attrs=attr_list)

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -3093,6 +3093,7 @@ class LdmsdCmdParser(cmd.Cmd):
                 [ip=]              An IP masks to filter advertisements using the source IP
                 [regex=]           A regular expression to match sampler hostnames
                 [disable_start=]   Tell LDMSD not to start the producers
+                [perm=]            The permission to modify the prdcr_listen in the future
             Parameters to Control Advertised Producers:
                 [quota=]           The send quota our ldmsd (the one we are controlling)
                                    advertises to the prdcr (default: value from ldmsd --quota


### PR DESCRIPTION
Without the change, the UID, GID, and Permission of prdcr_listen configuration objects are always 0. The patch fixes this.