### PR TITLE
Iterate using sizeof for LDMS_MSG_TYPE and LDMS_MSG_EVENT_TYPE

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -6132,7 +6132,7 @@ const char *ldms_msg_type_sym(ldms_msg_type_t t)
 		[LDMS_MSG_AVRO_SER] = "LDMS_MSG_AVRO_SER",
 	};
 
-	if (t <= LDMS_MSG_AVRO_SER)
+	if (t < sizeof(tbl) / sizeof(tbl[0]))
 		return tbl[t];
 	assert(NULL=="Invalid ldms_msg type");
 }
@@ -6147,8 +6147,7 @@ const char *ldms_msg_event_type_sym(enum ldms_msg_event_type t)
 		[LDMS_MSG_EVENT_UNSUBSCRIBE_STATUS] =
 			"LDMS_MSG_EVENT_UNSUBSCRIBE_STATUS"
 	};
-	if (t <= LDMS_MSG_EVENT_CLIENT_CLOSE) {
+	if (t < sizeof(tbl) / sizeof(tbl[0]))
 		return tbl[t];
-	}
 	assert(NULL=="Invalid ldms_msg_event type");
 }


### PR DESCRIPTION
In the future, if new ldms_msg message types and event types are required, they can be added without modifying the check