### PR TITLE
Fix nested structure definitions in anonymous union

### DIFF
--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -692,8 +692,8 @@ int ldms_xprt_set_quota(ldms_t x, int64_t recv_quota, int64_t rate_limit);
  * \param ctxt   Application's context
  * \param fn     Application's function to free the context
  */
-typedef void (*app_ctxt_free_fn)(void *ctxt);
-void ldms_xprt_ctxt_set(ldms_t x, void *ctxt, app_ctxt_free_fn fn);
+typedef void (*ldms_app_ctxt_free_fn)(void *ctxt);
+void ldms_xprt_ctxt_set(ldms_t x, void *ctxt, ldms_app_ctxt_free_fn fn);
 
 /**
  * \brief Get application's context
@@ -2187,42 +2187,52 @@ typedef enum ldms_xprt_ops_e {
 	LDMS_XPRT_OP_COUNT
 } ldms_xprt_ops_t;
 
+struct ldms_lookup_profile_s {
+	struct timespec app_req_ts;
+	struct timespec req_send_ts;
+	struct timespec req_recv_ts;
+	struct timespec share_ts;
+	struct timespec rendzv_ts;
+	struct timespec read_ts;
+	struct timespec complete_ts;
+	struct timespec deliver_ts;
+};
+
+struct ldms_update_profile_s {
+	struct timespec app_req_ts;
+	struct timespec read_ts;
+	struct timespec read_complete_ts;
+	struct timespec deliver_ts;
+};
+
+struct ldms_set_delete_profile_s {
+	struct timespec send_ts;
+	struct timespec recv_ts;
+	struct timespec ack_ts;
+};
+
+struct ldms_send_profile_s {
+	struct timespec app_req_ts;
+	struct timespec send_ts;
+	struct timespec complete_ts;
+	struct timespec deliver_ts;
+};
+
+struct ldms_strm_publish_profile_s {
+	uint32_t hop_num;
+	struct timespec recv_ts;
+	struct timespec send_ts; /*  to remote client */
+};
+
 struct  ldms_op_ctxt {
 	struct ref_s ref;
 	enum ldms_xprt_ops_e op_type;
 	union {
-		struct lookup_profile_s {
-			struct timespec app_req_ts;
-			struct timespec req_send_ts;
-			struct timespec req_recv_ts;
-			struct timespec share_ts;
-			struct timespec rendzv_ts;
-			struct timespec read_ts;
-			struct timespec complete_ts;
-			struct timespec deliver_ts;
-		} lookup_profile;
-		struct update_profile {
-			struct timespec app_req_ts;
-			struct timespec read_ts;
-			struct timespec read_complete_ts;
-			struct timespec deliver_ts;
-		} update_profile;
-		struct set_delete_profile_s {
-			struct timespec send_ts;
-			struct timespec recv_ts;
-			struct timespec ack_ts;
-		} set_del_profile;
-		struct send_profile_s {
-			struct timespec app_req_ts;
-			struct timespec send_ts;
-			struct timespec complete_ts;
-			struct timespec deliver_ts;
-		} send_profile;
-		struct strm_publish_profile_s {
-			uint32_t hop_num;
-			struct timespec recv_ts;
-			struct timespec send_ts; /*  to remote client */
-		} msg_pub_profile;
+		struct ldms_lookup_profile_s lookup_profile;
+		struct ldms_update_profile_s update_profile;
+		struct ldms_set_delete_profile_s set_del_profile;
+		struct ldms_send_profile_s send_profile;
+		struct ldms_strm_publish_profile_s msg_pub_profile;
 	};
 	TAILQ_ENTRY(ldms_op_ctxt) ent;
 };

--- a/ldms/src/core/ldms_msg.c
+++ b/ldms/src/core/ldms_msg.c
@@ -240,7 +240,7 @@ int __rep_publish(struct ldms_rail_ep_s *rep, const char *name,
 			uint32_t hop_cnt,
 			struct ldms_msg_hop * hops,
 			const char *data, size_t data_len,
-			struct strm_publish_profile_s *pts)
+			struct ldms_strm_publish_profile_s *pts)
 {
 	int rc = 0;
 	int name_len = strlen(name) + 1;

--- a/ldms/src/core/ldms_msg.h
+++ b/ldms/src/core/ldms_msg.h
@@ -181,5 +181,5 @@ int __rep_publish(struct ldms_rail_ep_s *rep, const char *name,
 			uint32_t hop_cnt,
 			struct ldms_msg_hop *hops,
 			const char *data, size_t data_len,
-			struct strm_publish_profile_s *pts);
+			struct ldms_strm_publish_profile_s *pts);
 #endif /* __LDMS_MSG_H__ */

