### PR TITLE
Provide sampling interval and offset in the plugn_sets output

### DIFF
--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1681,6 +1681,15 @@ class LdmsdCmdParser(cmd.Cmd):
         List the sets by the plugin that provides the sets
         Parameters:
         [name=]   The plugin name
+
+        Output format:
+        <plugin_name> [<sample_interval>/<sample_offset>]:
+            <set_1>
+            <set_2>
+            ...
+
+        Each plugin displays its name followed by sampling parameters in brackets
+        (interval/offset) in microseconds, with data sets listed as indented items below.
         """
         arg = self.handle_args('plugn_sets', arg)
         if not arg:
@@ -1694,9 +1703,9 @@ class LdmsdCmdParser(cmd.Cmd):
             print("-- None --")
             return
         for p in plugns:
-            print("{0}:".format(p['plugin']))
+            print(f"{p['plugin']} [{p['interval_us']}:{p['offset_us']}]:")
             for s in p['sets']:
-                print("   {0}".format(s))
+                print(f"      {s}")
 
     def do_publish(self, arg):
         """

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -5671,8 +5671,11 @@ static int sampler_sets_json_obj(ldmsd_req_ctxt_t reqc, ldmsd_cfgobj_sampler_t s
 	rc = linebuf_printf(reqc,
 			"{"
 			"\"plugin\":\"%s\","
+			"\"interval_us\":%ld,"
+			"\"offset_us\":%ld,"
 			"\"sets\":[",
-			samp->cfg.name);
+			samp->cfg.name,
+			samp->sample_interval_us, samp->sample_offset_us);
 	if (rc)
 		return rc;
 	set_count = 0;


### PR DESCRIPTION
There are no query commands that show the sampling interval of a set, so the patch makes `plugn_sets` to provide this information.

<img width="295" height="109" alt="image" src="https://github.com/user-attachments/assets/57622cf2-6f46-4f56-ba09-17e1a03ace58" />
