### PR TITLE
Fix ldmsd_xprt_term() incorrectly removing config file contexts

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -8747,8 +8747,10 @@ void ldmsd_xprt_term(ldms_t x)
 	while (rbn) {
 		struct rbn *next_rbn = rbn_succ(rbn);
 		reqc = container_of(rbn, struct ldmsd_req_ctxt, rbn);
-		if (reqc->key.conn_id == ldms_xprt_conn_id(x))
-			__free_req_ctxt(reqc);
+		if (reqc->key.flags != REQ_CTXT_KEY_F_CFGFILE) {
+			if (reqc->key.conn_id == ldms_xprt_conn_id(x))
+				__free_req_ctxt(reqc);
+		}
 		rbn = next_rbn;
 	}
 	req_ctxt_tree_unlock();


### PR DESCRIPTION
When a connection disconnects, ldmsd traverses the request message tree to remove contexts associated with that connection. However, the tree contains contexts from both config files and transports.

The current logic doesn't check the flags when determinnig whether a context belongs to a transport, causing it to incorrectly remove config file contexts that happen to share the same connect ID.

The fix ensures only transport contexts are removed during disconnection cleanup.