### PR TITLE
`dispatch-container-bake` workflow on release event

### DIFF
--- a/.github/data/dispatch.yaml
+++ b/.github/data/dispatch.yaml
@@ -5,7 +5,7 @@ inputs:
   vars: LDMS_REPO LDMS_REPO_URL
         LDMS_BRANCH LDMS_TAG
         SOS_REPO https://github.com/ovis-hpc/sos
-        SOS_BRANCH SOS-6
+        SOS_BRANCH b2.6
         MAESTRO_REPO https://github.com/ovis-hpc/maestro
         MAESTRO_BRANCH OVIS-4.4.5
         NUMSOS_REPO https://github.com/narategithub/numsos

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -39,20 +39,3 @@ jobs:
       with:
         files: |
           ./${{ env.TARBALL_NAME }}
-  dispatch-container-bake:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: dispatch ldms-containers bake
-        run: |
-          set -e
-          sed -i "s|LDMS_TAG|${{github.ref_name}}|" .github/data/dispatch.yaml
-          sed -i "s|LDMS_REPO_URL|${{github.server_url}}/${{github.repository}}|" .github/data/dispatch.yaml
-          python3 -c 'import sys,yaml,json; print(json.dumps(yaml.load(sys.stdin, yaml.SafeLoader)))' < .github/data/dispatch.yaml > dispatch.json
-          curl -L -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{secrets.NARATEGITHUB_LDMS_CONTAINERS_TOKEN}}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -d "@dispatch.json" \
-            "https://api.github.com/repos/narategithub/ldms-containers/actions/workflows/on_ldms_release.yaml/dispatches"

--- a/.github/workflows/dispatch-container-bake.yaml
+++ b/.github/workflows/dispatch-container-bake.yaml
@@ -1,0 +1,24 @@
+name: Dispatch Container Bake
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  dispatch-container-bake:
+    if: github.repository == 'ovis-hpc/ldms' || github.repository == 'narategithub/ldms'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: dispatch ldms-containers bake
+        run: |
+          set -e
+          sed -i "s|LDMS_TAG|${{github.ref_name}}|" .github/data/dispatch.yaml
+          sed -i "s|LDMS_REPO_URL|${{github.server_url}}/${{github.repository}}|" .github/data/dispatch.yaml
+          python3 -c 'import sys,yaml,json; print(json.dumps(yaml.load(sys.stdin, yaml.SafeLoader)))' < .github/data/dispatch.yaml > dispatch.json
+          curl -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{secrets.NARATEGITHUB_LDMS_CONTAINERS_TOKEN}}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d "@dispatch.json" \
+            "https://api.github.com/repos/narategithub/ldms-containers/actions/workflows/on_ldms_release.yaml/dispatches"


### PR DESCRIPTION
Move `dispatch-container-bake` job into its own workflow and change the event the workflow depends on from `on push tags` to `on release published` so that when a release is created (by any means; not just by matching pushed tag) our workflow will dispatch the container bake workflow in `narategithub/ldms-containers` repository.

Also conditioned this workflow to run only on `ovis-hpc/ldms` or `narategithub/ldms`, and change SOS branch to `b2.6`.

[fixup] dispatch

Backported from 10a9fd52ba9d023ba94e9f0df26593fd2b6ee222 on main.