### PR TITLE
DRAFT: backport lustre sampler documentation and OSD_SEARCH_PATH to b4.4

### DIFF
--- a/ldms/src/sampler/lustre_client/Plugin_lustre_client.man
+++ b/ldms/src/sampler/lustre_client/Plugin_lustre_client.man
@@ -19,7 +19,9 @@ by default, and the metric set instance names are
 derived from the llite instance name. Any user-supplied configuration values not
 documented here will be ignored.
 
-This plugin should work with at least Lustre versions 2.8, 2.10, and 2.12.
+This plugin should work with at least Lustre versions 2.8, 2.10,
+2.12 and 2.15. The debugfs filesystem must be mounted for lustre
+data access, which is also usually restricted to the root user.
 
 .SH CONFIGURATION ATTRIBUTE SYNTAX
 

--- a/ldms/src/sampler/lustre_client/lustre_client.c
+++ b/ldms/src/sampler/lustre_client/lustre_client.c
@@ -23,8 +23,8 @@
 
 /* locations where llite stats might be found */
 static const char * const llite_paths[] = {
-        "/proc/fs/lustre/llite",          /* lustre pre-2.12 */
         "/sys/kernel/debug/lustre/llite"  /* lustre 2.12 and later */
+        "/proc/fs/lustre/llite",          /* lustre pre-2.12 */
 };
 static const int llite_paths_len = sizeof(llite_paths) / sizeof(llite_paths[0]);
 static char *test_path = NULL;

--- a/ldms/src/sampler/lustre_mdc/Plugin_lustre_mdc.man
+++ b/ldms/src/sampler/lustre_mdc/Plugin_lustre_mdc.man
@@ -13,10 +13,13 @@ With LDMS (Lightweight Distributed Metric Service), plugins for the ldmsd (ldms 
 or a configuration file.
 
 The lustre_mdc plugin provides schema lustre_mdc for daemons with read access to
-the lustre files in /proc/fs/lustre/mdc/*/md_stats and  /sys/kernel/debug/lustre/mdc/*/stats.
+the lustre files in /proc/fs/lustre/mdc/*/md_stats and /sys/kernel/debug/lustre/mdc/*/stats.
 The metric sets will have instance names combining the producer name and the mdc name.
 
-This plugin will work with Lustre versions 2.12 and others which share these file locations and formats.
+This plugin should work with at least Lustre versions
+2.12 and 2.15, and others which share these file locations and formats.
+The debugfs filesystem must be mounted for lustre
+data access, which is also usually restricted to the root user.
 
 .SH CONFIGURATION ATTRIBUTE SYNTAX
 

--- a/ldms/src/sampler/lustre_mdt/Plugin_lustre_mdt.man
+++ b/ldms/src/sampler/lustre_mdt/Plugin_lustre_mdt.man
@@ -25,7 +25,8 @@ come from /proc/fs/lustre/mdt/*/job_stats.
 This plugin currently employs zero configuration. Any user-supplied configuration values will be ignored.  Future versions may add
 configuration options.
 
-This plugin should work with at least Lustre versions 2.8, 2.10, and 2.12.
+This plugin should work with at least Lustre versions 2.8, 2.10, and 2.12, 2.15.
+The debugfs filesystem must be mounted for lustre data access, which is also usually restricted to the root user.
 
 .SH CONFIGURATION ATTRIBUTE SYNTAX
 

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt.c
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt.c
@@ -20,7 +20,12 @@
 #define _GNU_SOURCE
 
 #define MDT_PATH "/proc/fs/lustre/mdt"
-#define OSD_SEARCH_PATH "/proc/fs/lustre"
+
+static const char * const possible_osd_base_paths[] = {
+	"/sys/fs/lustre", /* at least lustre >= 1.15 (probably >= 1.12) */
+	"/proc/fs/lustre", /* older lustre */
+	NULL
+};
 
 static struct comp_id_data cid;
 
