### PR TITLE
 minimal fix to zap_event_str in zap.c (change range check)

### DIFF
--- a/lib/src/zap/zap.c
+++ b/lib/src/zap/zap.c
@@ -201,7 +201,7 @@ enum zap_err_e zap_errno2zerr(int e)
 
 const char* zap_event_str(enum zap_event_type e)
 {
-	if ((int)e < 0 || e > ZAP_EVENT_LAST)
+	if ((int)e < 1 || e >= ZAP_EVENT_LAST)
 		return "ZAP_EVENT_UNKNOWN";
 	return __zap_event_str[e];
 }


### PR DESCRIPTION
Valid zap events range from 1 to zap_event_last-1.

 Changing enum define to use  ZAP_EVENT_LAST=ZAP_EVENT_SEND_COMPLETE
 might be a good idea, but may touch other code or tests of inter-version enum compatibility
