### PR TITLE
  fix potential use-after-free in ldms_msg_subscribe path

### DIFF
--- a/ldms/src/core/ldms_msg.c
+++ b/ldms/src/core/ldms_msg.c
@@ -219,6 +219,8 @@ static int __part_send(struct ldms_rail_ep_s *rep,
  out:
 	if (req)
 		free(req);
+	if (req->msg_part.more != 0)
+		va_end(ap);
 	return rc;
 }
 
@@ -1104,6 +1106,7 @@ __client_alloc(const char *match, int is_regex,
 	goto out;
  err_0:
 	free(c);
+	c = NULL;
  out:
 	return c;
 }


### PR DESCRIPTION
fix potential use-after-free in ldms_msg_subscribe path.
also fixed potential missing va_end in ldsm_msg_publish path
