### PR TITLE
add missing DAEMONS declaration to test scripts

### DIFF
--- a/ldms/scripts/examples/all_example
+++ b/ldms/scripts/examples/all_example
@@ -1,5 +1,6 @@
 export plugname=all_example
 portbase=61000
+DAEMONS 2
 LDMSD -p prolog.sampler 1
 LDMSD -p prolog.sampler -p prolog.store2 2
 MESSAGE ldms_ls on host 1:

--- a/ldms/scripts/examples/all_example.sos
+++ b/ldms/scripts/examples/all_example.sos
@@ -1,5 +1,6 @@
 export plugname=all_example
 portbase=61000
+DAEMONS 2
 LDMSD -p prolog.sampler 1
 VGARGS="--track-origins=yes "
 vgon

--- a/ldms/scripts/examples/app_sampler
+++ b/ldms/scripts/examples/app_sampler
@@ -2,6 +2,7 @@ export plugname=app_sampler
 export dsname=$(ldms_dstat_schema_name mmalloc=1 io=1 fd=1 auto-schema=1)
 export dstat_schema=$dsname
 portbase=61060
+DAEMONS 2
 ${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 15 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
 VGARGS="--leak-check=full --track-origins=yes --trace-children=yes"
 vgon

--- a/ldms/scripts/examples/array_example
+++ b/ldms/scripts/examples/array_example
@@ -1,5 +1,6 @@
 export plugname=array_example
 portbase=61004
+DAEMONS 2
 LDMSD -p prolog.sampler 1
 LDMSD -p prolog.sampler -p prolog.store2 2
 MESSAGE ldms_ls on host 1:

--- a/ldms/scripts/examples/blob_writer
+++ b/ldms/scripts/examples/blob_writer
@@ -2,6 +2,7 @@ export plugname=dstat
 export dsname=$(ldms_dstat_schema_name mmalloc=1 io=1 fd=1 auto-schema=1)
 export dstat_schema=$dsname
 portbase=61060
+DAEMONS 2
 # memcheck
 VGARGS="--trace-children=yes --track-origins=yes --leak-check=full --show-leak-kinds=all"
 # drd

--- a/ldms/scripts/examples/blob_writer_rollover
+++ b/ldms/scripts/examples/blob_writer_rollover
@@ -2,6 +2,7 @@ export plugname=dstat
 export dsname=$(ldms_dstat_schema_name mmalloc=1 io=1 fd=1 auto-schema=1)
 export dstat_schema=$dsname
 portbase=61060
+DAEMONS 2
 # memcheck
 VGARGS="--trace-children=yes --track-origins=yes --leak-check=full --show-leak-kinds=all"
 # drd

--- a/ldms/scripts/examples/clock
+++ b/ldms/scripts/examples/clock
@@ -1,5 +1,6 @@
 export plugname=clock
 portbase=61008
+DAEMONS 3
 LDMSD -p prolog.sampler 1 2
 LDMSD -p prolog.sampler -p prolog.store3 3
 MESSAGE ldms_ls on host 1:

--- a/ldms/scripts/examples/clock.job
+++ b/ldms/scripts/examples/clock.job
@@ -1,6 +1,7 @@
 # this sampler uses the old job option
 export plugname=clock
 portbase=62008
+DAEMONS 3
 JOBDATA $TESTDIR/job.data 1 2 3
 LDMSD -p prolog.jobid -p prolog.sampler 1 2
 LDMSD -p prolog.jobid -p prolog.sampler -p prolog.jobid.store3 3

--- a/ldms/scripts/examples/conf_csv
+++ b/ldms/scripts/examples/conf_csv
@@ -1,4 +1,5 @@
 portbase=61076
+DAEMONS 3
 MESSAGE starting agg and two collectors
 JOBDATA $TESTDIR/job.data 1 2 3
 #vgon

--- a/ldms/scripts/examples/csvcheckattrs
+++ b/ldms/scripts/examples/csvcheckattrs
@@ -1,5 +1,6 @@
 export plugname=meminfo
 portbase=61098
+DAEMONS 2
 #export VGARGS="--track-origins=yes --leak-check=full --show-leak-kinds=all"
 LDMSD -p prolog.sampler 1
 #vgon

--- a/ldms/scripts/examples/darshan_stream_store
+++ b/ldms/scripts/examples/darshan_stream_store
@@ -1,5 +1,6 @@
 export plugname=darshan_stream_store
 portbase=61020
+DAEMONS 1
 
 echo '{"schema":"darshan_data", "uid":99066, "exe":"/pscratch/spwalto/darshan-ldms-output/mpi-io-test","job_id":21068382,"rank":1,"ProducerName":"ec1326","file":"/pscratch/spwalto/darshan-ldms-output/mpi-io-test_pC.tmp.dat","record_id":4994957589679181304,"module":"POSIX","type":"MET","max_byte":-1,"switches":-1,"flushes":-1,"cnt":2,"op":"open","seg":[{"pt_sel":-1,"irreg_hslab":-1,"reg_hslab":-1,"ndims":-1,"npoints":-1,"off":-1,"len":-1,"start":1.986402,"dur":0.000019,"total":0.000066,"timestamp":1743618561.073590}]}' > $LDMSD_RUN/x.json
 echo "" >> $LDMSD_RUN/x.json

--- a/ldms/scripts/examples/dcgm_nobase
+++ b/ldms/scripts/examples/dcgm_nobase
@@ -1,5 +1,6 @@
 export plugname=dcgm
 portbase=61073
+DAEMONS 2
 VGARGS="--leak-check=full --show-leak-kinds=definite  --track-origins=yes --trace-children=yes"
 JOBDATA $TESTDIR/job.data 1 2
 #vgon

--- a/ldms/scripts/examples/dstat
+++ b/ldms/scripts/examples/dstat
@@ -1,5 +1,6 @@
 export plugname=dstat
 portbase=61086
+DAEMONS 3
 LDMSD -p prolog.sampler 1 2
 LDMSD -p prolog.sampler -p prolog.store3 3
 MESSAGE ldms_ls on host 1:

--- a/ldms/scripts/examples/dstat.job
+++ b/ldms/scripts/examples/dstat.job
@@ -1,6 +1,7 @@
 # this sampler uses the new job option
 export plugname=dstat
 portbase=62086
+DAEMONS 3
 JOBDATA $TESTDIR/job.data 1 2 3
 export dsname1=$(ldms_dstat_schema_name mmalloc=1 io=1 fd=1 auto-schema=1 sc_clk_tck=1)
 echo DSNAME1=$dsname1

--- a/ldms/scripts/examples/edac
+++ b/ldms/scripts/examples/edac
@@ -1,5 +1,6 @@
 export plugname=edac
 portbase=61012
+DAEMONS 2
 # data comes from /sys/devices/system/edac/mc/mc*/csrow*
 export max_mc=$(ls /sys/devices/system/edac/mc/mc* -d |wc -l)
 export max_csrow=$(ls /sys/devices/system/edac/mc/mc0/csrow* -d |wc -l)

--- a/ldms/scripts/examples/filesingle
+++ b/ldms/scripts/examples/filesingle
@@ -1,5 +1,6 @@
 export plugname=filesingle
 portbase=61060
+DAEMONS 2
 ldms-sensors-config > $LDMSD_RUN/filesingle.conf
 export FSCONF=$LDMSD_RUN/filesingle.conf
 vgon

--- a/ldms/scripts/examples/fptrans
+++ b/ldms/scripts/examples/fptrans
@@ -1,5 +1,6 @@
 export plugname=fptrans
 portbase=61014
+DAEMONS 2
 LDMSD -p prolog.sampler 1
 LDMSD -p prolog.sampler -p prolog.store2 2
 MESSAGE ldms_ls on host 1:

--- a/ldms/scripts/examples/linux_proc_sampler
+++ b/ldms/scripts/examples/linux_proc_sampler
@@ -6,6 +6,7 @@ export LDMSD_LOG_TIME_SEC=1
 export LDMSD_EXTRA="-m 128m"
 
 portbase=61060
+DAEMONS 3
 cat << EOF > $LDMSD_RUN/exclude_env
 ^COLORTERM
 ^DBU.*

--- a/ldms/scripts/examples/linux_proc_sampler.job
+++ b/ldms/scripts/examples/linux_proc_sampler.job
@@ -5,6 +5,7 @@ export LDMSD_LOG_LEVEL=ERROR
 export LDMSD_LOG_TIME_SEC=1
 export LDMSD_EXTRA="-m 128m"
 
+DAEMONS 3
 tuser=nobody
 function SUSLEEP () {
 	if test "$bypass" = "1"; then

--- a/ldms/scripts/examples/lnet_stats
+++ b/ldms/scripts/examples/lnet_stats
@@ -1,5 +1,6 @@
 export plugname=lnet_stats
 portbase=61016
+DAEMONS 3
 export statfile=$LDMSD_RUN/lnet_dummy
 vgon
 LDMSD 1

--- a/ldms/scripts/examples/loadavg
+++ b/ldms/scripts/examples/loadavg
@@ -1,5 +1,6 @@
 export plugname=loadavg
 portbase=61060
+DAEMONS 4
 export LDMSD_MEM_SZ=60k
 
 #vgon

--- a/ldms/scripts/examples/lustre_mdc
+++ b/ldms/scripts/examples/lustre_mdc
@@ -3,6 +3,7 @@ export plugname=lustre_mdc
 #VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=all"
 #vgon
 portbase=61060
+DAEMONS 3
 LDMSD -s 2000000 1 2 3
 #vgoff
 SLEEP 2

--- a/ldms/scripts/examples/meminfo.job
+++ b/ldms/scripts/examples/meminfo.job
@@ -1,6 +1,7 @@
 # this sampler uses the new job option
 export plugname=meminfo
 portbase=62020
+DAEMONS 3
 JOBDATA $TESTDIR/job.data 1 2 3
 LDMSD -p prolog.jobid -p prolog.jobid.sampler 1 2
 LDMSD -p prolog.jobid -p prolog.jobid.sampler -p prolog.jobid.store3 3

--- a/ldms/scripts/examples/munge
+++ b/ldms/scripts/examples/munge
@@ -1,5 +1,6 @@
 export plugname=meminfo
 portbase=61014
+DAEMONS 3
 LDMSD_EXTRA="-a munge"
 LDMSD -p prolog.sampler 1
 LDMSD -p prolog.sampler -p prolog.store2 2

--- a/ldms/scripts/examples/procdiskstats
+++ b/ldms/scripts/examples/procdiskstats
@@ -1,5 +1,6 @@
 export plugname=procdiskstats
 portbase=61064
+DAEMONS 3
 LDMSD -p prolog.sampler 1 2
 LDMSD -p prolog.sampler -p prolog.store3 3
 MESSAGE ldms_ls on host 1:

--- a/ldms/scripts/examples/procinterrupts
+++ b/ldms/scripts/examples/procinterrupts
@@ -1,5 +1,6 @@
 export plugname=procinterrupts
 portbase=61068
+DAEMONS 3
 export LDMSD_EXTRA="-m 1G"
 LDMSD -p prolog.sampler 1 2
 LDMSD -p prolog.sampler -p prolog.store3 3

--- a/ldms/scripts/examples/procnet
+++ b/ldms/scripts/examples/procnet
@@ -3,6 +3,7 @@ IFACES=`ifconfig -a |grep UP |sed -e 's/:.*//g' | tr -s '[:space:]' , | sed -e '
 export IFACES
 
 portbase=61024
+DAEMONS 2
 VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=definite"
 #vgon
 LDMSD 1 2

--- a/ldms/scripts/examples/procnetdev
+++ b/ldms/scripts/examples/procnetdev
@@ -5,6 +5,7 @@ IFACES=`ifconfig -a |grep UP |sed -e 's/:.*//g' | tr -s '[:space:]' , | sed -e '
 export IFACES
 
 portbase=61024
+DAEMONS 2
 LDMSD 1 2
 MESSAGE ldms_ls on host 1:
 LDMS_LS 1 -l

--- a/ldms/scripts/examples/procnfs
+++ b/ldms/scripts/examples/procnfs
@@ -1,5 +1,6 @@
 export plugname=procnfs
 portbase=61028
+DAEMONS 3
 LDMSD -p prolog.sampler 1 2
 LDMSD -p prolog.sampler -p prolog.store3 3
 MESSAGE ldms_ls on host 1:

--- a/ldms/scripts/examples/procsensors
+++ b/ldms/scripts/examples/procsensors
@@ -1,5 +1,6 @@
 export plugname=procsensors
 portbase=61032
+DAEMONS 2
 LDMSD -p prolog.sampler 1
 LDMSD -p prolog.sampler -p prolog.store2 2
 MESSAGE ldms_ls on host 1:

--- a/ldms/scripts/examples/procstat
+++ b/ldms/scripts/examples/procstat
@@ -1,4 +1,5 @@
 portbase=61036
+DAEMONS 3
 LDMSD `seq 3`
 SLEEP 10
 MESSAGE ldms_ls on host 1:

--- a/ldms/scripts/examples/procstat.job
+++ b/ldms/scripts/examples/procstat.job
@@ -1,6 +1,7 @@
 # this sampler uses the new job option
 export plugname=procstat
 portbase=62036
+DAEMONS 3
 VGARGS="--leak-check=full --track-origins=yes --trace-children=yes"
 JOBDATA $TESTDIR/job.data 1 2 3
 LDMSD -p prolog.jobid -p prolog.jobid.sampler 1

--- a/ldms/scripts/examples/rabbitkw
+++ b/ldms/scripts/examples/rabbitkw
@@ -1,6 +1,7 @@
 # rabbitmq-server.service and epmd.service need to be running
 # in the default configuration (insecure) for this test to pass.
 portbase=61090
+DAEMONS 3
 AUTHFILE=$TESTDIR/run/authfile
 export AUTHFILE
 echo "secretword=guest" > $AUTHFILE

--- a/ldms/scripts/examples/renamecsv
+++ b/ldms/scripts/examples/renamecsv
@@ -1,5 +1,6 @@
 export plugname=meminfo
 portbase=61096
+DAEMONS 2
 #export VGARGS="--track-origins=yes --leak-check=full"
 LDMSD -p prolog.sampler 1
 #vgon

--- a/ldms/scripts/examples/rollagain
+++ b/ldms/scripts/examples/rollagain
@@ -1,5 +1,6 @@
 export plugname=meminfo
 portbase=61098
+DAEMONS 4
 #export VGARGS="--track-origins=yes --leak-check=full --show-leak-kinds=all"
 LDMSD -p prolog.sampler 1
 #vgon

--- a/ldms/scripts/examples/rollemptycsv
+++ b/ldms/scripts/examples/rollemptycsv
@@ -1,5 +1,6 @@
 export plugname=meminfo
 portbase=61096
+DAEMONS 3
 #export VGARGS="--track-origins=yes --leak-check=full"
 LDMSD -p prolog.sampler 1
 #vgon

--- a/ldms/scripts/examples/sampler_atasmart
+++ b/ldms/scripts/examples/sampler_atasmart
@@ -1,5 +1,6 @@
 export plugname=sampler_atasmart
 portbase=61044
+DAEMONS 2
 LDMSD 1 2
 MESSAGE ldms_ls on host 1:
 LDMS_LS 1 -l

--- a/ldms/scripts/examples/sequence_unsupp
+++ b/ldms/scripts/examples/sequence_unsupp
@@ -1,4 +1,5 @@
 portbase=61048
+DAEMONS 4
 export sampler=meminfo
 LDMSD `seq 4`
 

--- a/ldms/scripts/examples/setclones
+++ b/ldms/scripts/examples/setclones
@@ -1,5 +1,6 @@
 export plugname=synthetic
 portbase=61060
+DAEMONS 2
 LDMSD 1 2
 MESSAGE ldms_ls on host 2:
 LDMS_LS 2 -l

--- a/ldms/scripts/examples/shm
+++ b/ldms/scripts/examples/shm
@@ -10,6 +10,7 @@
 # e.g.; module purge; module load openmpi-gnu/3.0
 export plugname=meminfo
 portbase=60000
+DAEMONS 3
 # meminfo on daemon 1
 LDMSD 1
 # daemon 2shm is configured in shm.2

--- a/ldms/scripts/examples/stream_store
+++ b/ldms/scripts/examples/stream_store
@@ -1,5 +1,6 @@
 export plugname=stream_store
 portbase=61020
+DAEMONS 1
 echo '{"job-id" : 10364, "rank" : 1, "kokkos-perf-data" : [ {"name" : "SPARTAFOO0", "count": 0, "time": 0.0000},{"name" : "SPARTAFOO1", "count": 1, "time": 0.0001},{"name" : "SPARTAFOO2", "count": 2, "time": 0.0002},{"name" : "SPARTAFOO3", "count": 3, "time": 0.0003},{"name" : "SPARTAFOO4", "count": 4, "time": 0.0004},{"name" : "SPARTAFOO5", "count": 5, "time": 0.0005},{"name" : "SPARTAFOO6", "count": 6, "time": 0.0006},{"name" : "SPARTAFOO7", "count": 7, "time": 0.0007},{"name" : "SPARTAFOO8", "count": 8, "time": 0.0008},{"name" : "SPARTAFOO9", "count": 9, "time": 0.0009}] }' > $LDMSD_RUN/x.json
 echo "" >> $LDMSD_RUN/x.json
 VGARGS="--leak-check=full --show-leak-kinds=definite --track-origins=yes --trace-children=yes"

--- a/ldms/scripts/examples/strict_kill
+++ b/ldms/scripts/examples/strict_kill
@@ -1,5 +1,6 @@
 export plugname=filesingle
 portbase=61060
+DAEMONS 2
 ldms-sensors-config > $LDMSD_RUN/filesingle.conf
 export FSCONF=$LDMSD_RUN/filesingle.conf
 vgon

--- a/ldms/scripts/examples/synthetic
+++ b/ldms/scripts/examples/synthetic
@@ -1,5 +1,6 @@
 export plugname=synthetic
 portbase=61052
+DAEMONS 3
 LDMSD -p prolog.sampler 1 2
 LDMSD -p prolog.sampler -p prolog.store3 3
 MESSAGE ldms_ls on host 1:

--- a/ldms/scripts/examples/sysclassib
+++ b/ldms/scripts/examples/sysclassib
@@ -1,5 +1,6 @@
 export plugname=sysclassib
 portbase=61056
+DAEMONS 3
 LDMSD -p prolog.sampler 1 2
 LDMSD -p prolog.sampler -p prolog.store3 3
 MESSAGE ldms_ls on host 1:

--- a/ldms/scripts/examples/sysclassib.job
+++ b/ldms/scripts/examples/sysclassib.job
@@ -1,5 +1,6 @@
 export plugname=sysclassib
 portbase=62056
+DAEMONS 3
 JOBDATA $TESTDIR/job.data 1 2 3
 LDMSD -p prolog.jobid -p prolog.sampler 1 2
 LDMSD -p prolog.jobid -p prolog.sampler -p prolog.jobid.store3 3

--- a/ldms/scripts/examples/uidgidcsv
+++ b/ldms/scripts/examples/uidgidcsv
@@ -1,5 +1,6 @@
 export plugname=meminfo
 portbase=61096
+DAEMONS 2
 #export VGARGS="--track-origins=yes --leak-check=full"
 LDMSD -p prolog.sampler 1
 #vgon

--- a/ldms/scripts/examples/vmstat
+++ b/ldms/scripts/examples/vmstat
@@ -1,5 +1,6 @@
 export plugname=vmstat
 portbase=61060
+DAEMONS 2
 LDMSD -c 1 2
 SLEEP 5
 MESSAGE ldms_ls on host 1:


### PR DESCRIPTION
This defines the expected number of daemons for each input to ldms-static-test.sh where it was missing.
