### PR TITLE
Add missing locking around thread stat accesses

### DIFF
--- a/lib/src/ovis_event/ovis_event.c
+++ b/lib/src/ovis_event/ovis_event.c
@@ -779,7 +779,9 @@ ovis_scheduler_thrstats_get(ovis_scheduler_t sch, struct timespec *now, uint64_t
 		return NULL;
 	}
 
+	pthread_mutex_lock(&sch->mutex);
 	res = ovis_thrstats_result_get(&sch->stats, interval_s, &sch_res->stats);
+	pthread_mutex_unlock(&sch->mutex);
 	if (!res) {
 		goto err;
 	}

--- a/lib/src/zap/fabric/zap_fabric.c
+++ b/lib/src/zap/fabric/zap_fabric.c
@@ -2585,9 +2585,9 @@ static void *z_fi_io_thread_proc(void *arg)
 
 	pthread_cleanup_push(z_fi_io_thread_cleanup, arg);
  loop:
-	zap_thrstat_wait_start(thr->zap_io_thread.stat);
+	zap_thrstat_wait_start(&thr->zap_io_thread);
 	n = epoll_wait(thr->efd, ev, N_EV, -1);
-	zap_thrstat_wait_end(thr->zap_io_thread.stat);
+	zap_thrstat_wait_end(&thr->zap_io_thread);
 	n_cq = 0;
 	n_cm = 0;
 

--- a/lib/src/zap/rdma/zap_rdma.c
+++ b/lib/src/zap/rdma/zap_rdma.c
@@ -2668,9 +2668,9 @@ static void *z_rdma_io_thread_proc(void *arg)
 	}
 	pthread_cleanup_push(z_rdma_io_thread_cleanup, arg);
  loop:
-	zap_thrstat_wait_start(thr->zap_io_thread.stat);
+	zap_thrstat_wait_start(&thr->zap_io_thread);
 	n = epoll_wait(thr->efd, events, 16, -1);
-	zap_thrstat_wait_end(thr->zap_io_thread.stat);
+	zap_thrstat_wait_end(&thr->zap_io_thread);
 	n_cm = 0;
 	for (i = 0; i < n; i++) {
 		ctxt = events[i].data.ptr;

--- a/lib/src/zap/ugni/zap_ugni.c
+++ b/lib/src/zap/ugni/zap_ugni.c
@@ -3623,9 +3623,9 @@ static void *z_ugni_io_thread_proc(void *arg)
 		/* max timeout; see 'desperately reaping CQ' note below. */
 		timeout = 250;
 	}
-	zap_thrstat_wait_start(thr->zap_io_thread.stat);
+	zap_thrstat_wait_start(&thr->zap_io_thread);
 	n = epoll_wait(thr->efd, ev, N_EV, timeout);
-	zap_thrstat_wait_end(thr->zap_io_thread.stat);
+	zap_thrstat_wait_end(&thr->zap_io_thread);
 	was_not_empty = !TAILQ_EMPTY(&thr->submitted_wrq)    ||
 			!TAILQ_EMPTY(&thr->pending_rdma_wrq) ;
 	for (i = 0; i < n; i++) {

--- a/lib/src/zap/zap.h
+++ b/lib/src/zap/zap.h
@@ -834,23 +834,22 @@ void zap_thrstat_reset_all(struct timespec *now);
  * void *io_thread_proc(void *)
  * {
  *    ...
- *    zap_thrstat_t stats = zap_thrstat_new("my_thread", 128);
  *    while (1) {
- *        zap_thrstat_wait_start(stats);
+ *        zap_thrstat_wait_start(thread);
  *        ... wait for I/O event ...
- *        zap_thrstat_wait_end(stats);
+ *        zap_thrstat_wait_end(thread);
  *        ... process I/O event ...
  *    }
  * }
  * \param stats The Zap stats handle
  */
-void zap_thrstat_wait_start(zap_thrstat_t stats);
+void zap_thrstat_wait_start(void *);
 
 /**
  * \brief End an I/O wait measurement interval
  * \param stats The Zap stats handle
  */
-void zap_thrstat_wait_end(zap_thrstat_t stats);
+void zap_thrstat_wait_end(void *);
 
 /**
  * \struct zap_thrstat_result_entry

--- a/lib/src/zap/zap_priv.h
+++ b/lib/src/zap/zap_priv.h
@@ -564,7 +564,7 @@ struct zap_io_thread {
 	/** The transport handle. */
 	zap_t zap;
 
-	/** Primarily used to protect the _ep_list */
+	/** Used to protect the _ep_list and stat entries */
 	pthread_mutex_t mutex;
 
 	/** Thread statistics */


### PR DESCRIPTION
The threads managing thread objects in the Zap and
ovis_event libraries need to take the necessary
locks.