### PR TITLE
Fix function declaration/call found by gnu23 standard

### DIFF
--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -2355,9 +2355,11 @@ char *ldms_thrstat_op_str(enum ldms_thrstat_op_e e);
  * Return an ldms_thrstat_result structure or NULL on memory allocation failure.
  * This result must be freed with the ldms_thrstat_free_result() function.
  *
+ * \param interval_s Time interval in seconds to analyze (0 = use default 3s)
+ *
  * \return A pointer to an ldms_thrstat_result structure
  */
-struct ldms_thrstat_result *ldms_thrstat_result_get();
+struct ldms_thrstat_result *ldms_thrstat_result_get(uint64_t interval_s);
 
 /**
  * \brief Free an ldms_thrstat_result returned by \c ldms_thrstat_result_get

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -7813,7 +7813,7 @@ static char * __thread_stats_as_json(size_t *json_sz)
 		goto __APPEND_ERR;
 	}
 
-	lres = ldms_thrstat_result_get();
+	lres = ldms_thrstat_result_get(interval_s);
 	if (!lres)
 		goto __APPEND_ERR;
 

--- a/ldms/src/sampler/netlink/netlink-notifier.c
+++ b/ldms/src/sampler/netlink/netlink-notifier.c
@@ -4668,7 +4668,7 @@ int main(int argc, char * argv[])
 	forkstat_t *ft = NULL;
 	struct dump_args thread_args;
 	memset(&thread_args, 0, sizeof(thread_args));
-	ft = forkstat_create(printf, printf);
+	ft = forkstat_create();
 	if (!ft) {
 		fprintf(stderr, "%s: out of memory.\n", argv[0]);
 		return ENOMEM;


### PR DESCRIPTION
Prior GCC gnu standards (and C standard, e.g. gnu17) treat `int fn();` prototype as _any_ number of arguments. On openSUSE 16.0, GCC uses gnu23 standard as a default, which interpret `int fn();` as having _exactly_ zero arguments. This patch addressed declarations & calls found by the new gnu23 standard.