### PR TITLE
Disable the ldms_msg API by default

### DIFF
--- a/ldms/python/ldms.pxd
+++ b/ldms/python/ldms.pxd
@@ -878,6 +878,7 @@ cdef extern from "ldms.h" nogil:
     ctypedef int (*ldms_msg_event_cb_t)(ldms_msg_event_t ev, void *cb_arg) except *
 
     void ldms_msg_disable()
+    void ldms_msg_enable()
     int ldms_msg_is_enabled()
     int ldms_msg_publish(ldms_t x, const char *name,
                             ldms_msg_type_e msg_type,

--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -4800,5 +4800,8 @@ def ovis_log_set_level_by_name(str subsys_name, level):
 def msg_disable():
     ldms_msg_disable()
 
+def msg_enable():
+    ldms_msg_enable()
+
 def msg_is_enabled():
     return ldms_msg_is_enabled()

--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -150,6 +150,7 @@ LDMSD_CTRL_CMD_MAP = {'usage': {'req_attr': [], 'opt_attr': ['name']},
                       'msg_stats' : {'req_attr': [], 'opt_attr': ['regex', 'stream', 'json', 'reset']},
                       'msg_client_stats' : {'req_attr': [], 'opt_attr': ['json', 'reset']},
                       'msg_disable' : {'req_attr': [], 'opt_attr':[]},
+                      'msg_enable' : {'req_attr': [], 'opt_attr':[]},
                       ##### Daemon #####
                       'daemon_status': {'req_attr': [], 'opt_attr': ['thread_stats']},
                       ##### Misc. #####
@@ -675,6 +676,7 @@ class LDMSD_Request(object):
     MSG_STATS = 0xc00
     MSG_CLIENT_STATS = MSG_STATS + 1
     MSG_DISABLE = MSG_STATS + 2
+    MSG_ENABLE = MSG_STATS + 3
 
     LDMSD_REQ_ID_MAP = {
             'example': {'id': EXAMPLE},
@@ -1562,7 +1564,7 @@ class Communicator(object):
 
     def msg_disable(self):
         """
-        Disable LDMS message service in the daemon
+        Disable the LDMS message service in the daemon
 
         No parameters
         """
@@ -1574,6 +1576,19 @@ class Communicator(object):
         except Exception as e:
             return errno.ENOTCONN, str(e)
 
+    def msg_enable(self):
+        """
+        Enable LDMS the message service in the daemon
+
+        No parameters
+        """
+        req = LDMSD_Request(command_id=LDMSD_Request.MSG_ENABLE)
+        try:
+            req.send(self)
+            resp = req.receive(self)
+            return resp['errcode'], resp['msg']
+        except Exception as e:
+            return errno.ENOTCONN, str(e)
 
     def listen(self, xprt, port, host=None, auth=None, quota=None, rx_limit=None):
         """

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -2702,6 +2702,7 @@ class LdmsdCmdParser(cmd.Cmd):
             print(emsg)
             if is_debug:
                 raise RuntimeError(emsg)
+            return
         streams = fmt_status(msg)
         if arg.get('json'):
             print(json.dumps(streams, indent=1))
@@ -2760,6 +2761,7 @@ class LdmsdCmdParser(cmd.Cmd):
             print(emsg)
             if is_debug:
                 raise RuntimeError(emsg)
+            return
         clients = fmt_status(msg)
         if arg.get('json'):
             print(json.dumps(clients, indent=1))
@@ -2798,7 +2800,7 @@ class LdmsdCmdParser(cmd.Cmd):
 
     def do_msg_disable(self, arg):
         """
-        Disable LDMS Message Service in the daemon
+        Disable the LDMS Message Service in the daemon
 
         No Parameters
         """
@@ -2811,6 +2813,22 @@ class LdmsdCmdParser(cmd.Cmd):
 
     def complete_msg_disable(self, text, line, begidx, endidx):
         return self.__complete_attr_list('msg_disable', text)
+
+    def do_msg_enable(self, arg):
+        """
+        Enable the LDMS Message Service in the daemon
+
+        No Parameters
+        """
+        rc, msg = self.comm.msg_enable()
+        if rc != 0:
+            print(f'Error {rc}: {msg}')
+        else:
+            print('LDMS Message Service is ENABLED in the daemon')
+        return
+
+    def complete_msg_enable(self, text, line, begidx, endidx):
+        return self.__complete_attr_list('msg_enable', text)
 
     def do_listen(self, arg):
         """

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -1389,12 +1389,14 @@ typedef enum ldms_msg_type_e {
 } ldms_msg_type_t;
 
 /**
- * \brief Disable LDMS Message service
- *
- * Similar to \c ldmsd_stream, this service can be disabled but cannot be
- * enabled afterward.
+ * \brief Disable the LDMS Message service
  */
 void ldms_msg_disable();
+
+/**
+ * \brief Enable the LDMS Message service
+ */
+void ldms_msg_enable();
 
 /**
  * \brief Check if LDMS Message Service is enabled.

--- a/ldms/src/core/ldms_msg.c
+++ b/ldms/src/core/ldms_msg.c
@@ -94,7 +94,8 @@ static ovis_log_t __ldms_msg_log = NULL; /* see __ldms_msg_init() below */
 
 static int __msg_stats_level = 1;
 
-int ldms_msg_enabled = 1;
+/* Disable message support by default */
+int ldms_msg_enabled = 0;
 
 struct __msg_event_s {
 	struct ldms_msg_event_s pub;
@@ -2399,6 +2400,11 @@ int ldms_msg_publish_file(ldms_t x, const char *name,
 void ldms_msg_disable()
 {
 	ldms_msg_enabled = 0;
+}
+
+void ldms_msg_enable()
+{
+	ldms_msg_enabled = 1;
 }
 
 int ldms_msg_is_enabled()

--- a/ldms/src/ldmsd/ldmsd_request.h
+++ b/ldms/src/ldmsd/ldmsd_request.h
@@ -221,6 +221,7 @@ enum ldmsd_request {
 	LDMSD_MSG_STATS_REQ = 0xc00, /* Query stats of message service of this process */
 	LDMSD_MSG_CLIENT_STATS_REQ,  /* Query message client stats of this process */
 	LDMSD_MSG_DISABLE_REQ,       /* Disable message service */
+	LDMSD_MSG_ENABLE_REQ,	     /* Enable message service */
 };
 
 enum ldmsd_request_attr {


### PR DESCRIPTION
This change adds a new command 'msg_enable' that will enable the LDMS message service. It also changes the behavior in that the msg service can be enabled after it has been disabled. This used to be prohibited, however, the service is now disabled by default, therefore it must be permitted to enable the disabled message service.

Also added are configuration MSG_ENABLE_REQ and API ldms_msg_enable() and associated logic.

The msg_stats and msg_client_stats commands will not return data when the service is disabled and instead report an error indicating the the LDMS message service is disabled.