### PR TITLE
lustre: search for osd dir in multiple places (4.4.6 backport logic)

### DIFF
--- a/ldms/scripts/examples/lustre_client
+++ b/ldms/scripts/examples/lustre_client
@@ -4,10 +4,10 @@ portbase=61016
 DAEMONS $(seq 3)
 JOBDATA $TESTDIR/job.data 1 2 3
 VGARGS="--track-origins=yes --leak-check=full --show-leak-kinds=definite"
+#vgon
+LDMSD -p prolog.job_info 1
 vgoff
-LDMSD -p prolog.jobid 1
-vgoff
-LDMSD -p prolog.jobid 2
+LDMSD -p prolog.job_info 2
 LDMSD -p prolog.jobid.store3 3
 SLEEP 3
 MESSAGE ldms_ls on host 1:
@@ -15,7 +15,7 @@ LDMS_LS 1 -lv
 MESSAGE ldms_ls on host 2:
 LDMS_LS 2 -lv
 MESSAGE ldms_ls on host 3:
-LDMS_LS 3 -lv
+LDMS_LS 3 -v
 SLEEP 5
 KILL_LDMSD $(seq 3)
 file_created $STOREDIR/node/lustre_client

--- a/ldms/scripts/examples/lustre_client.1
+++ b/ldms/scripts/examples/lustre_client.1
@@ -1,3 +1,4 @@
+metric_sets_default_authz perm=0644
 load name=${plugname}
-config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} job_set=localhost${i}/jobid  extra215=1 extratimes=1 test_path=${HOME}/test-llite
+config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} job_set=localhost${i}/jobid extra215=1 extratimes=1 uid=3556 gid=3556 perm=0777
 start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/lustre_client.2
+++ b/ldms/scripts/examples/lustre_client.2
@@ -1,3 +1,3 @@
 load name=${plugname}
-config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} job_set=localhost${i}/jobid
+config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} job_set=localhost${i}/jobid uid=3554 gid=3554 perm=0644
 start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/lustre_mdt
+++ b/ldms/scripts/examples/lustre_mdt
@@ -1,0 +1,17 @@
+export plugname=lustre_mdt
+#VGARGS="--tool=drd --gen-suppressions=all --suppressions=ldms/scripts/examples/sampler.drd.supp --trace-mutex=yes --trace-cond=yes"
+#VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=all"
+#vgon
+portbase=61060
+LDMSD -s 2000000 1 2 3
+#vgoff
+SLEEP 2
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -v
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -v
+MESSAGE ldms_ls on host 3:
+LDMS_LS 3 -vl
+SLEEP 5
+KILL_LDMSD 1 2 3
+file_created $STOREDIR/node/${testname}_ops

--- a/ldms/scripts/examples/lustre_mdt.1
+++ b/ldms/scripts/examples/lustre_mdt.1
@@ -1,0 +1,3 @@
+load name=${testname}
+config name=${testname} producer=localhost${i} component_id=${i}
+start name=${testname} interval=1000000 offset=0

--- a/ldms/scripts/examples/lustre_mdt.2
+++ b/ldms/scripts/examples/lustre_mdt.2
@@ -1,0 +1,3 @@
+load name=${testname}
+config name=${testname} producer=localhost${i} component_id=${i} uid=1 gid=1 perm=777
+start name=${testname} interval=1000000 offset=0

--- a/ldms/scripts/examples/lustre_mdt.3
+++ b/ldms/scripts/examples/lustre_mdt.3
@@ -1,0 +1,16 @@
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} reconnect=2000000
+prdcr_start name=localhost1
+
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} reconnect=2000000
+prdcr_start name=localhost2
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=store_${testname}_ops plugin=store_csv schema=${testname}_ops container=node
+strgp_prdcr_add name=store_${testname}_ops regex=.*
+strgp_start name=store_${testname}_ops

--- a/ldms/scripts/examples/lustre_ost
+++ b/ldms/scripts/examples/lustre_ost
@@ -1,0 +1,17 @@
+export plugname=lustre_ost
+#VGARGS="--tool=drd --gen-suppressions=all --suppressions=ldms/scripts/examples/sampler.drd.supp --trace-mutex=yes --trace-cond=yes"
+#VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=all"
+#vgon
+portbase=61060
+LDMSD -s 2000000 1 2 3
+#vgoff
+SLEEP 2
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -v
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -v
+MESSAGE ldms_ls on host 3:
+LDMS_LS 3 -vl
+SLEEP 5
+KILL_LDMSD 1 2 3
+file_created $STOREDIR/node/${testname}_ops

--- a/ldms/scripts/examples/lustre_ost.1
+++ b/ldms/scripts/examples/lustre_ost.1
@@ -1,0 +1,3 @@
+load name=${testname}
+config name=${testname} producer=localhost${i} component_id=${i}
+start name=${testname} interval=1000000 offset=0

--- a/ldms/scripts/examples/lustre_ost.2
+++ b/ldms/scripts/examples/lustre_ost.2
@@ -1,0 +1,3 @@
+load name=${testname}
+config name=${testname} producer=localhost${i} component_id=${i} uid=1 gid=1 perm=777
+start name=${testname} interval=1000000 offset=0

