### PR TITLE
netlink.c must test for empty message before sending

### DIFF
--- a/ldms/src/sampler/netlink/netlink-notifier.c
+++ b/ldms/src/sampler/netlink/netlink-notifier.c
@@ -4331,6 +4331,9 @@ static int emit_info(forkstat_t *ft, struct proc_info *info, const char *type, i
 
 static int send_ldms_message(forkstat_t *ft, jbuf_t jb)
 {
+	if (jb->cursor < 2) {
+		return 0;
+	}
 	if (ft->json_log) {
 		fprintf(ft->json_log, "%s", jb->buf);
 	}


### PR DESCRIPTION
otherwise meaningless and wordy log message from json parser results.