--- a/ldms/src/core/ldms_rail.c
+++ b/ldms/src/core/ldms_rail.c
@@ -104,7 +104,7 @@ static int __rail_stats(ldms_t _r, ldms_xprt_stats_t stats, int mask, int is_res
 #define __rail_put(_r_, _n_) ___rail_put((_r_), (_n_), __func__, __LINE__)
 static ldms_t ___rail_get(ldms_t _r, const char *name, const char *func, int line); /* ref get */
 static void ___rail_put(ldms_t _r, const char *name, const char *func, int line); /* ref put */
-static void __rail_ctxt_set(ldms_t _r, void *ctxt, app_ctxt_free_fn fn);
+static void __rail_ctxt_set(ldms_t _r, void *ctxt, ldms_app_ctxt_free_fn fn);
 static void *__rail_ctxt_get(ldms_t _r);
 static uint64_t __rail_conn_id(ldms_t _r);
 static const char *__rail_type_name(ldms_t _r);
@@ -1403,7 +1403,7 @@ static void ___rail_put(ldms_t _r, const char *name, const char *func, int line)
 	_ref_put(&r->ref, name, func, line);
 }
 
-static void __rail_ctxt_set(ldms_t _r, void *ctxt, app_ctxt_free_fn fn)
+static void __rail_ctxt_set(ldms_t _r, void *ctxt, ldms_app_ctxt_free_fn fn)
 {
 	assert(XTYPE_IS_RAIL(_r->xtype));
 	ldms_rail_t r = (ldms_rail_t)_r;

--- a/ldms/src/core/ldms_rail.h
+++ b/ldms/src/core/ldms_rail.h
@@ -182,7 +182,7 @@ struct ldms_rail_s {
 	void *event_cb_arg;
 
 	void *app_ctxt;
-	app_ctxt_free_fn app_ctxt_free;
+	ldms_app_ctxt_free_fn app_ctxt_free;
 
 	pthread_mutex_t mutex; /* mainly for state */
 

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -186,13 +186,13 @@ ldms_t ldms_xprt_next(ldms_t x)
 	return x;
 }
 
-static void __ldms_xprt_ctxt_set(ldms_t x, void *ctxt, app_ctxt_free_fn fn)
+static void __ldms_xprt_ctxt_set(ldms_t x, void *ctxt, ldms_app_ctxt_free_fn fn)
 {
 	x->app_ctxt = ctxt;
 	x->app_ctxt_free_fn = fn;
 }
 
-void ldms_xprt_ctxt_set(ldms_t x, void *ctxt, app_ctxt_free_fn fn)
+void ldms_xprt_ctxt_set(ldms_t x, void *ctxt, ldms_app_ctxt_free_fn fn)
 {
 	x->ops.ctxt_set(x, ctxt, fn);
 }
@@ -3524,7 +3524,7 @@ static int __ldms_xprt_dir_cancel(ldms_t x);
 
 static ldms_t __ldms_xprt_get(ldms_t x, const char *name, const char *func, int line); /* ref get */
 static void __ldms_xprt_put(ldms_t x, const char *name, const char *func, int line); /* ref put */
-static void __ldms_xprt_ctxt_set(ldms_t x, void *ctxt, app_ctxt_free_fn fn);
+static void __ldms_xprt_ctxt_set(ldms_t x, void *ctxt, ldms_app_ctxt_free_fn fn);
 static void *__ldms_xprt_ctxt_get(ldms_t x);
 static uint64_t __ldms_xprt_conn_id(ldms_t x);
 static const char *__ldms_xprt_type_name(ldms_t x);

--- a/ldms/src/core/ldms_xprt.h
+++ b/ldms/src/core/ldms_xprt.h
@@ -470,7 +470,7 @@ struct ldms_xprt_ops_s {
 
 	ldms_t (*get)(ldms_t x, const char *name, const char *func, int line); /* ref get */
 	void (*put)(ldms_t x, const char *name, const char *func, int line); /* ref put */
-	void (*ctxt_set)(ldms_t x, void *ctxt, app_ctxt_free_fn fn);
+	void (*ctxt_set)(ldms_t x, void *ctxt, ldms_app_ctxt_free_fn fn);
 	void *(*ctxt_get)(ldms_t x);
 	uint64_t (*conn_id)(ldms_t x);
 	const char *(*type_name)(ldms_t x);
@@ -561,7 +561,7 @@ struct ldms_xprt {
 
 	/** Application's context */
 	void *app_ctxt;
-	app_ctxt_free_fn app_ctxt_free_fn;
+	ldms_app_ctxt_free_fn app_ctxt_free_fn;
 
 	LIST_ENTRY(ldms_xprt) xprt_link;
 };


### PR DESCRIPTION
C++ does not allow non-static members in anonymous unions. This change moves the structure definitions outside of the union.