### PR TITLE
fix missing values for ldmsd_cfgobj_type_str() of ldmsd_cfgobj

### DIFF
--- a/ldms/src/ldmsd/ldmsd_cfgobj.c
+++ b/ldms/src/ldmsd/ldmsd_cfgobj.c
@@ -181,6 +181,10 @@ static const char *__cfgobj_type_str[] = {
 	[LDMSD_CFGOBJ_STRGP]  = "strgp",
 	[LDMSD_CFGOBJ_LISTEN] = "listen",
 	[LDMSD_CFGOBJ_AUTH]   = "auth",
+        [LDMSD_CFGOBJ_PRDCR_LISTEN] = "prdcr_listen",
+        [LDMSD_CFGOBJ_SAMPLER] = "sampler",
+        [LDMSD_CFGOBJ_STORE] = "store"
+
 };
 
 const char *ldmsd_cfgobj_type_str(ldmsd_cfgobj_type_t t)


### PR DESCRIPTION
without this fix, callers of the type_str function can get back invalid pointers.