### PR TITLE
add stream_enable to stream-related tests and default to .conf

### DIFF
--- a/ldms/scripts/examples/app_sampler.1
+++ b/ldms/scripts/examples/app_sampler.1
@@ -1,3 +1,4 @@
+stream_enable
 load name=${testname}
 config name=${testname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i}
 start name=${testname} interval=1000000 offset=0

--- a/ldms/scripts/examples/app_sampler.2
+++ b/ldms/scripts/examples/app_sampler.2
@@ -1,3 +1,4 @@
+stream_enable
 load name=blob_stream_writer plugin=blob_stream_writer
 config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm
 

--- a/ldms/scripts/examples/blob_writer.1
+++ b/ldms/scripts/examples/blob_writer.1
@@ -1,3 +1,4 @@
+stream_enable
 #load name=dstat
 #config name=dstat producer=localhost${i} instance=localhost${i}/${dstat_schema} component_id=${i} mmalloc=1 io=1 fd=1 auto-schema=1)
 #start name=dstat interval=1000000 offset=0

--- a/ldms/scripts/examples/blob_writer.2
+++ b/ldms/scripts/examples/blob_writer.2
@@ -1,3 +1,4 @@
+stream_enable
 load name=blob_stream_writer plugin=blob_stream_writer
 config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm timing=1 types=1 spool=1
 

--- a/ldms/scripts/examples/blob_writer_rollover.1
+++ b/ldms/scripts/examples/blob_writer_rollover.1
@@ -1,3 +1,4 @@
+stream_enable
 #load name=dstat
 #config name=dstat producer=localhost${i} instance=localhost${i}/${dstat_schema} component_id=${i} mmalloc=1 io=1 fd=1 auto-schema=1)
 #start name=dstat interval=1000000 offset=0

--- a/ldms/scripts/examples/blob_writer_rollover.2
+++ b/ldms/scripts/examples/blob_writer_rollover.2
@@ -1,3 +1,4 @@
+stream_enable
 load name=blob_stream_writer plugin=blob_stream_writer
 config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm timing=1 types=1 spool=1 rolltype=3 rollover=10
 

--- a/ldms/scripts/examples/darshan_stream_store.1
+++ b/ldms/scripts/examples/darshan_stream_store.1
@@ -1,3 +1,4 @@
+stream_enable
 load name=darshan_stream_store
 config name=darshan_stream_store path=${STOREDIR}/sos stream=darshanConnector
 prdcr_add name=localhost1 host=localhost type=active xprt=sock port=${port1} reconnect=20000000

--- a/ldms/scripts/examples/linux_proc_sampler.1
+++ b/ldms/scripts/examples/linux_proc_sampler.1
@@ -1,3 +1,4 @@
+stream_enable
 load name=${testname}
 config name=${testname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} perm=0644 cfg_file=${LDMSD_RUN}/metrics.input
 start name=${testname} interval=1000000 offset=0

--- a/ldms/scripts/examples/linux_proc_sampler.2
+++ b/ldms/scripts/examples/linux_proc_sampler.2
@@ -1,3 +1,4 @@
+stream_enable
 # blobs must be allowed by writer plugin and prdcr_subscribe by daemon
 load name=blob_stream_writer plugin=blob_stream_writer
 config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm stream=linux_proc_sampler_env stream=linux_proc_sampler_argv types=1 stream=linux_proc_sampler_files

--- a/ldms/scripts/examples/linux_proc_sampler.3
+++ b/ldms/scripts/examples/linux_proc_sampler.3
@@ -1,3 +1,4 @@
+stream_enable
 prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} reconnect=2000000
 prdcr_start name=localhost2
 

--- a/ldms/scripts/examples/linux_proc_sampler.job.1
+++ b/ldms/scripts/examples/linux_proc_sampler.job.1
@@ -1,3 +1,4 @@
+stream_enable
 load name=${plugname}
 config name=${plugname} producer=localhost${i} schema=${plugname} instance=localhost${i}/${plugname} component_id=${i} perm=0644 cfg_file=${LDMSD_RUN}/metrics.input
 start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/linux_proc_sampler.job.2
+++ b/ldms/scripts/examples/linux_proc_sampler.job.2
@@ -1,3 +1,4 @@
+stream_enable
 # blobs must be allowed by writer plugin and prdcr_subscribe by daemon
 load name=blob_stream_writer plugin=blob_stream_writer
 config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm stream=linux_proc_sampler_env stream=linux_proc_sampler_argv types=1 stream=linux_proc_sampler_files

