### PR TITLE
slingshot_metrics: drop support for "groups"

### DIFF
--- a/ldms/src/sampler/slingshot_metrics/ldms-sampler_slingshot_metrics.rst
+++ b/ldms/src/sampler/slingshot_metrics/ldms-sampler_slingshot_metrics.rst
@@ -1,0 +1,104 @@
+.. _slingshot_metrics:
+
+========================
+slingshot_metrics
+========================
+
+----------------------------------------------
+Man page for the LDMS slingshot_metrics plugin
+----------------------------------------------
+
+:Date:   1 May 2022
+:Manual section: 7
+:Manual group: LDMS sampler
+
+
+SYNOPSIS
+========
+
+| Within ldmsd_controller or a configuration file:
+| config name=slingshot_metrics [ <attr> = <value> ]
+
+DESCRIPTION
+===========
+
+With LDMS (Lightweight Distributed Metric Service), plugins for the
+ldmsd (ldms aemon) are configured via ldmsd_controller or a
+configuration file. The slingshot_metrics plugin provides a single
+metric set that contains a list of records. Each record contains all of
+the metrics for a single slingshot NIC.
+
+The slingshot_metrics sampler plugin provides detailed counter metrics
+for each slignshot NIC.
+
+The schema is named "slingshot_metrics" by default.
+
+CONFIGURATION ATTRIBUTE SYNTAX
+==============================
+
+The slingshot_metrics plugin uses the sampler_base base class. This man
+page covers only the configuration attributes, or those with default
+values, specific to the this plugin; see :ref:`ldms_sampler_base(7) <ldms_sampler_base>` for the
+attributes of the base class.
+
+**config**
+   | name=<plugin_name> [counters=<COUNTER NAMES>] [counters_file=<path
+     to counters file>]
+   | configuration line
+
+   name=<plugin_name>
+      |
+      | This MUST be slingshot_metrics.
+
+   counters=<COUNTER NAMES>
+      |
+      | (Optional) A CSV list of names of slingshot counter names. See
+        Section COUTNER NAMES for details. If neither this option nor
+        counters_file are specified, a default set of counters will be
+        used.
+
+   counters_files=<path to counters file>
+      |
+      | (Optional) A path to a file that contains a list of counter
+        names, one per line. See Section COUNTER NAMES for details. A
+        line will be consider a comment if the character on the line is
+        a "#". If neither this option nor counters are specified, a
+        default set of counters will be used.
+
+   refresh_interval_sec=<seconds>
+      |
+      | (Optional) The sampler caches the list of slinghost devices, and
+        that cache is refreshed at the beginning of a sample cycle if
+        the refresh interval time has been exceeded.
+        refresh_interval_sec sets the minimum number of seconds between
+        refreshes of the device cache. The default refresh interval is
+        600 seconds.
+
+COUNTER NAMES
+=============
+
+The names of the counters can be found in the slingshot/cassini header
+file cassini_cntr_def.h in the array c1_cntr_defs (specifically the
+strings in the "name" field of said array entries).
+
+NOTE: If you used "group:<group name>" syntax in the past, that is no longer
+available due to API changes in the Slingshot Host Software stack (at least
+as of release/shs-12.0.0, perhaps earlier).
+
+However, you one may still use "group:all" to include all available counters.
+
+EXAMPLES
+========
+
+Within ldmsd_conteroller or a configuration file:
+
+::
+
+   load name=slingshot_metrics
+   config name=slingshot_metrics producer=host1 instance=host1/slingshot_metrics counters=ixe_rx_tcp_pkt,group:hni refresh_interval_sec=3600
+   start name=slingshot_metrics interval=1000000 offset=0
+
+SEE ALSO
+========
+
+:ref:`ldmsd(8) <ldmsd>`, :ref:`ldms_quickstart(7) <ldms_quickstart>`, :ref:`ldmsd_controller(8) <ldmsd_controller>`, :ref:`ldms_sampler_base(7) <ldms_sampler_base>`

--- a/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
+++ b/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
@@ -293,28 +293,10 @@ static int use_counter(const char * const counter_name);
 static int use_counter_group(const char * const counter_group)
 {
         int i;
-        bool all_counters = false;
-        enum c_cntr_group group;
         int rc;
 
-        if (!strcmp(counter_group, "all")) {
-                all_counters = true;
-        } else if (!strcmp(counter_group, "ext")) {
-                group = C_CNTR_GROUP_EXT;
-        } else if (!strcmp(counter_group, "pi_ipd")) {
-                group = C_CNTR_GROUP_PI_IPD;
-        } else if (!strcmp(counter_group, "mb")) {
-                group = C_CNTR_GROUP_MB;
-        } else if (!strcmp(counter_group, "cq")) {
-                group = C_CNTR_GROUP_CQ;
-        } else if (!strcmp(counter_group, "lpe")) {
-                group = C_CNTR_GROUP_LPE;
-        } else if (!strcmp(counter_group, "hni")) {
-                group = C_CNTR_GROUP_HNI;
-        } else if (!strcmp(counter_group, "ext2")) {
-                group = C_CNTR_GROUP_EXT2;
-        } else {
-                log_fn(LDMSD_LERROR, SAMP" unrecognized counter group \"%s\"\n",
+        if (strcmp(counter_group, "all")) {
+                ovis_log(mylog, OVIS_LERROR, "unrecognized counter group \"%s\"\n",
                        counter_group);
                 return -1;
         }
@@ -325,7 +307,7 @@ static int use_counter_group(const char * const counter_group)
                            due to grouping, and leaving space for future new
                            counters */
                         continue;
-                } else if (all_counters || c1_cntr_descs[i].group == group) {
+                } else {
                         rc = use_counter(c1_cntr_descs[i].name);
                         if (rc != 0) {
                                 return rc;

--- a/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
+++ b/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
@@ -296,7 +296,7 @@ static int use_counter_group(const char * const counter_group)
         int rc;
 
         if (strcmp(counter_group, "all")) {
-                ovis_log(mylog, OVIS_LERROR, "unrecognized counter group \"%s\"\n",
+                log_fn(LDMSD_LERROR, SAMP" unrecognized counter group \"%s\" (only \"all\" is supported)\n",
                        counter_group);
                 return -1;
         }


### PR DESCRIPTION
At least as of Slingshot Host Software release/shs-12.0.0, the API surrounding "groups" has been broken. As a result, we drop support for all groups except for "group:all".

This was cherry-picked from Chris Morrone's commit f4be13e

(At the very least, I want to see if this is the correct way to create a cherry-picked pull-request based on prior feedback -- even if these changes are disregarded again. Thank you for your time!)