### PR TITLE
Introduce pull request labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+main:
+- base-branch: main
+b4.4:
+- base-branch: b4.4
+b4.5:
+- base-branch: b4.5
+b4.6:
+- base-branch: b4.6

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+    labeler:
+        permissions:
+            contents: read
+            issues: write
+            pull-requests: write
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/labeler@v5


### PR DESCRIPTION
Introduce a new github workflow that adds github labels to PRs. The initial set of patterns just add the labels "main" or "b4.4" to a PR based on whether the PR targets the main or b4.4 branch.

(There are a couple of speculative patterns for b4.5 and b4.6, but it doesn't hurt to have those. We can add/remove patterns in the future as needed.)