--- a/ldms/scripts/examples/linux_proc_sampler.job.3
+++ b/ldms/scripts/examples/linux_proc_sampler.job.3
@@ -1,3 +1,4 @@
+stream_enable
 prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} reconnect=2000000
 prdcr_start name=localhost2
 

--- a/ldms/scripts/examples/proc_stream.1
+++ b/ldms/scripts/examples/proc_stream.1
@@ -1,3 +1,4 @@
+stream_enable
 load name=linux_proc_sampler
 config name=linux_proc_sampler producer=localhost${i} schema=linux_proc_sampler instance=localhost${i}/linux_proc_sampler component_id=${i} perm=0644 cfg_file=${LDMSD_RUN}/metrics.input
 start name=linux_proc_sampler interval=1000000 offset=0

--- a/ldms/scripts/examples/proc_stream.2
+++ b/ldms/scripts/examples/proc_stream.2
@@ -1,3 +1,4 @@
+stream_enable
 # blobs must be allowed by writer plugin and prdcr_subscribe by daemon
 load name=blob_stream_writer plugin=blob_stream_writer
 config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm stream=linux_proc_sampler_env stream=linux_proc_sampler_argv types=1 stream=linux_proc_sampler_files

--- a/ldms/scripts/examples/proc_stream.3
+++ b/ldms/scripts/examples/proc_stream.3
@@ -1,3 +1,4 @@
+stream_enable
 load name=blob_stream_writer plugin=blob_stream_writer
 config name=blob_stream_writer path=${STOREDIR} container=blobs_L2 stream=slurm stream=linux_proc_sampler_env stream=linux_proc_sampler_argv types=1 stream=linux_proc_sampler_files
 

--- a/ldms/scripts/examples/stream_store.1
+++ b/ldms/scripts/examples/stream_store.1
@@ -1,3 +1,4 @@
+stream_enable
 load name=stream_csv_store
 # 3 works for longer times (due to fixed internal sleep between count checks)
 #config name=stream_csv_store path=${STOREDIR} container=csv stream=foo buffer=1 rolltype=3 rollover=50

--- a/ldms/scripts/examples/stream_store_many
+++ b/ldms/scripts/examples/stream_store_many
@@ -1,0 +1,33 @@
+portbase=11000
+DAEMONS $(seq 3)
+echo '{"job-id" : 10364, "rank" : 1, "kokkos-perf-data" : [ {"name" : "SPARTAFOO0", "count": 0, "time": 0.0000},{"name" : "SPARTAFOO1", "count": 1, "time": 0.0001},{"name" : "SPARTAFOO2", "count": 2, "time": 0.0002},{"name" : "SPARTAFOO3", "count": 3, "time": 0.0003},{"name" : "SPARTAFOO4", "count": 4, "time": 0.0004},{"name" : "SPARTAFOO5", "count": 5, "time": 0.0005},{"name" : "SPARTAFOO6", "count": 6, "time": 0.0006},{"name" : "SPARTAFOO7", "count": 7, "time": 0.0007},{"name" : "SPARTAFOO8", "count": 8, "time": 0.0008},{"name" : "SPARTAFOO9", "count": 9, "time": 0.0009}] }' > $TESTDIR_FAST/x.json
+echo '{"job-id" : 10364, "rank" : 1, "kokkos-perf-data" : [ {"name" : "SPARTAFOO0", "count": 0, "time": 0.0000},{"name" : "SPARTAFOO1", "count": 1, "time": 0.0001},{"name" : "SPARTAFOO2", "count": 2, "time": 0.0002},{"name" : "SPARTAFOO3", "count": 3, "time": 0.0003},{"name" : "SPARTAFOO4", "count": 4, "time": 0.0004},{"name" : "SPARTAFOO5", "count": 5, "time": 0.0005},{"name" : "SPARTAFOO6", "count": 6, "time": 0.0006},{"name" : "SPARTAFOO7", "count": 7, "time": 0.0007},{"name" : "SPARTAFOO8", "count": 8, "time": 0.0008},{"name" : "SPARTAFOO9", "count": 9, "time": 0.0009}] }' > $TESTDIR_FAST/y.json
+VGARGS="--leak-check=full --show-leak-kinds=definite --track-origins=yes --trace-children=yes"
+vgon
+LDMSD 1 # publish to with -l
+LDMSD 2 # publish to without -l
+LDMSD 3 # store
+SLEEP 2
+vgoff
+threads=$(nproc --all)
+pubs=10
+if test "$bypass" = "1"; then
+	MESSAGE skipping publications
+else
+	/bin/rm -f $LOGDIR/lsp.1.* $LOGDIR/lsp.2.*
+	for i in $(seq $threads); do
+		ldmsd_stream_publish -p $port1 -a none -s foo -t json -x sock -h localhost -l -r $pubs -f $TESTDIR_FAST/x.json >> $LOGDIR/lsp.1.$i &
+		ldmsd_stream_publish -p $port2 -a none -s bar -t json -x sock -h localhost -r $pubs -f $TESTDIR_FAST/y.json >> $LOGDIR/lsp.2.$i &
+	done
+	ps guxw |grep ldmsd_stream_publish
+	MESSAGE publish launches done
+fi
+
+SLEEP 10
+MESSAGE stopping ldmsd_stream_publish
+pkill ldmsd_stream_publish
+SLEEP 10
+KILL_LDMSD $(seq 3)
+file_created $STOREDIR/blobs/foo.*
+file_created $STOREDIR/blobs/bar.*
+file_created $STOREDIR/node/dstat