@@ -84,7 +89,7 @@ static struct mdt_data *mdt_create(const char *mdt_name, const char *basedir)
         mdt->general_metric_set = mdt_general_create(producer_name, mdt->fs_name, mdt->name, &cid);
         if (mdt->general_metric_set == NULL)
                 goto out7;
-        mdt->osd_path = mdt_general_osd_path_find(OSD_SEARCH_PATH, mdt->name);
+        mdt->osd_path = mdt_general_osd_path_find(possible_osd_base_paths, mdt->name);
         rbn_init(&mdt->mdt_tree_node, mdt->name);
         rbt_init(&mdt->job_stats, string_comparator);
 

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt_general.c
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt_general.c
@@ -118,39 +118,39 @@ void mdt_general_schema_fini()
 /* Returns strdup'ed string or NULL.  Caller must free. */
 char *mdt_general_osd_path_find(const char * const *paths, const char *component_name)
 {
-    char *path;
-    char *osd_dir = NULL;
-    int i;
+        char *path;
+        char *osd_dir = NULL;
+        int i;
 
-    for (i = 0, path = (char *)paths[0]; path != NULL; i++, path = (char *)paths[i]) {
-        struct dirent *dirent;
-        DIR *dir;
+        for (i = 0, path = (char *)paths[0]; path != NULL; i++, path = (char *)paths[i]) {
+                struct dirent *dirent;
+                DIR *dir;
 
-        dir = opendir(path);
-        if (dir == NULL) {
-            continue;
-        }
-
-        while ((dirent = readdir(dir)) != NULL) {
-            if (dirent->d_type == DT_DIR &&
-                strncmp(dirent->d_name, "osd-", strlen("osd-")) == 0) {
-                char tmp_path[PATH_MAX];
-                snprintf(tmp_path, PATH_MAX, "%s/%s/%s",
-                     path, dirent->d_name, component_name);
-                if (access(tmp_path, F_OK) == 0) {
-                    osd_dir = strdup(tmp_path);
-                    break;
+                dir = opendir(path);
+                if (dir == NULL) {
+                        continue;
                 }
-            }
+
+                while ((dirent = readdir(dir)) != NULL) {
+                        if (dirent->d_type == DT_DIR &&
+                            strncmp(dirent->d_name, "osd-", strlen("osd-")) == 0) {
+                                char tmp_path[PATH_MAX];
+                                snprintf(tmp_path, PATH_MAX, "%s/%s/%s",
+                                path, dirent->d_name, component_name);
+                                if (access(tmp_path, F_OK) == 0) {
+                                        osd_dir = strdup(tmp_path);
+                                        break;
+                                }
+                        }
+                }
+
+                closedir(dir);
+
+                if (osd_dir != NULL) {
+                        break;
+                } 
+
         }
-
-        closedir(dir);
-
-        if (osd_dir != NULL) {
-            break;
-        } 
-
-    }
 
     return osd_dir;
 }

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt_general.c
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt_general.c
@@ -148,7 +148,7 @@ char *mdt_general_osd_path_find(const char * const *paths, const char *component
 
                 if (osd_dir != NULL) {
                         break;
-                } 
+                }
 
         }
 

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt_general.c
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt_general.c
@@ -116,41 +116,43 @@ void mdt_general_schema_fini()
 }
 
 /* Returns strdup'ed string or NULL.  Caller must free. */
