### PR TITLE
Fix ax_python_module_version.m4 file

### DIFF
--- a/m4/ax_python_module_version.m4
+++ b/m4/ax_python_module_version.m4
@@ -28,10 +28,31 @@
 AC_DEFUN([AX_PYTHON_MODULE_VERSION], [
     AX_PYTHON_MODULE([$1], [required], [$3])
     AC_MSG_CHECKING([for version $2 or higher of $1])
-    $PYTHON -c "import sys, $1; from distutils.version import StrictVersion; sys.exit(StrictVersion($1.__version__) < StrictVersion('$2'))" 2> /dev/null
+
+    python_fullversion=`${PYTHON} -c "import sys; print(sys.version)" | sed q`
+    python_majorversion=`echo "$python_fullversion" | sed '[s/^\([0-9]*\).*/\1/]'`
+    python_minorversion=`echo "$python_fullversion" | sed '[s/^[0-9]*\.\([0-9]*\).*/\1/]'`
+    python_version=`echo "$python_fullversion" | sed '[s/^\([0-9]*\.[0-9]*\).*/\1/]'`
+
+    # Reject unsupported Python versions as soon as practical.
+    if test "$python_majorversion" -lt 3; then
+      AC_MSG_ERROR([Python version $python_version is too old (version 3 or later is required)])
+    fi
+    # Determine which version class to use based on Python version
+    if test "$python_majorversion" -gt 3 || (test "$python_majorversion" -eq 3 && test "$python_minorversion" -ge 12); then
+        VERSION_CLASS="packaging.version"
+        VERSION_MODULE="Version"
+    else
+        VERSION_CLASS="distutils.version"
+        VERSION_MODULE="StrictVersion"
+    fi
+
+    # Check the module version using the selected version class
+    mod_ver=`$PYTHON -c "import sys, $1; from $VERSION_CLASS import $VERSION_MODULE; sys.exit(print($VERSION_MODULE($1.__version__)))"`
+    $PYTHON -c "import sys, $1; from $VERSION_CLASS import $VERSION_MODULE; sys.exit($VERSION_MODULE($1.__version__) < $VERSION_MODULE('$2'))" 2> /dev/null
     AS_IF([test $? -eq 0], [], [
         AC_MSG_RESULT([no])
-        AC_MSG_ERROR([You need at least version $2 of the $1 Python module.])
+        AC_MSG_ERROR([You need at least version $2 of the $1 Python module. Version detected is $mod_ver.])
     ])
     AC_MSG_RESULT([yes])
 ])


### PR DESCRIPTION
Closes #1854 

Condition based on 3.12+ python versions to use `from packaging.version import Version` in detecting module version since distutils is not supported in 3.12 python.

This may also resolve the issue #1869, but I'd need to see the config.log of the error encountered to know that for sure.