### PR TITLE
Update subscribe yaml parsing to handle messages and streams

### DIFF
--- a/ldms/man/ldmsd_yaml_parser.rst
+++ b/ldms/man/ldmsd_yaml_parser.rst
@@ -231,11 +231,15 @@ are the environment variable name.
 [subscribe]
 -----------
 
-List of dictionaries of streams to subscribe producers to.
+List of dictionaries of streams or messages to subscribe producers to.
 
 **stream**
    |
    | The name of the stream.
+
+**msg_tag**
+   |
+   | The name of the msg_tag.
 
 **regex**
    |


### PR DESCRIPTION
Rename write_stream_subscribe to write_subscribe
write_subscribe handles both msg_tag and stream options
Remove required attribute check for streams alone
Add check that ensures at least streams or msg_tag is specified