### PR TITLE
parse single argument to ldms-static-test DAEMONS calls correctly

### DIFF
--- a/ldms/scripts/ldms-static-test.rst
+++ b/ldms/scripts/ldms-static-test.rst
@@ -56,6 +56,8 @@ DAEMONS <daemon-numbers>
      that any daemon can connect to any other by referencing $portN as
      explained in ENVIRONMENT below. If omitted, the ordering and
      aggregation relationships of LDMSD calls may be infeasible.
+     If only a single number N is given, it will be expanded to the range
+     $(seq N).
 
 SET_LOG_LEVEL <DEBUG|ERROR|INFO|ALL|QUIET|WARNING|CRITICAL>
    |

--- a/ldms/scripts/ldms-static-test.sh.in
+++ b/ldms/scripts/ldms-static-test.sh.in
@@ -171,9 +171,14 @@ function DAEMONS {
 	if test $did_daemons = "1"; then
 		return
 	fi
-	for i in $*; do
+	if test "$#" = "1"; then
+		ALL_DAEMONS=$(seq $1)
+	else
+		ALL_DAEMONS="$*"
+	fi
+	for i in $ALL_DAEMONS; do
 		/bin/rm -f ${LOGDIR}/$i.txt ${LOGDIR}/vg.$i ${LOGDIR}/teardown.$i.txt ${LOGDIR}/$i.stdio
-		/bin/rm -f ${RUNDIR}/revconf.$i ${RUNDIR}/conf.$i ${RUNDIR}/yaml.$i ${RUNDIR}/yaml.$i.pre-sed ${RUNDIR}/start.$i
+		/bin/rm -f ${LDMSD_RUN}/revconf.$i ${LDMSD_RUN}/conf.$i ${LDMSD_RUN}/yaml.$i ${LDMSD_RUN}/yaml.$i.pre-sed ${LDMSD_RUN}/start.$i
 		ports[$i]=$(($portbase + $i))
 		eval export port$i=${ports[$i]}
 		binname=ldmsd.${ports[$i]}

--- a/ldms/scripts/ldms_pll-ldms-static-test.rst
+++ b/ldms/scripts/ldms_pll-ldms-static-test.rst
@@ -70,6 +70,8 @@ DAEMONS <daemon-numbers>
      parallel execution, the Nth daemon will run as the (N-1)th slurm
      task, since Slurm numbers tasks from 0 and this tool numbers tasks
      from 1.
+     If only a single number N is given, it will be expanded to the range
+     $(seq N).
 
 SET_LOG_LEVEL <DEBUG|ERROR|INFO|ALL|QUIET|WARNING|CRITICAL>
    |

--- a/ldms/scripts/pll-ldms-static-test.sh.in
+++ b/ldms/scripts/pll-ldms-static-test.sh.in
@@ -255,7 +255,11 @@ function DAEMONS {
 	if test $did_daemons = "1"; then
 		return
 	fi
-	ALL_DAEMONS="$*"
+	if test "$#" = "1"; then
+		ALL_DAEMONS=$(seq $1)
+	else
+		ALL_DAEMONS="$*"
+	fi
 	declare -a ALL_DAEMONS_ARRAY
 	for i in $*; do
 		ALL_DAEMONS_ARRAY[$i]=$i


### PR DESCRIPTION
This fixes the expected behavior if only a single argument is given to the DAEMONS function in the static testing scripts.
DAEMONS 7 now is processed as DAEMONS $(seq 1 7).

This changes no  C code.
