### PR TITLE
Include JSON parser errors in client drops

### DIFF
--- a/ldms/src/core/ldms_msg.c
+++ b/ldms/src/core/ldms_msg.c
@@ -707,6 +707,8 @@ __msg_deliver(struct __msg_buf_s *sbuf, uint64_t msg_gn,
 			_ev.pub.recv.json = json;
 			json_parser_free(jp);
 			if (rc) {
+				__counters_update(&sce->drops, &now, data_len);
+				__counters_update(&c->drops, &now, data_len);
 				goto cleanup;
 			}
 		}
@@ -717,7 +719,7 @@ __msg_deliver(struct __msg_buf_s *sbuf, uint64_t msg_gn,
 		if (__msg_stats_level > 0) {
 			pthread_rwlock_wrlock(&c->rwlock);
 			if (rc) {
-				__counters_update( &sce->drops, &now, data_len);
+				__counters_update(&sce->drops, &now, data_len);
 				__counters_update(&c->drops, &now, data_len);
 			} else {
 				__counters_update(&sce->tx, &now, data_len);


### PR DESCRIPTION
The client drop now count includes messages dropped because the callback returned a value other than zero and messages sent as JSON that do not parse correctly.

An example of the msg_stats command output follows:

```
sock:localhost:10002> msg_stats
name                           bytes        count        first                      last                      
------------------------------ ------------ ------------ -------------------------- --------------------------
linux_proc_sampler_argv            10661000          100 10-29-25 23:33:29 [219637] 10-29-25 23:33:29 [237672]
 - clients:
   - [.*] stream_dump, path:msg_data:
     - tx                                 0            0 -EMPTY-                    -EMPTY-                   
     - drops                       10661000          100 10-29-25 23:33:29 [219637] 10-29-25 23:33:29 [237672]
```
