### PR TITLE
update ldmsd_yaml_parser to use logging and support short options

### DIFF
--- a/ldms/man/ldmsd_yaml_parser.rst
+++ b/ldms/man/ldmsd_yaml_parser.rst
@@ -8,7 +8,7 @@ ldmsd_yaml_parser
 A python program to parse a YAML configuration file into a v4 LDMS configuration.
 ---------------------------------------------------------------------------------
 
-:Date: 20 Nov 2024 "ovis-4.4.5"
+:Date: 20 Nov 2024 "ovis-4.5.2"
 :Manual section: 8
 :Manual group: LDMSD
 
@@ -23,27 +23,33 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-A single ldmsd can be configured using a YAML configuration file. This
-can be done by running ldmsd directly, or generating a configuration
-parser with the ldmsd_yaml_parser
+A single ldmsd daemon configuration script or a fleet of them can be generated from
+an ldms YAML configuration file. When ldmsd is configured with a -y option, the
+ldmsd daemon uses ldmsd_yaml_parser to translate the yaml input.
 
 LDMSD YAML OPTIONS
 ==================
 
-**-y,**\ *CONFIG_PATH*
-   The path to the YAML configuration file.
+Option -y is required and options -n and -p are mutually exclusive.
 
-**-n,**\ *NAME*
-   The name of the LDMS daemon.
+**-y,--ldms_config**\ *INPUT_CONFIG_PATH*
+   The path to the LDMSD YAML configuration file. This is required.
 
-LDMSD_YAML_PARSER COMMAND SYNTAX
-================================
+**-p,--output_path,--generate_config_path**\ *DIR_PATH*
+   The name of an existing directory to dump fleet of files.
 
-**--ldms-config,**\ *CONFIG_PATH*
-   The path to the YAML configuration file.
+**-n,--daemon_name**\ *DAEMON_NAME*
+   The name of the single LDMS daemon to generate.
 
-**--daemon-name,**\ *NAME*
-   The name of the LDMS daemon to configure.
+**-l,--log_level**\ *LEVEL*
+   Set the log level (debug,info,warning,error,critical).
+   The debug level will dump anchor-expanded yaml and data derived from the yaml for review.
+
+**-L,--log_file**
+   Set the log output file to use instead of stderr.
+
+**-h,--help**
+   Print help to stdout.
 
 YAML CONFIGURATION SYNTAX
 =========================

--- a/ldms/python/ldmsd/ldmsd_yaml_parser
+++ b/ldms/python/ldmsd/ldmsd_yaml_parser
@@ -3,57 +3,62 @@ import os, sys
 import yaml
 import errno
 import argparse
+import logging
 from ldmsd.parser_util import *
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='LDMS Monitoring YAML Cluster Configuration Parser')
     required = parser.add_argument_group('required arguments')
-    required.add_argument('--ldms_config', metavar='FILE', required=True,
+    required.add_argument('-y','--ldms_config', metavar='LDMSD_YAML_FILE', required=True,
                         help='Path to LDMSD YAML configuration file. ')
-    parser.add_argument('--generate_config_path', metavar="STRING", required=False,
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-p','--output_path', "--generate_config_path", metavar="OUTPUT_DIR_NAME", required=False,
                         help='Path to directory to store generated v4 configuration files for an entire LDMS cluster. '
-                             'Samplers with similar configurations share a single configuration file. ',
+                             'Samplers with identical configurations share a single configuration file. ',
                         default=False)
-    parser.add_argument('--daemon_name', metavar='STRING', required=False,
+    group.add_argument('-n','--daemon_name', metavar='DAEMON_NAME', required=False,
                         default=False,
                         help='Daemon name to generate configuration from YAML file')
-    parser.add_argument('--debug', action='store_true',
-                        help='Enable debug information')
+    parser.add_argument('-L','--log_file', metavar='LOG_FILE_NAME', default=None,
+                        help='log file (default is stderr)')
+    parser.add_argument('-l','--log_level', metavar="LOG_LEVEL", default="ERROR",
+                        help='set logging level to one of DEBUG,INFO,WARNING,ERROR,CRITICAL')
     args = parser.parse_args()
-    if not args.debug:
-        import sys
-        sys.tracebacklimit=0
+    level = args.log_level.upper()
+    if not isinstance(logging.getLevelName(level), int):
+        logging.critical(f"Requested log level is undefined: {level}")
+        sys.exit(errno.EINVAL)
+    if not args.log_file is None:
+        logging.basicConfig(filename=args.log_file, level=level)
+    else:
+        logging.basicConfig(level=level)
+
     config_fp = open(args.ldms_config)
     conf_spec = yaml.safe_load(config_fp)
 
     if not isinstance(conf_spec, (list, dict)):
-        print(f"Error: input {args.ldms_config} is not yaml. Contents:", file=sys.stderr)
-        print(conf_spec, file=sys.stderr)
+        logging.error(f"Input {args.ldms_config} is not yaml. Contents:")
+        logging.error(conf_spec)
         sys.exit(errno.EINVAL)
 
     cluster = YamlCfg(None, None, conf_spec, args)
 
-    if args.daemon_name and args.generate_config_path:
-        print(f'Parameters "daemon_name" and "generate_config_path" are mutually exclusive.\n'
-              f'Specifying the "daemon_name" parameter will generate the configuration for a single ldmsd\n'
-              f'Specifying the "generate_config_path" parameter will generate an entire cluster\'s\n'
-              f'v4 configuration files in the path provided.\n', file=sys.stderr)
-        sys.exit(errno.EINVAL)
-
     if args.daemon_name:
         ldmsd_cfg_str = cluster.daemon_config(args.ldms_config, args.daemon_name)
+        print(f"# {__file__} generated {args.daemon_name} from {args.ldms_config} to stdout")
         print(f'{ldmsd_cfg_str}')
         sys.exit(0)
 
-    if args.generate_config_path:
-        rc = cluster.config_v4(args.generate_config_path)
+    if args.output_path:
+        logging.debug(f"{__file__} wrote group configs from {args.ldms_config} to {args.output_path}")
+        rc = cluster.config_v4(args.output_path)
         if rc:
             sys.exit(rc)
-        print('LDMSD v4 config files generated', file=sys.stderr)
+        logging.info('LDMSD config files generated')
         sys.exit(0)
 
-    if not args.generate_config_path and not args.ldms_config and not args.daemon_name:
-        print(f'No action detected. Exiting.', file=sys.stderr)
+    if not args.output_path and not args.ldms_config and not args.daemon_name:
+        logging.warning('No action detected. Exiting.')
 
     sys.exit(0)


### PR DESCRIPTION
Using logger prevents error messages from option processing or execution from contaminating output read by a daemon. Option updates address the missing -y from man page and other option naming/conflict check concerns.