### PR TITLE
add drd suppressions for set update and format 3 testing

### DIFF
--- a/ldms/scripts/examples/drd.set_update.supp
+++ b/ldms/scripts/examples/drd.set_update.supp
@@ -1,0 +1,38 @@
+# common suppressions for valgrind drd in ldms 4.5.1 metric set update
+# set transport in ldms assumes 1 write/many readers and that the
+# inconsistent flag is enough to handle read during write.
+{
+   ldms_metric_set_u64
+   drd:ConflictingAccess
+   fun:ldms_metric_set_u64
+   ...
+}
+{
+   __ldms_gn_inc
+   drd:ConflictingAccess
+   fun:__ldms_gn_inc
+   ...
+}
+{
+   ldms_metric_set_s64
+   drd:ConflictingAccess
+   fun:ldms_metric_set_s64
+   ...
+}
+{
+   ldms_metric_set_u32
+   drd:ConflictingAccess
+   fun:ldms_metric_set_u32
+   ...
+}
+{
+   ldms_transaction_end
+   drd:ConflictingAccess
+   fun:ldms_transaction_end
+}
+{
+   ldms_transaction_begin
+   drd:ConflictingAccess
+   fun:ldms_transaction_begin
+   ...
+}

--- a/ldms/scripts/examples/linux_proc_sampler
+++ b/ldms/scripts/examples/linux_proc_sampler
@@ -80,7 +80,7 @@ drd="valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.drd.txt --trace-cond=y
 memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --keep-debuginfo=yes --malloc-fill=3b"
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked --purge-track-dir &
 
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 2 &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 3 &
 
 # uncomment next one to test duplicate handling
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &

--- a/ldms/scripts/examples/linux_proc_sampler_drd
+++ b/ldms/scripts/examples/linux_proc_sampler_drd
@@ -80,15 +80,17 @@ drd="valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.drd.txt --trace-cond=y
 memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --keep-debuginfo=yes --malloc-fill=3b"
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked --purge-track-dir &
 
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 2 &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 3 &
 
+drd_supp=$(dirname $input)/drd.set_update.supp
 # uncomment next one to test duplicate handling
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
 VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=definite --time-stamp=yes --keep-debuginfo=yes --malloc-fill=3b"
-VGARGS="--tool=drd --trace-cond=yes --trace-fork-join=yes"
-vgon
+VGARGS="--tool=drd --trace-cond=yes --trace-fork-join=yes --gen-suppressions=all --time-stamp=yes --suppressions=$drd_supp"
+#vgon
 LDMSD 1
-vgon
+vgoff
+#vgon
 LDMSD 2
 vgoff
 #vgon
@@ -107,6 +109,7 @@ for lc in $(seq 1); do
 	SLEEP 2
 done
 SLEEP 5
+#KILL_NO_TEARDOWN=1
 KILL_LDMSD 3 2 1
 file_created $STOREDIR/node/$plugname
 file_created $STOREDIR/node/$dsname

--- a/ldms/scripts/examples/linux_proc_sampler_memcheck
+++ b/ldms/scripts/examples/linux_proc_sampler_memcheck
@@ -80,7 +80,7 @@ drd="valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.drd.txt --trace-cond=y
 memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --keep-debuginfo=yes --malloc-fill=3b"
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked --purge-track-dir &
 
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 2 &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 3 &
 
 # uncomment next one to test duplicate handling
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &

--- a/ldms/scripts/examples/linux_proc_sampler_no_teardown
+++ b/ldms/scripts/examples/linux_proc_sampler_no_teardown
@@ -6,7 +6,7 @@ export dstat_schema=$dsname
 export LDMSD_LOG_TIME_SEC=1
 export LDMSD_EXTRA="-m 128m"
 
-SET_LOG_LEVEL ERROR
+SET_LOG_LEVEL INFO
 
 portbase=61060
 DAEMONS 3
@@ -80,24 +80,28 @@ drd="valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.drd.txt --trace-cond=y
 memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --keep-debuginfo=yes --malloc-fill=3b"
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked --purge-track-dir &
 
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 2 &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 3 &
 
+drd_supp=$(dirname $input)/drd.set_update.supp
 # uncomment next one to test duplicate handling
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
-VGARGS="--tool=drd --trace-cond=yes --trace-fork-join=yes"
 VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=definite --time-stamp=yes --keep-debuginfo=yes --malloc-fill=3b"
+VGARGS="--tool=drd --trace-cond=yes --trace-fork-join=yes --gen-suppressions=all --time-stamp=yes --suppressions=$drd_supp"
 #vgon
 LDMSD 1
 vgoff
+#vgon
 LDMSD 2
+vgoff
+#vgon
 LDMSD 3
 vgoff
 SLEEP 2
-MESSAGE ldms_ls on host 1:
+#MESSAGE ldms_ls on host 1:
 #LDMS_LS 1 -v
-MESSAGE ldms_ls on host 2:
+#MESSAGE ldms_ls on host 2:
 SLEEP 1
-LDMS_LS 2 -v
+#LDMS_LS 2 -v
 SLEEP 5
 #MESSAGE stream_client_dump on sampler daemon 1
 #for lc in $(seq 1); do


### PR DESCRIPTION
this updates the ldms-static-test.sh linux_proc_sampler_* tests to check for thread races more sensibly.

At present, linux_proc_sampler_drd  crashes (with or without drd enabled by updating the vgon flags in the script) while running its generated shutdown script on the L1 (daemon 2).  see related issue
