### PR TITLE
bugfix: env variables must be usable in interval, offset attributes

### DIFF
--- a/ldms/python/ldmsd/parser_util.py
+++ b/ldms/python/ldmsd/parser_util.py
@@ -84,6 +84,8 @@ def check_intrvl_str(interval_s):
         return interval_s
     if type(interval_s) != str:
         raise ValueError(f'{error_str}')
+    if "${" in interval_s:
+        return interval_s
     interval_s = interval_s.lower()
     unit = next((unit for unit in unit_strs if unit in interval_s), None)
     if unit:


### PR DESCRIPTION
fixes #2157 backported to b4.5