### PR TITLE
fix locations checked in ldms-sensors-config script for cpu frequency

### DIFF
--- a/ldms/src/sampler/filesingle/Makefile.am
+++ b/ldms/src/sampler/filesingle/Makefile.am
@@ -24,7 +24,7 @@ bin_SCRIPTS += ldms-sensors-config
 dist_man7_MANS += ldms-sampler_filesingle.man
 dist_man1_MANS += ldms-sensors-config.man
 
-TESTS = test_sensors test_lscpu
+TESTS = test_sensors
 endif
 
 EXTRA_DIST += \

--- a/ldms/src/sampler/filesingle/ldms-sensors-config
+++ b/ldms/src/sampler/filesingle/ldms-sensors-config
@@ -24,6 +24,13 @@ IGNORE_TYPES = [
     "hyst",
 ]
 
+def get_freq_file(temp):
+    met_file1 = temp.replace("max_fr", "cur_fr")
+    if os.path.isfile(met_file1):
+        return met_file1
+    met_file2 = temp.replace("cpuinfo_max_freq", "scaling_cur_freq")
+    if os.path.isfile(met_file2):
+        return met_file2
 
 def main():
     parser = argparse.ArgumentParser(
@@ -203,7 +210,7 @@ def main():
             continue
         if line.startswith("openat("):
             temp = line.split('"')[1]
-            met_file = temp.replace("max_fr", "cur_fr")
+            met_file = get_freq_file(temp)
             parts = temp.split("/")
             device = parts[-3]
             item = "cur_freq"
@@ -213,7 +220,7 @@ def main():
             devices[device][item] = {"label": "cur_freq", "inputfile": met_file}
         elif line.startswith("open("):
             temp = line.split('"')[1]
-            met_file = temp.replace("max_fr", "cur_fr")
+            met_file = get_freq_file(temp)
             parts = temp.split("/")
             device = parts[-3]
             item = "cur_freq"


### PR DESCRIPTION
linux kernels (at an unknown version earlier than 4.18) switched from cpuinfo_cur_freq to scaling_cur_freq file name.
The modification checks both locations instead of trying to detect kernel version and assume the answer based on version.

The build-time test_lscpu gold input is no longer valid for some systems,
so it is no longer part of the test rule.