### PR TITLE
DCGM Sampler: sampler interval config is ignored by yaml_parser

### DIFF
--- a/ldms/python/ldmsd/parser_util.py
+++ b/ldms/python/ldmsd/parser_util.py
@@ -34,8 +34,6 @@ DEFAULT_ATTR_VAL = {
 }
 
 INT_ATTRS = [
-    'interval',
-    'offset',
     'reconnect',
     'flush'
 ]


### PR DESCRIPTION
This fix omits ignoring on "interval" key in `parser_util.py` logic.  