### PR TITLE
Change update hint validation log from ERROR to INFO level

### DIFF
--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -325,7 +325,7 @@ static void __update_set_info(ldmsd_prdcr_set_t set, ldms_dir_set_t dset)
 
 		/* Sanity check the hints */
 		if (offset_us >= intrvl_us) {
-			ovis_log(prdcr_log, OVIS_LERROR, "set %s: Invalid hint '%s', ignoring hint\n",
+			ovis_log(prdcr_log, OVIS_LINFO, "set %s: hint '%s', ignoring hint\n",
 					set->inst_name, hint);
 		} else {
 			if (offset_us != LDMSD_UPDT_HINT_OFFSET_NONE)


### PR DESCRIPTION
Change the update hint validation from ERROR to DEBUG level when encountering invalid hints like '0:0'. This is expected behavior when sets exist but sampling hasn't started, or for event-driven samplers that don't require starting the sampler plugins.