### PR TITLE
Minor GPU sampler build fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,9 +154,12 @@ m4_ifndef([PKG_CHECK_MODULES],
 PKG_PROG_PKG_CONFIG
 
 # <rdc/rdc.h> fails to include <assert.h> in at least rocm 6.2.1, hence the
-# include of assert.h here.
+# include of assert.h here. No longer needed as of >=6.4.0
+# rdc/rdc.h in at least ROCm 6.4.0/6.4.1 forgets to include <stdbool.h>,
+# so we include it here for them before including <rdc/rdc.h> */
 AC_LIB_HAVE_LINKFLAGS([rdc_bootstrap], [], [
 #include <assert.h>
+#include <stdbool.h>
 #include <rdc/rdc.h>
 ])
 AM_CONDITIONAL([HAVE_LIBRDC_BOOTSTRAP], [test "x$HAVE_LIBRDC_BOOTSTRAP" = xyes])

--- a/ldms/src/sampler/dcgm_sampler/Makefile.am
+++ b/ldms/src/sampler/dcgm_sampler/Makefile.am
@@ -15,7 +15,8 @@ libdcgm_sampler_la_LDFLAGS = \
         -export-symbols-regex 'ldmsd_plugin_interface' \
         -version-info 1:0:0
 libdcgm_sampler_la_CPPFLAGS = \
-	@OVIS_INCLUDE_ABS@
+	@OVIS_INCLUDE_ABS@ \
+	-I/usr/include/datacenter-gpu-manager-4
 
 pkglib_LTLIBRARIES = libdcgm_sampler.la
 

--- a/ldms/src/sampler/rdc_sampler/rdcinfo.h
+++ b/ldms/src/sampler/rdc_sampler/rdcinfo.h
@@ -58,6 +58,9 @@
 /* rdc/rdc.h in at least ROCm 6.2.1 forget to include <assert.h>, so we
  * include it here for them before including <rdc/rdc.h> */
 #include <assert.h>
+/* rdc/rdc.h in at least ROCm 6.4.0/6.4.1 forgets to include <stdbool.h>,
+ * so we include it here for them before including <rdc/rdc.h> */
+#include <stdbool.h>
 #include <rdc/rdc.h>
 
 #define SAMP "rdc_sampler"


### PR DESCRIPTION
This PR contains two simple GPU sampler build fixes.

In DCGM 4.0, they moved the headers to
    
  /usr/include/datacenter-gpu-manager-4
    
and now require ana explicit preprocessor include:
    
  -I/usr/include/datacenter-gpu-manager-4
    
There is no harm in adding that include all the time, even
when dcgm 3 is installed. When dcgm 3 is installed, the
headers will just be found in the standard path. So we add
that to CPPFLAGS in the dcgm_sampler build.

In ROCm 6.4.1 the rdc.h header began using the "bool" type, 
but failed to #include <stdbool.h>. So it won't compile on its own.
We add stdbool.h to the librdc test in configure.ac and also add it to the
rdc_sampler.
