### PR TITLE
Adjust permissions to allow release creation.

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ovishpc/ldms-dev-ubuntu-2204:latest-amd64
+    permissions:
+        contents: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
github has changed permissioning. action-gh-release can no longer create a release or attach files to a release without being granted explicit permission. This adds said permission.