--- a/ldms/scripts/examples/lustre_ost.3
+++ b/ldms/scripts/examples/lustre_ost.3
@@ -1,0 +1,16 @@
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} reconnect=2000000
+prdcr_start name=localhost1
+
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} reconnect=2000000
+prdcr_start name=localhost2
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=store_${testname}_ops plugin=store_csv schema=${testname}_ops container=node
+strgp_prdcr_add name=store_${testname}_ops regex=.*
+strgp_start name=store_${testname}_ops

--- a/ldms/scripts/examples/prolog.job_info
+++ b/ldms/scripts/examples/prolog.job_info
@@ -1,0 +1,5 @@
+# start the text based job_info sampler on node i assuming the JOBDATA macro
+# has been applied.
+load name=jobinfo
+config name=jobinfo producer=localhost${i} instance=localhost${i}/jobid component_id=${i} schema=jobid file=${TESTDIR}/job.data.${i}
+start name=jobinfo interval=1000000 offset=-200000

--- a/ldms/src/sampler/lustre_client/Plugin_lustre_client.man
+++ b/ldms/src/sampler/lustre_client/Plugin_lustre_client.man
@@ -19,7 +19,9 @@ by default, and the metric set instance names are
 derived from the llite instance name. Any user-supplied configuration values not
 documented here will be ignored.
 
-This plugin should work with at least Lustre versions 2.8, 2.10, and 2.12.
+This plugin should work with at least Lustre versions 2.8, 2.10,
+2.12 and 2.15. The debugfs filesystem must be mounted for lustre
+data access, which is also usually restricted to the root user.
 
 .SH CONFIGURATION ATTRIBUTE SYNTAX
 

--- a/ldms/src/sampler/lustre_client/lustre_client.c
+++ b/ldms/src/sampler/lustre_client/lustre_client.c
@@ -23,8 +23,8 @@
 
 /* locations where llite stats might be found */
 static const char * const llite_paths[] = {
-        "/proc/fs/lustre/llite",          /* lustre pre-2.12 */
-        "/sys/kernel/debug/lustre/llite"  /* lustre 2.12 and later */
+        "/sys/kernel/debug/lustre/llite",  /* lustre 2.12 and later */
+        "/proc/fs/lustre/llite"            /* lustre pre-2.12 */
 };
 static const int llite_paths_len = sizeof(llite_paths) / sizeof(llite_paths[0]);
 static char *test_path = NULL;

--- a/ldms/src/sampler/lustre_mdc/Plugin_lustre_mdc.man
+++ b/ldms/src/sampler/lustre_mdc/Plugin_lustre_mdc.man
@@ -13,10 +13,13 @@ With LDMS (Lightweight Distributed Metric Service), plugins for the ldmsd (ldms 
 or a configuration file.
 
 The lustre_mdc plugin provides schema lustre_mdc for daemons with read access to
-the lustre files in /proc/fs/lustre/mdc/*/md_stats and  /sys/kernel/debug/lustre/mdc/*/stats.
+the lustre files in /proc/fs/lustre/mdc/*/md_stats and /sys/kernel/debug/lustre/mdc/*/stats.
 The metric sets will have instance names combining the producer name and the mdc name.
 
-This plugin will work with Lustre versions 2.12 and others which share these file locations and formats.
+This plugin should work with at least Lustre versions
+2.12 and 2.15, and others which share these file locations and formats.
+The debugfs filesystem must be mounted for lustre
+data access, which is also usually restricted to the root user.
 
 .SH CONFIGURATION ATTRIBUTE SYNTAX
 

--- a/ldms/src/sampler/lustre_mdt/Plugin_lustre_mdt.man
+++ b/ldms/src/sampler/lustre_mdt/Plugin_lustre_mdt.man
@@ -25,7 +25,8 @@ come from /proc/fs/lustre/mdt/*/job_stats.
 This plugin currently employs zero configuration. Any user-supplied configuration values will be ignored.  Future versions may add
 configuration options.
 
-This plugin should work with at least Lustre versions 2.8, 2.10, and 2.12.
+This plugin should work with at least Lustre versions 2.8, 2.10, and 2.12, 2.15.
+The debugfs filesystem must be mounted for lustre data access, which is also usually restricted to the root user.
 
 .SH CONFIGURATION ATTRIBUTE SYNTAX
 

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt.c
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt.c
@@ -20,7 +20,12 @@
 #define _GNU_SOURCE
 
 #define MDT_PATH "/proc/fs/lustre/mdt"
-#define OSD_SEARCH_PATH "/proc/fs/lustre"
+
+static const char * const possible_osd_base_paths[] = {
+	"/sys/fs/lustre", /* at least lustre >= 1.15 (probably >= 1.12) */
+	"/proc/fs/lustre", /* older lustre */
+	NULL
+};
 
 static struct comp_id_data cid;
 
