### PR TITLE
Ensure thread-safe sampler operations with state validation

### DIFF
--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -1058,6 +1058,13 @@ struct ldmsd_cfgobj_sampler {
 	/* Set to 1 if the plugin has been configured */
 	int configured;
 
+	enum ldmsd_cfgobj_sampler_state {
+		LDMSD_SAMP_STATE_INIT = 0,
+		LDMSD_SAMP_STATE_CONFIGURED,
+		LDMSD_SAMP_STATE_RUNNING,
+		LDMSD_SAMP_STATE_TERMINATING,
+	} state;
+
 	/* Private context pointer, managed by plugin */
 	void *context;
 	/* ovis_log handle to use when logging plugin messages */
@@ -1075,6 +1082,21 @@ struct ldmsd_cfgobj_sampler {
 	int use_xthread; /* !0 if use exclusitve thread */
 	pthread_t xthread; /* the exclusive thread */
 };
+
+static inline const char *
+ldmsd_cfgobj_sampler_state_str(enum ldmsd_cfgobj_sampler_state state) {
+	switch (state) {
+	case LDMSD_SAMP_STATE_INIT:
+		return "INIT";
+	case LDMSD_SAMP_STATE_CONFIGURED:
+		return "CONFIGURED";
+	case LDMSD_SAMP_STATE_RUNNING:
+		return "RUNNING";
+	case LDMSD_SAMP_STATE_TERMINATING:
+		return "TERMINATING";
+	}
+	return "BAD STATE";
+}
 
 #define LDMSD_DEFAULT_SAMPLE_INTERVAL 1000000
 /** Metric name for component ids (u64). */

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -5452,6 +5452,11 @@ static int plugn_term_handler(ldmsd_req_ctxt_t reqc)
 				"The specified plugin instance '%s' has "
 				"active users and cannot be terminated.",
 				instance_name);
+	} else if (reqc->errcode == EBUSY) {
+		cnt = snprintf(reqc->line_buf, reqc->line_len,
+				"The plugin instance '%s' is running. " \
+				"The instance needs to be stopped before " \
+				"being terminated.", instance_name);
 	} else {
 		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
 				"Failed to terminate the plugin instance '%s'.",
@@ -5571,6 +5576,26 @@ static int plugn_config_handler(ldmsd_req_ctxt_t reqc)
 		goto send_reply;
 	}
 
+	ldmsd_cfgobj_lock(cfg);
+	if (sampler) {
+		if (sampler->state == LDMSD_SAMP_STATE_RUNNING) {
+			reqc->errcode = EBUSY;
+			reqc->line_off = snprintf(reqc->line_buf, reqc->line_len,
+						  "The plugin instance '%s' is running. " \
+						  "Please stop it before re-configuring it.",
+						  sampler->cfg.name);
+			ldmsd_cfgobj_unlock(cfg);
+			goto send_reply;
+		}
+		if (sampler->state == LDMSD_SAMP_STATE_TERMINATING) {
+			reqc->errcode = EBUSY;
+			reqc->line_off = snprintf(reqc->line_buf, reqc->line_len,
+						  "The plugin instance '%s' has been terminated.",
+						  sampler->cfg.name);
+			ldmsd_cfgobj_unlock(cfg);
+			goto send_reply;
+		}
+	}
 	free(cfg->avl_str);
 	free(cfg->kvl_str);
 	cfg->avl_str = av_to_string(av_list, 0);
@@ -5584,6 +5609,7 @@ static int plugn_config_handler(ldmsd_req_ctxt_t reqc)
 		reqc->errcode = sampler->api->base.config((ldmsd_plug_handle_t)sampler, kw_list, av_list);
 		if (!reqc->errcode) {
 			sampler->configured = 1;
+			sampler->state = LDMSD_SAMP_STATE_CONFIGURED;
 		}
 	} else {
 		reqc->errcode = store->api->base.config((ldmsd_plug_handle_t)store, kw_list, av_list);
@@ -5591,6 +5617,7 @@ static int plugn_config_handler(ldmsd_req_ctxt_t reqc)
 			store->configured = 1;
 		}
 	}
+	ldmsd_cfgobj_unlock(cfg);
 	if (reqc->errcode) {
 		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
 				"Error %d configuring plugin instance '%s'.",


### PR DESCRIPTION
Introduce states to sampler config objects and acquire the config object's mutex in the configuration path to prevent race conditions. Prior to this change, ldmsd did not acquire locks during configuration, allowing potential concurrent access where a sampler could be configured while actively sampling or executing other operations.

The state machine enforces correctness across all sampler plugin interfaces (config, sample, term, etc.) by ensuring operations are only called when the sampler is in an appropriate state. The usage() interface is excluded from mutex protection as it returns a constant description string.