### PR TITLE
add ERRORS section to man, describing handling without msg_enable

### DIFF
--- a/ldms/src/sampler/app_sampler/ldms-sampler_app_sampler.rst
+++ b/ldms/src/sampler/app_sampler/ldms-sampler_app_sampler.rst
@@ -259,6 +259,11 @@ BUGS
 
 No known bugs.
 
+ERRORS
+======
+
+Plugin configuration will fail with ENOTSUP unless the daemon is configured with 'msg_enable'.
+
 EXAMPLES
 ========
 

--- a/ldms/src/sampler/app_sampler/ldms-sampler_linux_proc_sampler.rst
+++ b/ldms/src/sampler/app_sampler/ldms-sampler_linux_proc_sampler.rst
@@ -389,6 +389,11 @@ The files defined with published_pid_dir appear in (for example)
 and each contains the JSON message sent by the publisher. Publishers,
 not ldmsd, populate this directory to allow asynchronous startup.
 
+ERRORS
+======
+
+Plugin configuration will fail with ENOTSUP unless the daemon is configured with 'msg_enable'.
+
 NOTES
 =====
 

--- a/ldms/src/sampler/blob_msg/ldms-sampler_blob_msg_writer.rst
+++ b/ldms/src/sampler/blob_msg/ldms-sampler_blob_msg_writer.rst
@@ -137,6 +137,11 @@ the .TIMING file as a binary pair (tv_sec, tv_usec) with each value
 stored as a little-endian 64 bit value which should be read and then
 converted with le64toh.
 
+ERRORS
+======
+
+Plugin will do nothing useful unless the daemon is configured with 'msg_enable'.
+
 NOTES
 =====
 

--- a/ldms/src/sampler/hello_ldms_msg/ldms-sampler_hello_ldms_msg.rst
+++ b/ldms/src/sampler/hello_ldms_msg/ldms-sampler_hello_ldms_msg.rst
@@ -52,6 +52,11 @@ BUGS
 
 No known bugs.
 
+ERRORS
+======
+
+Plugin will do nothing useful unless the daemon is configured with 'msg_enable'.
+
 EXAMPLES
 ========
 

--- a/ldms/src/sampler/papi/ldms-sampler_papi_sampler.rst
+++ b/ldms/src/sampler/papi/ldms-sampler_papi_sampler.rst
@@ -89,6 +89,11 @@ BUGS
 
 No known bugs.
 
+ERRORS
+======
+
+Plugin configuration will fail with ENOTSUP unless the daemon is configured with 'msg_enable'.
+
 EXAMPLES
 ========
 

--- a/ldms/src/sampler/slurm/ldms-sampler_slurm_sampler.rst
+++ b/ldms/src/sampler/slurm/ldms-sampler_slurm_sampler.rst
@@ -73,6 +73,11 @@ BUGS
 
 No known bugs.
 
+ERRORS
+======
+
+Plugin will do nothing useful unless the daemon is configured with 'msg_enable'.
+
 EXAMPLES
 ========
 

--- a/ldms/src/sampler/syspapi/ldms-sampler_syspapi_sampler.rst
+++ b/ldms/src/sampler/syspapi/ldms-sampler_syspapi_sampler.rst
@@ -104,6 +104,13 @@ BUGS
 
 No known bugs.
 
+ERRORS
+======
+
+Plugin configuration will log an error and continue if the daemon is
+configured without 'msg_enable', and the pause and resume capablity
+will be disabled.
+
 EXAMPLES
 ========
 


### PR DESCRIPTION
This documents undocumented behavior of documented plugins calling ldms_msg_subscribe when msg_enable has not been specified.
cherry-pick of #2183 