@@ -84,7 +89,7 @@ static struct mdt_data *mdt_create(const char *mdt_name, const char *basedir)
         mdt->general_metric_set = mdt_general_create(producer_name, mdt->fs_name, mdt->name, &cid);
         if (mdt->general_metric_set == NULL)
                 goto out7;
-        mdt->osd_path = mdt_general_osd_path_find(OSD_SEARCH_PATH, mdt->name);
+        mdt->osd_path = mdt_general_osd_path_find(possible_osd_base_paths, mdt->name);
         rbn_init(&mdt->mdt_tree_node, mdt->name);
         rbt_init(&mdt->job_stats, string_comparator);
 

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt_general.c
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt_general.c
@@ -151,8 +151,15 @@ char *mdt_general_osd_path_find(const char * const *paths, const char *component
                 }
 
         }
+        if (osd_dir != NULL) {
+                log_fn(LDMSD_LDEBUG, SAMP" for mdt %s found osd dir %s\n",
+                       component_name, osd_dir);
+        } else {
+                log_fn(LDMSD_LWARNING, SAMP" osd for mdt %s not found\n",
+                       component_name);
+        }
 
-    return osd_dir;
+        return osd_dir;
 }
 
 static uint64_t file_read_uint64_t(const char *dir, const char *file)

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt_general.h
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt_general.h
@@ -16,7 +16,7 @@ int mdt_general_schema_init(const comp_id_t cid);
 void mdt_general_schema_fini();
 ldms_set_t mdt_general_create(const char *producer_name, const char *fs_name,
                               const char *mdt_name, const comp_id_t cid);
-char *mdt_general_osd_path_find(const char *search_path, const char *mdt_name);
+char *mdt_general_osd_path_find(const char * const *paths, const char *component_name);
 void mdt_general_sample(const char *mdt_name, const char *stats_path,
                         const char *osd_path, ldms_set_t general_metric_set);
 void mdt_general_destroy(ldms_set_t set);

--- a/ldms/src/sampler/lustre_ost/Plugin_lustre_ost.man
+++ b/ldms/src/sampler/lustre_ost/Plugin_lustre_ost.man
@@ -25,7 +25,9 @@ come from /proc/fs/lustre/ost/*/job_stats.
 This plugin currently employs zero configuration. Any user-supplied configuration values will be ignored.  Future versions may add
 configuration options.
 
-This plugin should work with at least Lustre versions 2.8, 2.10, and 2.12.
+This plugin should work with at least Lustre versions 2.8, 2.10,
+2.12 and 2.15. The debugfs filesystem must be mounted for lustre
+data access, which is also usually restricted to the root user.
 
 .SH CONFIGURATION ATTRIBUTE SYNTAX
 

--- a/ldms/src/sampler/lustre_ost/lustre_ost.c
+++ b/ldms/src/sampler/lustre_ost/lustre_ost.c
@@ -20,7 +20,12 @@
 #define _GNU_SOURCE
 
 #define OBDFILTER_PATH "/proc/fs/lustre/obdfilter"
-#define OSD_SEARCH_PATH "/proc/fs/lustre"
+
+static const char * const possible_osd_base_paths[] = {
+	"/sys/fs/lustre", /* at least lustre >= 1.15 (probably >= 1.12) */
+	"/proc/fs/lustre", /* older lustre */
+	NULL
+};
 
 static struct comp_id_data cid;
 
@@ -84,9 +89,13 @@ static struct ost_data *ost_create(const char *ost_name, const char *basedir)
         ost->general_metric_set = ost_general_create(producer_name, ost->fs_name, ost->name, &cid);
         if (ost->general_metric_set == NULL)
                 goto out7;
-        ost->osd_path = ost_general_osd_path_find(OSD_SEARCH_PATH, ost->name);
+        ost->osd_path = ost_general_osd_path_find(possible_osd_base_paths, ost->name);
         rbn_init(&ost->ost_tree_node, ost->name);
         rbt_init(&ost->job_stats, string_comparator);
+
+        log_fn(LDMSD_LINFO, SAMP
+                " using stats, jobstats, and osd data from %s, %s, and %s\n",
+                ost->stats_path, ost->job_stats_path, ost->osd_path);
 
         return ost;
 out7:

--- a/ldms/src/sampler/lustre_ost/lustre_ost_general.h
+++ b/ldms/src/sampler/lustre_ost/lustre_ost_general.h
@@ -16,7 +16,7 @@ int ost_general_schema_init(const comp_id_t cid);
 void ost_general_schema_fini();
 ldms_set_t ost_general_create(const char *producer_name, const char *fs_name,
                               const char *ost_name, const comp_id_t cid);
-char *ost_general_osd_path_find(const char *search_path, const char *ost_name);
+char *ost_general_osd_path_find(const char * const *paths, const char *ost_name);
 void ost_general_sample(const char *ost_name, const char *stats_path,
                         const char *osd_path, ldms_set_t general_metric_set);
 void ost_general_destroy(ldms_set_t set);


### PR DESCRIPTION
Details of this backport incorporate pulling in requisite modifications to lustre_{mdt,ost,mdc,client} samplers to enable support for searching an array of paths, updates to documentation, and new tests and some small fixes. 