### PR TITLE
json_stream_sampler cleanup

### DIFF
--- a/ldms/src/sampler/json/json_stream_sampler.c
+++ b/ldms/src/sampler/json/json_stream_sampler.c
@@ -1210,6 +1210,9 @@ static void destructor(ldmsd_plug_handle_t handle)
 	if (js->stream_client)
 		ldmsd_stream_close(js->stream_client);
 	purge_schema_tree(handle, js);
+	pthread_mutex_destroy(&js->sch_tree_lock);
+	pthread_mutex_destroy(&js->lock);
+	free(js);
 }
 
 struct ldmsd_sampler ldmsd_plugin_interface = {


### PR DESCRIPTION
Removes the last vestiges of the cfgobj structs from json_stream_sampler. Also fixes the per-instance context allocation by performing it in constructor().

Remove the global __log, and uses a per-instance log handle, allowing the plugin to be multi-instance capable.

@tom95858 this PR includes your 'Revert "Fix json_stream_sampler"' from PR #2006.