### PR TITLE
Remove obsolete python argparse test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -776,7 +776,6 @@ AS_IF([test "x$want_python" != xno], [
 		[AX_PYTHON_DEVEL([>='3.6'])
 		 pkgpythondir="${pythondir}/ovis_ldms"
 		 pkgpyexecdir="${pkgpythondir}"
-		 AX_PYTHON_MODULE_VERSION(["argparse"], 1.1, "python")
 		 python_found=true
 		 CYTHON_CHECK([0.25], [$PYTHON_VERSION],
 		 	[cython_found=true], [cython_found=false])],


### PR DESCRIPTION
argparse has been in the python standard library since python 3.2. We require at least python 3.6. Also, modules that enter the standard library almost universally stop having their individual versions incremented, instead being versioned by python's global version.

Thus our test for the argparse version is obsolete and can be removed.