### PR TITLE
Revert "papi_sampler: improve linkage for libpapi_hook.la"

### DIFF
--- a/ldms/src/sampler/papi/Makefile.am
+++ b/ldms/src/sampler/papi/Makefile.am
@@ -14,14 +14,13 @@ COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
 		$(top_builddir)/lib/src/coll/libcoll.la \
 		$(top_builddir)/lib/src/ovis_json/libovis_json.la \
 		$(top_builddir)/lib/src/ovis_log/libovis_log.la \
-		$(top_builddir)/ldms/src/sampler/papi/libpapi_hook.la \
 		-lm -lpthread
 
 libpapi_hook_la_SOURCES = papi_hook.c papi_hook.h
 pkglib_LTLIBRARIES += libpapi_hook.la
 
 libpapi_sampler_la_SOURCES = papi_sampler.h papi_sampler.c papi_config.c
-libpapi_sampler_la_LIBADD = $(COMMON_LIBADD) $(LTLIBPAPI)
+libpapi_sampler_la_LIBADD = $(COMMON_LIBADD) $(LTLIBPAPI) libpapi_hook.la
 libpapi_sampler_la_CFLAGS = -DSYSCONFDIR='"$(sysconfdir)"'
 pkglib_LTLIBRARIES += libpapi_sampler.la
 dist_man7_MANS += ldms-sampler_papi_sampler.man


### PR DESCRIPTION
This reverts commit 381b4c88b92af8031ec786f3d132250095328547.