### PR TITLE
fix missing null check in ovis_json:json_attr_find

### DIFF
--- a/lib/src/ovis_json/ovis_json.c
+++ b/lib/src/ovis_json/ovis_json.c
@@ -121,6 +121,8 @@ json_entity_t json_attr_next(json_entity_t a)
 
 json_entity_t json_attr_find(json_entity_t d, const char *name)
 {
+	if (!d || !name)
+		return NULL;
 	hent_t ent;
 	json_attr_t a;
 	assert (d->type == JSON_DICT_VALUE);


### PR DESCRIPTION
seg fault observed in json query when running ldms-static-test.sh linux_proc_sampler