### PR TITLE
Fix CLIENT_CLOSE race in ldms_msg

### DIFF
--- a/ldms/python/ldms.pxd
+++ b/ldms/python/ldms.pxd
@@ -852,6 +852,7 @@ cdef extern from "ldms.h" nogil:
         LDMS_MSG_EVENT_RECV
         LDMS_MSG_EVENT_SUBSCRIBE_STATUS
         LDMS_MSG_EVENT_UNSUBSCRIBE_STATUS
+        LDMS_MSG_EVENT_CLIENT_CLOSE
     struct ldms_addr:
         uint8_t  addr[4];
         uint16_t sin_port;

--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -4390,6 +4390,10 @@ cdef int __msg_client_cb(ldms_msg_event_t ev, void *arg) with gil:
     cdef MsgClient c = <MsgClient>arg
     cdef MsgData sdata
 
+    if ev.type == LDMS_MSG_EVENT_CLIENT_CLOSE:
+        Py_DECREF(c)
+        return 0
+
     if ev.type != LDMS_MSG_EVENT_RECV:
         return 0
 
@@ -4580,6 +4584,7 @@ cdef class MsgClient(object):
                                        CSTR(BYTES(desc)))
         if not self.c:
             raise RuntimeError(f"ldms_msg_subscribe() error, errno: {errno}")
+        Py_INCREF(self)
 
     def close(self):
         if not self.c:


### PR DESCRIPTION
`CLIENT_CLOSE` event was incorrectly posted right away on `ldms_msg_client_close()` call, which raced with the on-going message delivery callbacks and broke the guarantee `CLIENT_CLOSE` being the last event. This patch fix this issue by dropping `ref` instead of posting `CLIENT_CLOSE` right away in `ldms_msg_client_close()`. When `ref` reached 0, we are sure that no one really is using the msg client (not even in the channel-client list for msg delivery), and then we can safely post the `CLIENT_CLOSE`. The client resources can then be freed after `CLIENT_CLOSE` callback returns.