### PR TITLE
Remove update hint setting in ldmsd_set_register()

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -698,15 +698,6 @@ int ldmsd_set_register(ldms_set_t set, const char *cfg_name)
 	s->set = set;
 	s->sampler = samp;
 
-	rc = ldmsd_set_update_hint_set(set, samp->sample_interval_us, samp->sample_offset_us);
-	if (rc) {
-		ovis_log(NULL, OVIS_LINFO,
-			 "Error %d setting the set hint data %ld:%ld "
-			 "for the set '%s'.\n",
-			 rc,
-			 samp->sample_interval_us, samp->sample_offset_us,
-			 ldms_set_instance_name_get(set));
-	}
 	LIST_INSERT_HEAD(&samp->set_list, s, entry);
 	ldmsd_sampler_find_put(samp);
 	return 0;


### PR DESCRIPTION
The update hint has been set in two places: ldmsd_set_register() and ldmsd_sampler_start(). Since the sample interval and offset are given at sampler plugin start time, the hint setting in ldmsd_sampler_start() should be sufficient.