### PR TITLE
Return a xprt status error from Xprt.msg_subscribe

### DIFF
--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -4070,6 +4070,9 @@ cdef class Xprt(object):
         ctxt.cb = cb
         ctxt.cb_arg = cb_arg
 
+        if self._conn_rc != 0:
+            raise Exception("The ransport is not connected.")
+
         tmp = BYTES(match)
         c_match = <const char*>tmp
         c_is_regex = <int>is_regex
@@ -4550,8 +4553,8 @@ cdef class MsgClient(object):
                       0 otherwise, and the `match` is treated as an exact match
                       to the channel name
     - cb (callable): an optional callback function to deliver the data
-                        with the following signature
-                          `def cb(MsgClient client, MsgData data, object cb_arg)`
+                     with the following signature
+                     `def cb(MsgClient client, MsgData data, object cb_arg)`
     - cb_arg (object):  an optional application callback argument.
     - desc (str): a short description of the client.
     - sr_client (SchemaRegistryClient): a Confluent Kafka Client object,


### PR DESCRIPTION
Return an error if attempting to subscribe using the Python API on a transport that is not connected. The error otherwise is that msg is not enabled because the peer cannot be contacted to determine if message publication is enabled.
