### PR TITLE
bugfix: env variables must be usable in interval, offset attributes

### DIFF
--- a/ldms/python/ldmsd/parser_util.py
+++ b/ldms/python/ldmsd/parser_util.py
@@ -86,8 +86,11 @@ def check_intrvl_str(interval_s):
         return interval_s
     if type(interval_s) != str:
         raise ValueError(f'{error_str}')
-    if bool(re.match(r'^\${*[A-Za-z][A-Za-z0-9_]*}*$', interval_s)):
-        return interval_s
+    if interval_s.startswith("$"):
+        if bool(re.match(r'^\$(?:\{[A-Za-z][A-Za-z0-9_]*\}|[A-Za-z][A-Za-z0-9_]*)$', interval_s)):
+            return interval_s
+        else:
+            raise ValueError(f'"{interval_s}" is not a valid environment reference to a time-interval string\n')
     interval_s = interval_s.lower()
     unit = next((unit for unit in unit_strs if unit in interval_s), None)
     if unit:


### PR DESCRIPTION
check for environment variable with or without curly braces. addressing [#2169](https://github.com/ovis-hpc/ldms/pull/2169)

@baallan this will replace your PR mentioned above with changes to address raised concerns.




