### PR TITLE
Add error reporting for malformed YAML input file.

### DIFF
--- a/ldms/python/ldmsd/ldmsd_yaml_parser
+++ b/ldms/python/ldmsd/ldmsd_yaml_parser
@@ -27,13 +27,19 @@ if __name__ == "__main__":
     config_fp = open(args.ldms_config)
     conf_spec = yaml.safe_load(config_fp)
 
+    if not isinstance(conf_spec, (list, dict)):
+        print(f"Error: input {args.ldms_config} is not yaml. Contents:", file=sys.stderr)
+        print(conf_spec, file=sys.stderr)
+        sys.exit(errno.EINVAL)
+
     cluster = YamlCfg(None, None, conf_spec, args)
 
     if args.daemon_name and args.generate_config_path:
         print(f'Parameters "daemon_name" and "generate_config_path" are mutually exclusive.\n'
               f'Specifying the "daemon_name" parameter will generate the configuration for a single ldmsd\n'
-              f'Specifying the "generate_config_path" parameter will generate an entire cluster\'s v4 configuration files in the path provided.\n')
-        sys.exit(0)
+              f'Specifying the "generate_config_path" parameter will generate an entire cluster\'s\n'
+              f'v4 configuration files in the path provided.\n', file=sys.stderr)
+        sys.exit(errno.EINVAL)
 
     if args.daemon_name:
         ldmsd_cfg_str = cluster.daemon_config(args.ldms_config, args.daemon_name.rstrip('0'))
@@ -44,10 +50,10 @@ if __name__ == "__main__":
         rc = cluster.config_v4(args.generate_config_path)
         if rc:
             sys.exit(rc)
-        print('LDMSD v4 config files generated')
+        print('LDMSD v4 config files generated', file=sys.stderr)
         sys.exit(0)
 
     if not args.generate_config_path and not args.ldms_config and not args.daemon_name:
-        print(f'No action detected. Exiting...')
+        print(f'No action detected. Exiting.', file=sys.stderr)
 
     sys.exit(0)

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -1129,8 +1129,12 @@ char *__process_yaml_config_file(const char *path, const char *dname)
 		}
 	}
 	cfg_str[tbytes] = '\0';
-	(void)pclose(fp);
+	int rc = pclose(fp);
 	fp = NULL;
+	if (rc && !tbytes) {
+		free(cfg_str);
+		return NULL;
+	}
 	return cfg_str;
 err:
 	if (cfg_str)


### PR DESCRIPTION
Automated testing and admins of systemd daemons need ldmsd_yaml_parser results that are usable. For example, .conf files fed to -y now yield less-cryptic errors and malformed yaml is now reported via return code.

This patch:
- routes the main error messages of ldmsd_yaml_parser to stderr and sets the return value to an errno value.
- converts an nonzero error on pclose of the ldmsd_yaml_parser subprocess to a NULL return if the output string is also empty.
- traps anything that is not a reasonable yaml result (list or dict)