### PR TITLE
trap cases in process_lookup_reply with null ctxt->op_ctxt 

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -1865,8 +1865,9 @@ void process_lookup_reply(struct ldms_xprt *x, struct ldms_reply *reply,
 	struct ldms_thrstat *thrstat;
 
 	thrstat = zap_thrstat_ctxt_get(x->zap_ep);
-	memcpy(&ctxt->op_ctxt->lookup_profile.complete_ts, &thrstat->last_op_start,
-					    sizeof(struct timespec));
+	if (ctxt && ctxt->op_ctxt)
+		memcpy(&ctxt->op_ctxt->lookup_profile.complete_ts, &thrstat->last_op_start,
+				    sizeof(struct timespec));
 
 	int rc = ntohl(reply->hdr.rc);
 	if (!rc) {


### PR DESCRIPTION
suppress time copy or get seg fault in memcpy (writing into null) observed in running ldms-static-test.sh linux_proc_sampler