### PR TITLE
quiet enobufs messages and fix reconnect_interval over-sed that broke netlink tests

### DIFF
--- a/ldms/scripts/examples/app_sampler
+++ b/ldms/scripts/examples/app_sampler
@@ -2,7 +2,7 @@ export plugname=app_sampler
 export dsname=$(ldms_dstat_schema_name mmalloc=1 io=1 fd=1 auto-schema=1)
 export dstat_schema=$dsname
 portbase=61060
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect_interval=1 -D 15 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 15 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
 VGARGS="--leak-check=full --track-origins=yes --trace-children=yes"
 vgon
 LDMSD 1

--- a/ldms/scripts/examples/blob_writer
+++ b/ldms/scripts/examples/blob_writer
@@ -7,7 +7,7 @@ VGARGS="--trace-children=yes --track-origins=yes --leak-check=full --show-leak-k
 # drd
 #VGARGS="--trace-children=yes  --tool=drd --trace-mutex=yes"
 # track everything notifier config:
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect_interval=1 -D 20 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 20 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --log-nobufs=1 --exclude-short-time=0.0001 &
 #vgon
 LDMSD 1 2
 #vgoff
@@ -18,6 +18,12 @@ LDMS_LS 2 -l
 SLEEP 1
 SLEEP 1
 SLEEP 1
+sc=5000
+si=0.001
+MESSAGE try $sc sleep $si
+for i in $(seq $sc); do
+	sleep $si &
+done
 SLEEP 1
 SLEEP 1
 SLEEP 1

--- a/ldms/scripts/examples/blob_writer_rollover
+++ b/ldms/scripts/examples/blob_writer_rollover
@@ -7,7 +7,7 @@ VGARGS="--trace-children=yes --track-origins=yes --leak-check=full --show-leak-k
 # drd
 #VGARGS="--trace-children=yes  --tool=drd --trace-mutex=yes"
 # track everything notifier config:
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect_interval=1 -D 60 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs -v 1 &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 60 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs -v 1 &
 LDMSD 1
 #vgon
 LDMSD 2

--- a/ldms/scripts/examples/linux_proc_sampler
+++ b/ldms/scripts/examples/linux_proc_sampler
@@ -74,12 +74,12 @@ done
 
 drd="valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.drd.txt --trace-cond=yes --trace-fork-join=yes"
 memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --keep-debuginfo=yes --malloc-fill=3b"
-#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect_interval=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked --purge-track-dir &
+#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked --purge-track-dir &
 
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect_interval=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 2 &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 2 &
 
 # uncomment next one to test duplicate handling
-#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect_interval=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
 VGARGS="--tool=drd --trace-cond=yes --trace-fork-join=yes"
 VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=definite --time-stamp=yes --keep-debuginfo=yes --malloc-fill=3b"
 #vgon

--- a/ldms/scripts/examples/linux_proc_sampler.job
+++ b/ldms/scripts/examples/linux_proc_sampler.job
@@ -88,14 +88,14 @@ JOBDATA $TESTDIR/job.data 1
 drd="valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.drd.txt --trace-cond=yes --trace-fork-join=yes"
 memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --keep-debuginfo=yes --malloc-fill=3b"
 memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --malloc-fill=3b"
-#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect_interval=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked --purge-track-dir &
+#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked --purge-track-dir &
 
 echo \
-"${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect_interval=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 1 --ProducerName=$(hostname) --purge-track-dir --format 3 --jobid-file=$TESTDIR/job.data.1 " > ${LDMSD_RUN}/start.netlink
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect_interval=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 1 --ProducerName=$(hostname) --purge-track-dir --format 3 --jobid-file=$TESTDIR/job.data.1 &
+"${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 1 --ProducerName=$(hostname) --purge-track-dir --format 3 --jobid-file=$TESTDIR/job.data.1 " > ${LDMSD_RUN}/start.netlink
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 1 --ProducerName=$(hostname) --purge-track-dir --format 3 --jobid-file=$TESTDIR/job.data.1 &
 
 # uncomment next one to test duplicate handling
