### PR TITLE
Fix TIMESTAMP type handling.

### DIFF
--- a/ldms/python/ldms.pxd
+++ b/ldms/python/ldms.pxd
@@ -566,6 +566,7 @@ cdef extern from "ldms.h" nogil:
         V_RECORD_TYPE      "LDMS_V_RECORD_TYPE"
         V_RECORD_INST      "LDMS_V_RECORD_INST"
         V_RECORD_ARRAY     "LDMS_V_RECORD_ARRAY"
+        V_TIMESTAMP   "LDMS_V_TIMESTAMP"
         V_FIRST       "LDMS_V_FIRST"
         V_LAST        "LDMS_V_LAST"
         LDMS_V_NONE
@@ -596,6 +597,7 @@ cdef extern from "ldms.h" nogil:
         LDMS_V_RECORD_TYPE
         LDMS_V_RECORD_INST
         LDMS_V_RECORD_ARRAY
+        LDMS_V_TIMESTAMP
         LDMS_V_FIRST
         LDMS_V_LAST
     union ldms_value:
@@ -612,6 +614,7 @@ cdef extern from "ldms.h" nogil:
         double v_d
         ldms_list v_lh
         ldms_list_entry v_le
+        ldms_timestamp v_ts
         char a_char[0]
         uint8_t a_u8[0]
         int8_t a_s8[0]

--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -641,6 +641,11 @@ cdef py_ldms_metric_array_get_float(Set s, int m_idx, int e_idx):
 cdef py_ldms_metric_get_double(Set s, int m_idx):
     return ldms_metric_get_double(s.rbd, m_idx)
 
+cdef py_ldms_metric_get_ts(Set s, int m_idx):
+    cdef ldms_mval_t mv = ldms_metric_get(s.rbd, m_idx)
+    ts = mv.v_ts.sec + mv.v_ts.usec*1e-6
+    return ts
+
 cdef py_ldms_metric_array_get_double(Set s, int m_idx, int e_idx):
     return ldms_metric_array_get_double(s.rbd, m_idx, e_idx)
 
@@ -696,6 +701,8 @@ METRIC_GETTER_TBL = {
 
         LDMS_V_RECORD_TYPE : py_ldms_metric_get_record_type,
         LDMS_V_RECORD_ARRAY : py_ldms_metric_get_record_array,
+
+        LDMS_V_TIMESTAMP : py_ldms_metric_get_ts,
     }
 
 
@@ -876,6 +883,13 @@ cdef py_ldms_metric_array_set_float(Set s, int m_idx, int e_idx, val):
 cdef py_ldms_metric_set_double(Set s, int m_idx, val):
     return ldms_metric_set_double(s.rbd, m_idx, val)
 
+cdef py_ldms_metric_set_ts(Set s, int m_idx, val):
+    cdef ldms_mval_t mv = ldms_metric_get(s.rbd, m_idx)
+    f = float(val)
+    mv.v_ts.sec = int(f)
+    mv.v_ts.usec = int((f % 1) * 1e6)
+    return f
+
 cdef py_ldms_metric_array_set_double(Set s, int m_idx, int e_idx, val):
     return ldms_metric_array_set_double(s.rbd, m_idx, e_idx, val)
 
@@ -917,6 +931,8 @@ METRIC_SETTER_TBL = {
         LDMS_V_LIST : py_ldms_metric_set_list,
         LDMS_V_RECORD_TYPE : py_ldms_metric_set_record_type,
         LDMS_V_RECORD_ARRAY : py_ldms_metric_set_record_array,
+
+        LDMS_V_TIMESTAMP : py_ldms_metric_set_ts,
     }
 
 

--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -5269,6 +5269,7 @@ int ldms_schema_metric_add_template(ldms_schema_t s,
 		case LDMS_V_S64:
 		case LDMS_V_F32:
 		case LDMS_V_D64:
+		case LDMS_V_TIMESTAMP:
 			if (ent->flags & LDMS_MDESC_F_META) {
 				ret = ldms_schema_meta_add_with_unit(
 						s, ent->name, ent->unit, ent->type

--- a/ldms/src/ldmsd/ldms_ls.c
+++ b/ldms/src/ldmsd/ldms_ls.c
@@ -335,6 +335,9 @@ size_t prim_value_format(enum ldms_value_type type, ldms_mval_t val, size_t n, i
 			cnt += snprintf(&buf[cnt], BUF_LEN - cnt, "%f", val->a_d[i]);
 		}
 		break;
+	case LDMS_V_TIMESTAMP:
+		cnt = snprintf(buf, BUF_LEN, "%u.%06u", val->v_ts.sec, val->v_ts.usec);
+		break;
 	default:
 		return 0;
 	}
@@ -644,6 +647,9 @@ void value_format(ldms_set_t s, enum ldms_value_type type, ldms_mval_t val, size
 			printf("]");
 			printf("\n");
 		}
+		break;
+	case LDMS_V_TIMESTAMP:
+		printf("%u.%06u", val->v_ts.sec, val->v_ts.usec);
 		break;
 	default:
 		printf("Unknown metric type");


### PR DESCRIPTION
TIMESTAMP type was not properly handled in Python, schema add, and `ldms_ls`.