### PR TITLE
Add 'summary' to prdcr_listen_status to only report the status

### DIFF
--- a/ldms/man/ldmsd_peer_daemon_advertisement.rst
+++ b/ldms/man/ldmsd_peer_daemon_advertisement.rst
@@ -55,6 +55,7 @@ prdcr_listen_del
    name=\ *NAME*
 
 prdcr_listen_status
+   [summary=\ *true|false*]
 
 DESCRIPTION
 ===========
@@ -245,6 +246,10 @@ hostnames. The parameters are:
 
 **prdcr_listen_status** report the status of each prdcr_listen object.
 There is no parameter.
+
+   [summary=True|False]
+      False (default) to report both status and producers corresponding to each prdcr_listen.
+      True to report only the status of each prdcr_listen.
 
 EXAMPLE
 =======

--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -3131,9 +3131,16 @@ class Communicator(object):
         except Exception as e:
             return errno.ENOTCONN, str(e)
 
-    def prdcr_listen_status(self):
+    def prdcr_listen_status(self, summary = False):
         """
         Get the status of all producer listen
+
+        Parameters:
+        [summary=True|False]          If false (default), for each prdcr_listen,
+                                      the status and the producers corresponding
+                                      to the prdcr_listen will be reported.
+                                      If true, for each prdcr_listen,
+                                      only the status will be reported.
 
         Returns:
         A tuple of status, data
@@ -3141,7 +3148,8 @@ class Communicator(object):
          - data is the status of all producer listeners
            or an error message if status != 0 or None
         """
-        req = LDMSD_Request(command_id=LDMSD_Request.PRDCR_LISTEN_STATUS)
+        req = LDMSD_Request(command_id=LDMSD_Request.PRDCR_LISTEN_STATUS,
+                            attrs = [LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.SUMMARY, value=summary)])
         try:
             req.send(self)
             resp = req.receive(self)

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -3260,6 +3260,13 @@ class LdmsdCmdParser(cmd.Cmd):
     def do_prdcr_listen_status(self, arg):
         """
         Display the status of all producer listen
+
+        Parameters:
+            [summary=True|False]      If false (default), for each prdcr_listen,
+                                      the status and the producers corresponding
+                                      to the prdcr_listen will be reported.
+                                      If true, for each prdcr_listen,
+                                      only the status will be reported.
         """
         arg = self.handle_args('prdcr_listen_status', arg)
         if arg is None:


### PR DESCRIPTION
Without the patch, prdcr_listen_status always reports the status and producers corresponding to each prdcr_listen. The patch adds the summary attribute to the command. When summary=true is given, prdcr_listen_status reports only the status of each prdcr_listen.