### PR TITLE
Add summary mode to prdcr_status to only report the status

### DIFF
--- a/ldms/man/ldmsd_controller.rst
+++ b/ldms/man/ldmsd_controller.rst
@@ -441,7 +441,11 @@ Query producer status
       |
       | The producer name. If none is given, the statuses of all
         producers are reported.
-
+   **[summary** *true|false* **]**
+      |
+      | If false (default), for each producer, the status and the list of sets collected
+        from the produce will be reported. The true, only the status of each producer
+        will be reported.
 
 Disable stream communication
 ----------------------------

--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -97,7 +97,7 @@ LDMSD_CTRL_CMD_MAP = {'usage': {'req_attr': [], 'opt_attr': ['name']},
                       'prdcr_start_regex': {'req_attr': ['regex'],
                                             'opt_attr': ['interval', 'reconnect']},
                       'prdcr_stop_regex': {'req_attr': ['regex']},
-                      'prdcr_status': {'req_attr': [], 'opt_attr':['name']},
+                      'prdcr_status': {'req_attr': [], 'opt_attr':['name', 'summary']},
                       'prdcr_set_status': {'opt_attr': ['producer', 'instance', 'schema']},
                       'prdcr_hint_tree': {'req_attr':['name'], 'opt_attr': []},
                       'prdcr_subscribe': {'req_attr':['regex'],
@@ -2778,12 +2778,14 @@ class Communicator(object):
             self.close()
             return errno.ENOTCONN, str(e)
 
-    def prdcr_status(self, name = None):
+    def prdcr_status(self, name = None, summary = False):
         """
         Query the LDMSD for the status of one or more producers.
 
         Keyword Parameters:
         [name] - If not None (default), the name of the producer to query.
+        [summary] - If false (default), for each producer, the producer sets will be reported.
+                    If true, only the producer status will be reported.
 
         Returns:
         A tuple of status, data
@@ -2794,6 +2796,8 @@ class Communicator(object):
         attrs = None
         if name:
             attrs = [ LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.NAME, value=name) ]
+        if summary:
+            attrs += [ LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.SUMMARY, value = summary)]
         req = LDMSD_Request(command_id=LDMSD_Request.PRDCR_STATUS, attrs=attrs)
         try:
             req.send(self)

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1034,6 +1034,9 @@ class LdmsdCmdParser(cmd.Cmd):
         Get the statuses of all producers
         Parameters:
         [name=]        producer name
+        [summary=]     True to print only the producer status.
+                       False (default) will print the producer status
+                       and the producer sets collected from the producer host
         """
         arg = self.handle_args('prdcr_status', arg)
         if not arg:
@@ -1066,10 +1069,11 @@ class LdmsdCmdParser(cmd.Cmd):
                     f"{prdcr['quota']:>8} " \
                     f"{prdcr['rx_rate']:>8} " \
                     f"{pstate:12} {prdcr['type']:10}")
-            for pset in prdcr['sets']:
-                print("    {0:16} {1:16} {2}".format(pset['inst_name'],
-                                                        pset['schema_name'],
-                                                        pset['state']))
+            if arg['summary'] is None or arg['summary'] == False:
+                for pset in prdcr['sets']:
+                    print("    {0:16} {1:16} {2}".format(pset['inst_name'],
+                                                            pset['schema_name'],
+                                                            pset['state']))
 
     def complete_prdcr_status(self, text, line, begidx, endidx):
         return self.__complete_attr_list('prdcr_status', text)
@@ -3125,7 +3129,7 @@ class LdmsdCmdParser(cmd.Cmd):
         arg = self.handle_args('prdcr_status', arg)
         if not arg:
             return
-        rc, msg = self.comm.prdcr_status(arg['name'])
+        rc, msg = self.comm.prdcr_status(arg['name'], summary=False)
         if rc != 0:
             print(f'Error {rc}: {msg}')
             return


### PR DESCRIPTION
Without the patch, prdcr_status reports the status of each producer and the list of sets collected from the producer. The patch added the summary attribute so that when summary=true prdcr_status reports only the producer status. This reduces the size of messages sent from ldmsd to the interface. The default is to report the status and the list of sets, i.e., summary=false.