--- a/ldms/scripts/examples/stream_store_many.1
+++ b/ldms/scripts/examples/stream_store_many.1
@@ -1,0 +1,4 @@
+stream_enable
+load name=dstat
+config name=dstat producer=localhost${i} schema=dstat instance=localhost${i}/dstat component_id=${i}  mmalloc=1 io=1 fd=1 stat=1
+start name=dstat interval=1000000 offset=0

--- a/ldms/scripts/examples/stream_store_many.2
+++ b/ldms/scripts/examples/stream_store_many.2
@@ -1,0 +1,4 @@
+stream_enable
+load name=dstat
+config name=dstat producer=localhost${i} schema=dstat instance=localhost${i}/dstat component_id=${i} mmalloc=1 io=1 fd=1 stat=1
+start name=dstat interval=1000000 offset=0

--- a/ldms/scripts/examples/stream_store_many.3
+++ b/ldms/scripts/examples/stream_store_many.3
@@ -1,0 +1,24 @@
+stream_enable
+load name=blob_stream_writer plugin=blob_stream_writer
+config name=blob_stream_writer path=${STOREDIR} container=blobs stream=foo stream=bar types=1 timing=1 debug=1
+
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+prdcr_add name=localhost1 host=localhost type=active xprt=sock port=${port1} reconnect=20000000
+prdcr_subscribe stream=bar regex=localhost*
+prdcr_subscribe stream=foo regex=localhost*
+prdcr_start name=localhost1
+
+prdcr_add name=localhost2 host=localhost type=active xprt=sock port=${port2} reconnect=20000000
+prdcr_subscribe stream=bar regex=localhost*
+prdcr_subscribe stream=foo regex=localhost*
+prdcr_start name=localhost2
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=store_dstat plugin=store_csv schema=dstat container=node
+strgp_prdcr_add name=store_dstat regex=.*
+strgp_start name=store_dstat

--- a/ldms/scripts/ldms-static-test.sh.in
+++ b/ldms/scripts/ldms-static-test.sh.in
@@ -173,7 +173,7 @@ function DAEMONS {
 	fi
 	for i in $*; do
 		/bin/rm -f ${LOGDIR}/$i.txt ${LOGDIR}/vg.$i ${LOGDIR}/teardown.$i.txt ${LOGDIR}/$i.stdio
-		/bin/rm -f ${RUNDIR}/revconf.$i ${RUNDIR}/conf.$i ${RUNDIR}/yaml.$i ${RUNDIR}/yaml.$i.pre-sed ${RUNDIR}/start.$i
+		/bin/rm -f ${LDMSD_RUN}/revconf.$i ${LDMSD_RUN}/conf.$i ${LDMSD_RUN}/yaml.$i ${LDMSD_RUN}/yaml.$i.pre-sed ${LDMSD_RUN}/start.$i
 		ports[$i]=$(($portbase + $i))
 		eval export port$i=${ports[$i]}
 		binname=ldmsd.${ports[$i]}
@@ -283,6 +283,10 @@ function LDMSD {
 			;;
 		esac
 	done
+
+	if test "$use_conf$use_yaml" = "00"; then
+		use_conf=1
+	fi
 	if test "$use_conf" = "1" -a "$use_yaml" = "1"; then
 		echo "Conflicting options: cannot use both yaml and raw conf inputs"
 		bypass=1


### PR DESCRIPTION
Since the default disable of streams was added, a batch of test script updates is required to enable streams in stream tests.
There are no C changes here.
In addition, the new stream_store_many test provides a brief storm (that may be scaled) of stream publications and
a fix is added to select .conf as the assumed test input format if -y is not seen in the LDMSD macro arguments.