### PR TITLE
 document ovis_log.h that the result of ovis_log_level_to_str must be freed.

### DIFF
--- a/lib/src/ovis_log/ovis_log.h
+++ b/lib/src/ovis_log/ovis_log.h
@@ -376,6 +376,7 @@ int ovis_log_str_to_level(const char *level_s);
  *
  * \return a string. On errors, NULL is returned, and errno is set.
  */
+__attribute__((malloc))
 char *ovis_log_level_to_str(int level);
 
 #endif


### PR DESCRIPTION
    document ovis_log.h that the result of ovis_log_level_to_str must be freed.

This lets both the compiler & user can easily see it in ovis_log.h.
ovis_log_level_to_str should not appear directly in a formatting argument list.


