### PR TITLE
Add (at log level DEBUG) yaml input and builder tree log output

### DIFF
--- a/ldms/python/ldmsd/ldmsd_yaml_parser
+++ b/ldms/python/ldmsd/ldmsd_yaml_parser
@@ -4,6 +4,7 @@ import yaml
 import errno
 import argparse
 import logging
+import pprint
 from ldmsd.parser_util import *
 
 if __name__ == "__main__":
@@ -37,6 +38,9 @@ if __name__ == "__main__":
     config_fp = open(args.ldms_config)
     conf_spec = yaml.safe_load(config_fp)
 
+    logging.debug("ORIGINAL YAML after anchor expansion")
+    logging.debug(pprint.pformat(conf_spec))
+
     if not isinstance(conf_spec, (list, dict)):
         logging.error(f"Input {args.ldms_config} is not yaml. Contents:")
         logging.error(conf_spec)
@@ -46,13 +50,21 @@ if __name__ == "__main__":
 
     if args.daemon_name:
         ldmsd_cfg_str = cluster.daemon_config(args.ldms_config, args.daemon_name)
+        import json
+        logging.debug("# YamlCfg after processing:")
+        logging.debug(cluster)
+        logging.debug("# ========================================================")
         print(f"# {__file__} generated {args.daemon_name} from {args.ldms_config} to stdout")
         print(f'{ldmsd_cfg_str}')
         sys.exit(0)
 
     if args.output_path:
         logging.debug(f"{__file__} wrote group configs from {args.ldms_config} to {args.output_path}")
+        logging.debug("# --------------------------------------------------------")
         rc = cluster.config_v4(args.output_path)
+        logging.debug("YamlCfg after processing:")
+        logging.debug(cluster)
+        logging.debug("# ========================================================")
         if rc:
             sys.exit(rc)
         logging.info('LDMSD config files generated')

--- a/ldms/python/ldmsd/parser_util.py
+++ b/ldms/python/ldmsd/parser_util.py
@@ -9,6 +9,8 @@ import bisect
 import itertools as it
 import collections
 import ldmsd.hostlist as hostlist
+import logging
+import pprint
 
 AUTH_ATTRS = [
     'auth',
@@ -787,10 +789,8 @@ class YamlCfg(object):
                 'producers': self.producers,
                 'updaters': self.updaters,
                 'stores': self.stores,
-                'samplers': self.samplers,
-                'multi_shot': self.multi_shot
+                'samplers': self.samplers
                 }
-        import pprint
         return pprint.pformat(printable)
 
     def ldmsd_arg_list(self, local_path, dmn_grp, dmn):
@@ -1189,6 +1189,9 @@ class YamlCfg(object):
         all exist on the machines relevant to the ldmsd cluster.
         """
         for dmn in self.daemons:
+            logging.debug(f"daemon {dmn} PRETTY:")
+            logging.debug(pprint.pformat(self.daemons[dmn]))
+            logging.debug(f"daemon {dmn} END --------")
             try:
                 dstr = self.daemon_config(self.args.ldms_config, dmn)
                 if len(dstr) > 1:


### PR DESCRIPTION
this makes it possible for admins to see in the log what ldmsd_yaml_parser though they said after yaml anchor expansion and what builder data later results from the expanded yaml.