### PR TITLE
 fix ovis_log leaks/wild pointers in log_register and open      

### DIFF
--- a/lib/src/ovis_log/ovis_log.c
+++ b/lib/src/ovis_log/ovis_log.c
@@ -405,7 +405,7 @@ ovis_log_t ovis_log_register(const char *subsys_name, const char *desc)
 		errno = EEXIST;
 		return NULL;
 	}
-	log = malloc(sizeof(*log));
+	log = calloc(1, sizeof(*log));
 	if (!log) {
 		errno = ENOMEM;
 		return NULL;
@@ -469,7 +469,7 @@ static int __get_log_info(ovis_log_t l, struct ovis_log_buf *buf)
 	char *level_s;
 
 	if (l->level == OVIS_LDEFAULT)
-		level_s = "default";
+		level_s = strdup("default");
 	else
 		level_s = ovis_log_level_to_str(l->level);
 
@@ -477,7 +477,8 @@ static int __get_log_info(ovis_log_t l, struct ovis_log_buf *buf)
 			        "\"desc\":\"%s\","
 			        "\"level\":\"%s\"}",
 				l->name, l->desc,
-				level_s);
+				level_s ? level_s : "out_of_memory");
+	free(level_s);
 	return rc;
 }
 
@@ -518,12 +519,14 @@ char *ovis_log_list(const char *subsys)
 		goto err;
 	}
 
+	char *lls = ovis_log_level_to_str(default_log.level);
 	rc = __buf_append(buf, "{\"name\":\"%s (default)\","
 			        "\"desc\":\"%s\","
 			        "\"level\":\"%s\"}",
 				default_log.name,
 				default_log.desc,
-				ovis_log_level_to_str(default_log.level));
+				lls);
+	free(lls);
 	if (rc) {
 		errno = rc;
 		goto err;
@@ -594,12 +597,14 @@ static FILE *__log_open(const char *path)
 		ovis_log(NULL, OVIS_LERROR,
 				"Cannot redirect log to %s\n", path);
 		errno = EINTR;
+		fclose(f);
 		return NULL;
 	}
 	if (dup2(fd, 2) < 0) {
 		ovis_log(NULL, OVIS_LERROR,
 				"Cannot redirect log to %s\n", path);
 		errno = EINTR;
+		fclose(f);
 		return NULL;
 	}
 	return f;


### PR DESCRIPTION
    - fix uninit pointer use in ovis_log_register error paths
    - fix memory ovis_log_level_to_str leak in ovis_log_list
    - fix unclosed files in __log_open error paths.
