### PR TITLE
Fix slurm_notifier linking against unnecessary libraries

### DIFF
--- a/ldms/src/sampler/spank/Makefile.am
+++ b/ldms/src/sampler/spank/Makefile.am
@@ -6,11 +6,7 @@ dist_man7_MANS=
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
-		$(top_builddir)/ldms/src/core/libldms.la \
-		@LDFLAGS_GETTIME@ \
-		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
-		$(top_builddir)/lib/src/coll/libcoll.la \
+COMMON_LIBADD = $(top_builddir)/ldms/src/core/libldms.la \
 		$(top_builddir)/lib/src/ovis_json/libovis_json.la
 
 libslurm_notifier_la_SOURCES = slurm_notifier.c


### PR DESCRIPTION
slurm_notifier is a SPANK plugin that runs in Slurm's process space and communicates with ldmsd over the network. It should not link against LDMSD internal libraries or utilities it doesn't use.

Linking against libsampler_base introduces undefined symbol references to ldmsd_set_register/ldmsd_set_deregister that cannot be resolved when Slurm loads the plugin. While lazy binding masks this in most environments, systems with immediate binding will fail to load the plugin.

Remove libsampler_base, libovis_util, libcoll, and LDFLAGS_GETTIME from slurm_notifier's link dependencies. Keep only libldms and libovis_json which the plugin requires.