### PR TITLE
slingshot_metrics: drop support for "groups"

### DIFF
--- a/ldms/src/sampler/slingshot_metrics/ldms-sampler_slingshot_metrics.rst
+++ b/ldms/src/sampler/slingshot_metrics/ldms-sampler_slingshot_metrics.rst
@@ -81,12 +81,11 @@ The names of the counters can be found in the slingshot/cassini header
 file cassini_cntr_def.h in the array c1_cntr_defs (specifically the
 strings in the "name" field of said array entries).
 
-In addition to the individual counter names, this plugin allows
-specifying entire groups of counters by using the counter name pattern
-"group:<group name>", for insance, "group:hni". The available groups
-are: ext, pi_ipd, mb, cq, lpe, hni, ext2. These groups correspond with
-the enum c_cntr_group in the cassini_cntr_def.h file. Additionally, one
-may use "group:all", which simply includes all available counters.
+NOTE: If you used "group:<group name>" syntax in the past, that is no longer
+available due to API changes in the Slingshot Host Software stack (at least
+as of release/shs-12.0.0, perhaps earlier).
+
+However, you one may still use "group:all" to include all available counters.
 
 EXAMPLES
 ========

--- a/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
+++ b/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
@@ -294,27 +294,9 @@ static int use_counter(const char * const counter_name);
 static int use_counter_group(const char * const counter_group)
 {
         int i;
-        bool all_counters = false;
-        enum c_cntr_group group;
         int rc;
 
-        if (!strcmp(counter_group, "all")) {
-                all_counters = true;
-        } else if (!strcmp(counter_group, "ext")) {
-                group = C_CNTR_GROUP_EXT;
-        } else if (!strcmp(counter_group, "pi_ipd")) {
-                group = C_CNTR_GROUP_PI_IPD;
-        } else if (!strcmp(counter_group, "mb")) {
-                group = C_CNTR_GROUP_MB;
-        } else if (!strcmp(counter_group, "cq")) {
-                group = C_CNTR_GROUP_CQ;
-        } else if (!strcmp(counter_group, "lpe")) {
-                group = C_CNTR_GROUP_LPE;
-        } else if (!strcmp(counter_group, "hni")) {
-                group = C_CNTR_GROUP_HNI;
-        } else if (!strcmp(counter_group, "ext2")) {
-                group = C_CNTR_GROUP_EXT2;
-        } else {
+        if (strcmp(counter_group, "all")) {
                 ovis_log(mylog, OVIS_LERROR, "unrecognized counter group \"%s\"\n",
                        counter_group);
                 return -1;
@@ -326,7 +308,7 @@ static int use_counter_group(const char * const counter_group)
                            due to grouping, and leaving space for future new
                            counters */
                         continue;
-                } else if (all_counters || c1_cntr_descs[i].group == group) {
+                } else {
                         rc = use_counter(c1_cntr_descs[i].name);
                         if (rc != 0) {
                                 return rc;


### PR DESCRIPTION
At least as of Slingshot Host Software release/shs-12.0.0, the API surrounding "groups" has been broken. As a result, we drop support for all groups except for "group:all".