### PR TITLE
Remove 'advertiser' from the prdcr_status output

### DIFF
--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1050,6 +1050,8 @@ class LdmsdCmdParser(cmd.Cmd):
             port = prdcr['port']
             if prdcr['type'] == 'bridge':
                 continue
+            if prdcr['type'] == 'advertiser':
+                continue
             pstate = prdcr['state']
             if prdcr['type'] == 'advertised':
                 if prdcr['state'] == 'STANDBY':


### PR DESCRIPTION
The patch removes advertisers from the prdcr_status. advertiser_status is available to report the status of advertisers already. Including advertisers in the prdcr_status output could be confusing.