### PR TITLE
 Fix decomposition group timeout value parsing

### DIFF
--- a/ldms/src/decomp/ldmsd_decomposition.rst
+++ b/ldms/src/decomp/ldmsd_decomposition.rst
@@ -205,9 +205,13 @@ as follows.
       discarded.
 
    **"timeout"** : "*TIME*"
-      The amount of time (e.g. "30m") of group inactivity (no row added
+      The amount of time (e.g. "30s") of group inactivity (no row added
       to the group) to trigger row cache cleanup for the group. If this
       value is not set, the row cache won't be cleaned up.
+
+      The units of the time value may only be "s" (seconds),
+      "ms" (milliseconds), "us" (microseconds), or "ns" (nanoseconds).
+      A unitless number is assumed to be "us".
 
 **Static Decomposition Example 1: simple meminfo with fill**
    The following is an example of a static decomposition definition

--- a/ldms/src/decomp/static/decomp_static.c
+++ b/ldms/src/decomp/static/decomp_static.c
@@ -588,8 +588,10 @@ static int handle_group(
 		}
 	}
 
+	timeout = NULL;
 	jtimeout = json_object_get(jgroup, "timeout");
 	if (jtimeout) {
+		const char *timeout_string;
 		if (json_typeof(jtimeout) != JSON_STRING) {
 			THISLOG(reqc, EINVAL, "strgp '%s': row '%d': "
 				"group['timeout'] must be a STRING describing "
@@ -599,10 +601,15 @@ static int handle_group(
 			goto err_0;
 
 		}
-		ldmsd_timespec_from_str(&_timeout, json_string_value(jtimeout));
+		timeout_string = json_string_value(jtimeout);
+		rc = ldmsd_timespec_from_str(&_timeout, timeout_string);
+		if (rc != 0) {
+			THISLOG(reqc, EINVAL, "strgp '%s': row '%d': "
+				"group['timeout'] value \"%s\" has invalid format.\n",
+				strgp->obj.name, row_no, timeout_string);
+			goto err_0;
+		}
 		timeout = &_timeout;
-	} else {
-		timeout = NULL;
 	}
 
 	strgp->row_cache = ldmsd_row_cache_create(strgp, cfg_row->row_limit, timeout);


### PR DESCRIPTION
Check the return code when parsing the value of decomposition's group timeout field.

Update the documentation to list which units are supported in the timeout value.

Fixes #2108