### PR TITLE
Update subscribe yaml parsing to handle messages and streams

### DIFF
--- a/ldms/man/ldmsd_yaml_parser.rst
+++ b/ldms/man/ldmsd_yaml_parser.rst
@@ -235,11 +235,15 @@ are the environment variable name.
 [subscribe]
 -----------
 
-List of dictionaries of streams to subscribe producers to.
+List of dictionaries of streams or messages to subscribe producers to.
 
 **stream**
    |
    | The name of the stream.
+
+**msg_tag**
+   |
+   | The name of the msg_tag.
 
 **regex**
    |

--- a/ldms/python/ldmsd/parser_util.py
+++ b/ldms/python/ldmsd/parser_util.py
@@ -498,11 +498,11 @@ class YamlCfg(object):
             if subscribe:
                 for sub in subscribe:
                     check_required([ 'regex' ], sub, '"aggregators" stream specification')
-                    msg = check_opt('message_channel', sub)
+                    msg = check_opt('msg_tag', sub)
                     stream = check_opt('stream', sub)
                     if not msg and not stream:
                         raise ValueError(f'"subscribe" for hostlist {group} must contain '\
-                                         f'either a "stream" or "message_channel" attribute\n')
+                                         f'either a "stream" or "msg_tag" attribute\n')
             for name in names:
                 aggregators[group][name] = { 'state' : 'stopped' } # 'running', 'error'
                 self.build_advertisers(agg_spec)


### PR DESCRIPTION
Rename write_stream_subscribe to write_subscribe
write_subscribe handles both msg_tag and stream options
Remove required attribute check for streams alone
Add check that ensures at least stream or msg_tag is specified