### PR TITLE
fix -y identification of file in -y error reporting and fix leaks /ldmsd.c

### DIFF
--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -1733,6 +1733,11 @@ struct ldmsd_str_ent {
 	TAILQ_ENTRY(ldmsd_str_ent) entry;
 };
 TAILQ_HEAD(ldmsd_str_list, ldmsd_str_ent);
+/* uncomment next line when gcc 11 is the minimum we support with ldms. */
+/* __attribute__ ((returns_nonnull)) */
+/** make a string list entry, or exit with ENOMEM.
+ * \return new list entry, which is never NULL.
+ */
 struct ldmsd_str_ent *ldmsd_str_ent_new(char *s);
 void ldmsd_str_ent_free(struct ldmsd_str_ent *ent);
 void ldmsd_str_list_destroy(struct ldmsd_str_list *list);


### PR DESCRIPTION
- fix -y identification of file in error reporting and associated memory leak
- fix memory leak in log level change error path
- mark 'cleanup' as noreturn to make gcc analyses smarter and fix file/mem leaks in cleanup.
- make (and future attribute mark) 'ldmsd_str_ent_new' as nonnull to keep -c/-y option processing code simple.