### PR TITLE
Fix double ntohl() in processing a push update

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2284,7 +2284,7 @@ static void process_push_reply(struct ldms_xprt *x, struct ldms_reply *reply,
 	}
 
 	if (set->push_cb) {
-		set->push_cb(x, set, ntohl(push_flags), set->push_cb_arg);
+		set->push_cb(x, set, push_flags, set->push_cb_arg);
 	}
 }
 


### PR DESCRIPTION
The push_flags value is already in host byte order after the first ntohl() conversion. Remove the redundant second ntohl() call that was corrupting the flag values passed to the callback.

This resulted in the producer set's reference count logic failing to detect push updates, leading to incorrect reference management.