### PR TITLE
Add support for msg_enable in configuration files.

### DIFF
--- a/ldms/src/core/ldms_msg.c
+++ b/ldms/src/core/ldms_msg.c
@@ -94,8 +94,8 @@ static ovis_log_t __ldms_msg_log = NULL; /* see __ldms_msg_init() below */
 
 static int __msg_stats_level = 1;
 
-/* Disable message support by default */
-int ldms_msg_enabled = 0;
+/* Initially enabled, see ldms_msg_disable/ldms_msg_enable */
+int ldms_msg_enabled = 1;
 
 struct __msg_event_s {
 	struct ldms_msg_event_s pub;

--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -2137,6 +2137,8 @@ int main(int argc, char *argv[])
 		av_free(auth_opt);
 		exit(1);
 	}
+	/* Disable message traffic by default. */
+	ldms_msg_disable();
 
 	if (pidfile) {
 		if( !access( pidfile, F_OK ) ) {

--- a/ldms/src/ldmsd/ldmsd_request_util.c
+++ b/ldms/src/ldmsd/ldmsd_request_util.c
@@ -103,6 +103,7 @@ struct req_str_id req_str_id_table[] = {
 	{  "metric_sets_default_authz", LDMSD_SET_DEFAULT_AUTHZ_REQ  },
 	{  "msg_client_stats",   LDMSD_MSG_CLIENT_STATS_REQ  },
 	{  "msg_disable",        LDMSD_MSG_DISABLE_REQ  },
+	{  "msg_enable",	 LDMSD_MSG_ENABLE_REQ  },
 	{  "msg_stats",          LDMSD_MSG_STATS_REQ  },
 	{  "oneshot",            LDMSD_ONESHOT_REQ  },
 	{  "option",             LDMSD_CMDLINE_OPTIONS_SET_REQ  },
@@ -372,6 +373,10 @@ const char *ldmsd_req_id2str(enum ldmsd_request req_id)
 	case LDMSD_STREAM_NEW_REQ : return "STREAM_NEW_REQ";
 	case LDMSD_STREAM_STATUS_REQ : return "STREAM_DIR_REQ";
 	case LDMSD_STREAM_DISABLE_REQ : return "STREAM_DISABLE_REQ";
+
+	case LDMSD_MSG_DISABLE_REQ : return "MSG_DISABLE_REQ";
+	case LDMSD_MSG_ENABLE_REQ : return "MSG_ENABLE_REQ";
+
 	default: return "UNKNOWN_REQ";
 	}
 }


### PR DESCRIPTION
The msg_enable command was previously only supported for network clients such as ldmsd_controller.

This change also changes how messages are disabled in LDMSD. Previously, messages were disabled in the API itself by default. This forces clients external to LDMSD to explicitly call ldms_msg_enable() in order to enable messages. With this change, messages are disabled in the LDMS Daemon by default, but enabled in the API.