### PR TITLE
Replace profiling TYPE attribute with explicit enable/disable commands

### DIFF
--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -2491,16 +2491,47 @@ class LdmsdCmdParser(cmd.Cmd):
     def complete_xprt_stats(self, text, line, begidx, endidx):
         return self.__complete_attr_list('xprt_stats', text)
 
+    def do_profiling_disable(self, arg):
+        """
+        Disable the profiling feature
+
+        Parameters:
+           NONE
+        """
+        rc, msg = self.comm.profiling_disable()
+        if rc != 0:
+            print(f'Error {rc}: {msg}')
+        else:
+            print('LDMS Profiling is DISABLED in the daemon')
+        return
+
+    def complete_profiling_disable(self, text, line, begidx, endidx):
+        return self.__complete_attr_list('profiling_disable', text)
+
+    def do_profiling_enable(self, arg):
+        """
+        Enable the profiling feature
+
+        Parameters:
+           NONE
+        """
+        rc, msg = self.comm.profiling_enable()
+        if rc != 0:
+            print(f'Error {rc}: {msg}')
+        else:
+            print('LDMS Profiling is ENABLED in the daemon')
+        return
+
+    def complete_profiling_enable(self, text, line, begidx, endidx):
+        return self.__complete_attr_list('profiling_enable', text)
+
     def do_profiling(self, arg):
         """
-        Enable/disable and query the LDMS operation profiling data
-
         The command was intended for diagnostic or study to improve ldmsd performance.
 
         The command always reports the cached profiling data if exists.
 
         Parameters:
-          [enabled=]   True to enable LDMS profiling
           [reset=]     True to reset and free cached profiling data after the report
         """
         arg = self.handle_args('profiling', arg)

--- a/ldms/src/ldmsd/ldmsd_request.h
+++ b/ldms/src/ldmsd/ldmsd_request.h
@@ -166,6 +166,8 @@ enum ldmsd_request {
 	LDMSD_PID_FILE_REQ,
 	LDMSD_BANNER_MODE_REQ,
 	LDMSD_PROFILING_REQ,
+	LDMSD_PROFILING_DISABLE_REQ,
+	LDMSD_PROFILING_ENABLE_REQ,
 
 	/* failover requests by user */
 	LDMSD_FAILOVER_CONFIG_REQ = 0x700, /* "failover_config" user command */

--- a/ldms/src/ldmsd/ldmsd_request_util.c
+++ b/ldms/src/ldmsd/ldmsd_request_util.c
@@ -128,6 +128,8 @@ struct req_str_id req_str_id_table[] = {
 	{  "prdcr_subscribe",    LDMSD_PRDCR_SUBSCRIBE_REQ },
 	{  "prdcr_unsubscribe",  LDMSD_PRDCR_UNSUBSCRIBE_REQ },
 	{  "profiling",          LDMSD_PROFILING_REQ },
+	{  "profiling_disable",  LDMSD_PROFILING_DISABLE_REQ },
+	{  "profiling_enable",   LDMSD_PROFILING_ENABLE_REQ },
 	{  "publish_kernel",     LDMSD_PUBLISH_KERNEL_REQ  },
 	{  "qgroup_config",      LDMSD_QGROUP_CONFIG_REQ },
 	{  "qgroup_info",        LDMSD_QGROUP_INFO_REQ },
@@ -341,6 +343,8 @@ const char *ldmsd_req_id2str(enum ldmsd_request req_id)
 	case LDMSD_SET_SEC_MOD_REQ       : return "SET_SEC_REQ";
 	case LDMSD_LOG_STATUS_REQ        : return "LOG_STATUS_REQ";
 	case LDMSD_PROFILING_REQ         : return "PROFILING_REQ";
+	case LDMSD_PROFILING_DISABLE_REQ : return "PROFILING_DISABLE_REQ";
+	case LDMSD_PROFILING_ENABLE_REQ : return "PROFILING_ENABLE_REQ";
 
 	/* failover requests by user */
 	case LDMSD_FAILOVER_CONFIG_REQ        : return "FAILOVER_CONFIG_REQ";


### PR DESCRIPTION
Previously, the profiling command used the TYPE attribute to represent the enable/disable parameter, which was semantically confusing and could lead to misunderstandings about the attribute's purpose.

This patch introduces a dedicated LDMSD_ATTR_ENABLE attribute and updates the profiling command to use it, making the command handling code clearer and more intuitive.