-#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect_interval=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
 VGARGS="--tool=drd --trace-cond=yes --trace-fork-join=yes"
 VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=definite --time-stamp=yes --keep-debuginfo=yes --malloc-fill=3b"
 #vgon

--- a/ldms/scripts/examples/proc_stream
+++ b/ldms/scripts/examples/proc_stream
@@ -60,9 +60,9 @@ EOF
 rm -f $LOGDIR/json*.log
 rm -rf $STOREDIR
 mkdir -p $STOREDIR
-# valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.txt ${BUILDDIR}/sbin/ldms-netlink-notifier --port=61071 --auth=none --reconnect_interval=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+# valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.txt ${BUILDDIR}/sbin/ldms-netlink-notifier --port=61071 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
 # uncomment next one to test duplicate handling
-#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61071 --auth=none --reconnect_interval=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61071 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
 VGARGS="--tool=drd --suppressions=/scratch1/baallan/ovis/ldms/scripts/examples/linux_proc_sampler.drd.supp"
 VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=definite --time-stamp=yes --keep-debuginfo=yes"
 DAEMONS $(seq 3)
@@ -75,7 +75,7 @@ LDMSD 1
 vgoff
 LDMSD 3
 vgoff
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61071 --auth=none --reconnect_interval=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61071 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
 SLEEP 2
 MESSAGE ldms_ls on host 1:
 LDMS_LS 1 -v

--- a/ldms/src/sampler/netlink/netlink-notifier.c
+++ b/ldms/src/sampler/netlink/netlink-notifier.c
@@ -308,6 +308,7 @@ typedef int (*print_f)(const char *fmt, ...);
 typedef struct forkstat {
 	bool stop_recv;				/* true if monitor exit wanted */
 	bool sane_procs;			/* true if not inside a container */
+	bool log_nobufs;			/* true if we should print nobufs msgs */
 	unsigned max_pids;			/* array size; >= INT_MAX if not ready */
 	struct pi_list *proc_info;		/* Proc array w/locks*/
 	struct pi_list *proc_info_head;	/* Proc array -1th ptr */
@@ -423,6 +424,7 @@ static const int signals[] = {
 #define default_format "3" /* this is also the max format known */
 #define default_heartbeat NULL /* none by default*/
 #define default_component_id NULL
+#define default_log_nobufs NULL
 #define default_ProducerName NULL
 #define default_track_dir "/var/run/ldms-netlink-tracked"
 #define default_purge NULL
@@ -1931,6 +1933,7 @@ static void *monitor(void *vp)
 	char eibuf[32]; // extra_info output space
 
 	print_heading(ft);
+	uint64_t nobufs_count = 0;
 
 	jbuf_t jbd = jbuf_new();
 	jbuf_t jb = jbd;
@@ -1951,20 +1954,24 @@ static void *monitor(void *vp)
 				arg->ret = 0;
 				return NULL;
 			case ENOBUFS: {
-				time_t now;
-				struct tm tm;
+				if (ft->log_nobufs) {
+					time_t now;
+					struct tm tm;
 
-				now = time(NULL);
-				if (now == ((time_t) -1)) {
-					PRINTF("--:--:-- recv ----- "
-						"nobufs %8.8s (%s)\n",
-						"", strerror(err));
+					now = time(NULL);
+					if (now == ((time_t) -1)) {
+						PRINTF("--:--:-- recv ----- "
+							"nobufs %8.8s (%s)\n",
+							"", strerror(err));
+					} else {
+						(void)localtime_r(&now, &tm);
+						PRINTF("%2.2d:%2.2d:%2.2d recv ----- "
+							"nobufs %8.8s (%s)\n",
+							tm.tm_hour, tm.tm_min, tm.tm_sec, "",
+							strerror(err));
+					}
 				} else {
-					(void)localtime_r(&now, &tm);
-					PRINTF("%2.2d:%2.2d:%2.2d recv ----- "
-						"nobufs %8.8s (%s)\n",
-						tm.tm_hour, tm.tm_min, tm.tm_sec, "",
-						strerror(err));
+					nobufs_count++;
 				}
 				break;
 			}
@@ -1975,7 +1982,7 @@ static void *monitor(void *vp)
 				return NULL;
 			}
 		}
-
+		/* this loop is a no-op when len==-1 */
 		for (nlmsghdr = (struct nlmsghdr *)buf;
 			NLMSG_OK (nlmsghdr, len);
 			nlmsghdr = NLMSG_NEXT (nlmsghdr, len)) {
@@ -2343,6 +2350,9 @@ static void *monitor(void *vp)
 		}
 	}
 	jbuf_free(jbd);