-char *mdt_general_osd_path_find(const char *search_path, const char *mdt_name)
+char *mdt_general_osd_path_find(const char * const *paths, const char *component_name)
 {
+    char *path;
+    char *osd_dir = NULL;
+    int i;
+
+    for (i = 0, path = (char *)paths[0]; path != NULL; i++, path = (char *)paths[i]) {
         struct dirent *dirent;
         DIR *dir;
-        char *osd_path = NULL;
 
-        dir = opendir(search_path);
+        dir = opendir(path);
         if (dir == NULL) {
-                return NULL;
+            continue;
         }
 
         while ((dirent = readdir(dir)) != NULL) {
-                if (dirent->d_type == DT_DIR &&
-                    strncmp(dirent->d_name, "osd-", strlen("osd-")) == 0) {
-                        char tmp_path[PATH_MAX];
-                        snprintf(tmp_path, PATH_MAX, "%s/%s/%s",
-                                 search_path, dirent->d_name, mdt_name);
-                        if (access(tmp_path, F_OK) == 0) {
-                                osd_path = strdup(tmp_path);
-                                break;
-                        }
+            if (dirent->d_type == DT_DIR &&
+                strncmp(dirent->d_name, "osd-", strlen("osd-")) == 0) {
+                char tmp_path[PATH_MAX];
+                snprintf(tmp_path, PATH_MAX, "%s/%s/%s",
+                     path, dirent->d_name, component_name);
+                if (access(tmp_path, F_OK) == 0) {
+                    osd_dir = strdup(tmp_path);
+                    break;
                 }
+            }
         }
 
         closedir(dir);
 
-        if (osd_path != NULL) {
-                log_fn(LDMSD_LDEBUG, SAMP" for mdt %s found osd path %s\n",
-                       mdt_name, osd_path);
-        } else {
-                log_fn(LDMSD_LWARNING, SAMP" osd for mdt %s not found\n",
-                       mdt_name);
-        }
+        if (osd_dir != NULL) {
+            break;
+        } 
 
-        return osd_path;
+    }
+
+    return osd_dir;
 }
 
 static uint64_t file_read_uint64_t(const char *dir, const char *file)

--- a/ldms/src/sampler/lustre_ost/Plugin_lustre_ost.man
+++ b/ldms/src/sampler/lustre_ost/Plugin_lustre_ost.man
@@ -25,7 +25,9 @@ come from /proc/fs/lustre/ost/*/job_stats.
 This plugin currently employs zero configuration. Any user-supplied configuration values will be ignored.  Future versions may add
 configuration options.
 
-This plugin should work with at least Lustre versions 2.8, 2.10, and 2.12.
+This plugin should work with at least Lustre versions 2.8, 2.10,
+2.12 and 2.15. The debugfs filesystem must be mounted for lustre
+data access, which is also usually restricted to the root user.
 
 .SH CONFIGURATION ATTRIBUTE SYNTAX
 

--- a/ldms/src/sampler/lustre_ost/lustre_ost.c
+++ b/ldms/src/sampler/lustre_ost/lustre_ost.c
@@ -20,7 +20,12 @@
 #define _GNU_SOURCE
 
 #define OBDFILTER_PATH "/proc/fs/lustre/obdfilter"
-#define OSD_SEARCH_PATH "/proc/fs/lustre"
+
+static const char * const possible_osd_base_paths[] = {
+	"/sys/fs/lustre", /* at least lustre >= 1.15 (probably >= 1.12) */
+	"/proc/fs/lustre", /* older lustre */
+	NULL
+};
 
 static struct comp_id_data cid;
 
@@ -84,7 +89,7 @@ static struct ost_data *ost_create(const char *ost_name, const char *basedir)
         ost->general_metric_set = ost_general_create(producer_name, ost->fs_name, ost->name, &cid);
         if (ost->general_metric_set == NULL)
                 goto out7;
-        ost->osd_path = ost_general_osd_path_find(OSD_SEARCH_PATH, ost->name);
+        ost->osd_path = ost_general_osd_path_find(possible_osd_base_paths, ost->name);
         rbn_init(&ost->ost_tree_node, ost->name);
         rbt_init(&ost->job_stats, string_comparator);
 


### PR DESCRIPTION
This pull request accomplishes the following updates to the various lustre samplers:

1. Update documentation for debugfs requirement
2. Update documentation for Lustre 2.15
3. Switch `#define OSD_SEARCH_PATH "/proc/fs/lustre"` to use array `possible_osd_base_paths` including `/sys/fs/lustre`
