### PR TITLE
fix bad_messages_check misconfig and add msg_client_stats calls to test

### DIFF
--- a/ldms/scripts/examples/bad_messages_check
+++ b/ldms/scripts/examples/bad_messages_check
@@ -102,13 +102,21 @@ LDMSD 3
 vgoff
 SLEEP 5
 # start publisher loops before ldmsd 1
-# all input objects are missing their final }.
+# All input objects are missing their final } except the slurm input.
 # For plugins that want json, no data should get stored.
 # No data should get leaked due to parse failures.
-REPLAY_PIDS=$(REPLAY_JSON 1 5 bad.linux_proc_sampler_argv-1.json  bad.linux_proc_sampler_env-1.json  bad.linux_proc_sampler_files-1.json  bad.slurm-1.json)
+REPLAY_PIDS=$(REPLAY_JSON 1 1 bad.linux_proc_sampler_argv-1.json  bad.linux_proc_sampler_env-1.json  bad.linux_proc_sampler_files-1.json slurm-1.json)
 echo $REPLAY_PIDS
 
 SLEEP 10
+
+MESSAGE msg_client_stats L0
+echo msg_client_stats | ldmsd_controller -h localhost -p $port1 -a none -x sock
+MESSAGE msg_client_stats L1
+echo msg_client_stats | ldmsd_controller -h localhost -p $port2 -a none -x sock
+MESSAGE msg_client_stats L2
+echo msg_client_stats | ldmsd_controller -h localhost -p $port3 -a none -x sock
+
 # all the replayers should be done
 CHECK_PIDS "message publisher" "unexpectedly still here" "gone as expected" $REPLAY_PIDS
 KILL_LDMSD 1 2 3

--- a/ldms/scripts/examples/bad_messages_check.2
+++ b/ldms/scripts/examples/bad_messages_check.2
@@ -6,9 +6,9 @@ start name=dstat interval=1000000 offset=0
 
 prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} reconnect=2000000
 prdcr_subscribe regex=.* message_channel=slurm
-prdcr_subscribe regex=.* message_channel=linux_proc_sampler_argv
-prdcr_subscribe regex=.* message_channel=linux_proc_sampler_env
-prdcr_subscribe regex=.* message_channel=linux_proc_sampler_files
+prdcr_subscribe regex=.* message_channel=bad.linux_proc_sampler_argv
+prdcr_subscribe regex=.* message_channel=bad.linux_proc_sampler_env
+prdcr_subscribe regex=.* message_channel=bad.linux_proc_sampler_files
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000 auto_interval=true

--- a/ldms/scripts/examples/bad_messages_check.3
+++ b/ldms/scripts/examples/bad_messages_check.3
@@ -6,14 +6,14 @@ start name=dstat interval=1000000 offset=0
 
 # blobs must be allowed by writer plugin and prdcr_subscribe by daemon
 load name=blob_msg_writer plugin=blob_msg_writer
-config name=blob_msg_writer path=${STOREDIR} container=blobs message_channel=slurm message_channel=linux_proc_sampler_env message_channel=linux_proc_sampler_argv types=1 message_channel=linux_proc_sampler_files
+config name=blob_msg_writer path=${STOREDIR} container=blobs message_channel=slurm message_channel=bad.linux_proc_sampler_env message_channel=bad.linux_proc_sampler_argv types=1 message_channel=bad.linux_proc_sampler_files
 start name=blob_msg_writer interval=10000000000
 
 prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} reconnect=2000000
 prdcr_subscribe regex=.* message_channel=slurm
-prdcr_subscribe regex=.* message_channel=linux_proc_sampler_argv
-prdcr_subscribe regex=.* message_channel=linux_proc_sampler_env
-prdcr_subscribe regex=.* message_channel=linux_proc_sampler_files
+prdcr_subscribe regex=.* message_channel=bad.linux_proc_sampler_argv
+prdcr_subscribe regex=.* message_channel=bad.linux_proc_sampler_env
+prdcr_subscribe regex=.* message_channel=bad.linux_proc_sampler_files
 prdcr_start name=localhost2
 
 updtr_add name=allhosts interval=1000000 offset=200000 auto_interval=true

--- a/ldms/scripts/examples/msg_load_check
+++ b/ldms/scripts/examples/msg_load_check
@@ -126,6 +126,10 @@ KILL_LDMSD 1 2 3
 # give the file system time to catch up, if it's slow.
 SLEEP 20
 
+#MESSAGE "L0 __msg_deliver-ies $(grep __msg_deliver $LOGDIR/1.txt | wc -l)"
+#MESSAGE "L1 __msg_deliver-ies $(grep __msg_deliver $LOGDIR/2.txt | wc -l)"
+#MESSAGE "L2 __msg_deliver-ies $(grep __msg_deliver $LOGDIR/3.txt | wc -l)"
+
 file_created $STOREDIR/node/$dsname
 rollover_created $STOREDIR/blobs/slurm.DAT
 rollover_created $STOREDIR/blobs/linux_proc_sampler_argv.DAT


### PR DESCRIPTION
This makes the expected count of messages appear when bad messages are sent.
(L1/L2 message subscriptions were misconfigured)