### PR TITLE
Fix __dlog() to pass va_list to ovis_log()

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -149,7 +149,7 @@ void __dlog(int match, const char *fmt, ...)
 		vfprintf(ldmsd_req_debug_file, fmt, ap);
 		fflush(ldmsd_req_debug_file);
 	} else {
-		ovis_log(config_log, OVIS_LALWAYS, fmt, ap);
+		ovis_vlog(config_log, OVIS_LALWAYS, fmt, ap);
 	}
 	va_end(ap);
 }


### PR DESCRIPTION
The patch changes the call from ovis_log() to ovis_vlog() to properly handle the va_list argument passed from __dlog().

Fixes #2015 