### PR TITLE
Add parameter checking to ldms_xprt_rail_new

### DIFF
--- a/ldms/src/core/ldms_rail.c
+++ b/ldms/src/core/ldms_rail.c
@@ -255,12 +255,12 @@ ldms_t ldms_xprt_rail_new(const char *xprt_name,
 		goto err_0;
 	}
 
-	if (strlen(auth_name) > LDMS_AUTH_NAME_MAX) {
+	if (!auth_name || (strlen(auth_name) > LDMS_AUTH_NAME_MAX)) {
 		errno = EINVAL;
 		goto err_0;
 	}
 
-	if (strlen(xprt_name) >= LDMS_MAX_TRANSPORT_NAME_LEN) {
+	if (!xprt_name || (strlen(xprt_name) >= LDMS_MAX_TRANSPORT_NAME_LEN)) {
 		errno = EINVAL;
 		goto err_0;
 	}


### PR DESCRIPTION
Add NULL parameter checking for the xprt name and auth_name parameters. Presently, the function will crash if either of these parameters is NULL. This patch returns EINVAL instead.