### PR TITLE
Fix genders function filter

### DIFF
--- a/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ldms-functions.in
+++ b/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ldms-functions.in
@@ -356,7 +356,8 @@ build_genders_file () {
 	for i in $LDMS_GENDERS; do
 		echo "#-------------------" >> $ALLGENDERS
 		echo "# from $i:" >> $ALLGENDERS
-		cat $i >> $ALLGENDERS
+		echo "# excluding all except bootnode and ldms keywords" >>$ALLGENDERS
+		cat $i | egrep '(bootnode|ldms)' >> $ALLGENDERS
 	done
 
 	if ! test -f "$ALLGENDERS"; then

--- a/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ldms-functions.in
+++ b/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ldms-functions.in
@@ -356,7 +356,7 @@ build_genders_file () {
 	for i in $LDMS_GENDERS; do
 		echo "#-------------------" >> $ALLGENDERS
 		echo "# from $i:" >> $ALLGENDERS
-		echo "# excluding all except bootnode and ldms keywords" >>$ALLGENDERS
+		echo "# excluding all except bootnode and ldms keywords" >> $ALLGENDERS
 		cat $i | egrep '(bootnode|ldms)' >> $ALLGENDERS
 	done
 


### PR DESCRIPTION
Extra-long genders files contribute to slow starts;  the filter for relevant attributes solves this.  Only relevant for 4.4.x.