+	if (!(ft->opt_flags & OPT_QUIET) && nobufs_count) {
+		PRINTF("%" PRIu64 " unlogged enobufs events since startup\n", nobufs_count);
+	}
 	return NULL;
 }
 
@@ -2403,6 +2413,7 @@ static struct exclude_arg excludes[] = {
 	{default_heartbeat, VT_SCALAR, 0, "NOTIFIER_HEARTBEAT", NULL, 0, PLINIT},
 	{default_purge, VT_NONE, 0, "NOTIFIER_PURGE_TRACK_DIR", NULL, 0, PLINIT},
 	{default_jobid_file, VT_FILE, 0, "NOTIFIER_JOBID_FILE", NULL, 0, PLINIT},
+	{default_log_nobufs, VT_SCALAR, 0, "NOTIFIER_LOG_NOBUFS", NULL, 0, PLINIT},
 };
 static struct exclude_arg *bin_exclude = &excludes[0];
 static struct exclude_arg *dir_exclude = &excludes[1];
@@ -2423,6 +2434,7 @@ static struct exclude_arg *format_arg = &excludes[15];
 static struct exclude_arg *heartbeat_arg = &excludes[16];
 static struct exclude_arg *purge_track_dir_arg = &excludes[17];
 static struct exclude_arg *jobid_file_arg = &excludes[18];
+static struct exclude_arg *log_nobufs_arg = &excludes[19];
 
 static struct option long_options[] = {
 	{"exclude-programs", optional_argument, 0, 0},
@@ -2444,6 +2456,7 @@ static struct option long_options[] = {
 	{"heartbeat", required_argument, 0, 0},
 	{"purge-track-dir", no_argument, 0, 0},
 	{"jobid-file", required_argument, 0, 0},
+	{"log-nobufs", required_argument, 0, 0},
 	{0, 0, 0, 0}
 };
 
@@ -2977,6 +2990,7 @@ static void forkstat_option_dump(forkstat_t *ft, struct exclude_arg *excludes)
 	printf("forkstat struct:\n");
 	printf("\tstop_recv= %d\n", (int)ft->stop_recv);
 	printf("\tsane_procs= %d\n", (int)ft->sane_procs);
+	printf("\tlog_nobufs= %d\n", (int)ft->log_nobufs);
 	printf("\tmax_pids= %u\n", ft->max_pids);
 	printf("\topt_flags= %lu\n", (unsigned long) ft->opt_flags);
 	printf("\topt_uidmin= %u\n", ft->opt_uidmin);
@@ -4800,6 +4814,11 @@ int main(int argc, char * argv[])
 		ft->compid_field = strdup(ctmp);
 	} else {
 		ft->compid_field = strdup("");
+	}
+	if (log_nobufs_arg[0].parsed || getenv(log_nobufs_arg->env)) {
+		ft->log_nobufs = (bool)strtol(log_nobufs_arg->paths[0].n, NULL, 10);
+	} else {
+		ft->log_nobufs = 0;
 	}
 	if ( (heartbeat_arg[0].parsed || getenv(heartbeat_arg->env)) &&
 		set_heartbeat(heartbeat_arg->paths[0].n, ft)) {


### PR DESCRIPTION
this adds the --log-nobufs option; the default is to no longer complain about kernel-side ring buffer inadequacy unless requested.
it also fixes uncaught incorrect replacement of reconnect with reconnect_interval in netlink invocations in test scripts which was already fixed on main.

backport of #1954 to b4.4