### PR TITLE
Fix buffer size in ldmsd_stream_publish_file() fgets call

### DIFF
--- a/ldms/src/ldmsd/ldmsd_stream.c
+++ b/ldms/src/ldmsd/ldmsd_stream.c
@@ -721,7 +721,7 @@ int ldmsd_stream_publish_file(const char *stream, const char *type,
 			msglog("Out of memory\n");
 			goto close_xprt;
 		}
-		while (0 != (s = fgets(b, sizeof(b)-1, file))) {
+		while (0 != (s = fgets(b, max_msg_len-1, file))) {
 			cnt = strlen(s);
 			if (data_len + cnt >= len) {
 				/*


### PR DESCRIPTION
Replace sizeof(b) with max_msg_len-1 in a fgets call. Since b is a malloc'd pointer, sizeof(b) returns the pointer size (8 bytes) rather than the allocated buffer size, severely limiting read capacity.

This ensures fgets() can utilize the full allocated buffer size when reading from the file.