### PR TITLE
Remove deprecated imp module from ldmsd_util.py

### DIFF
--- a/ldms/python/ldmsd/ldmsd_util.py
+++ b/ldms/python/ldmsd/ldmsd_util.py
@@ -334,13 +334,17 @@ def get_var_from_file(module_name, filepath):
 
     @return: A module of the name module_name
 
-    @see: imp.load_source
+    @see: importlib.util
     """
-    import imp
-    f = open(filepath)
-    data = imp.load_source(module_name, '', f)
-    f.close()
-    return data
+    import importlib.util
+    import importlib.machinery
+    import sys
+    loader = importlib.machinery.SourceFileLoader(module_name, filepath)
+    spec = importlib.util.spec_from_file_location(module_name, filepath, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    loader.exec_module(module)
+    return module
 
 class LDMSD(object):
     """A utility class to handle an LDMS Daemon subprocess"""


### PR DESCRIPTION
Removes deprecated imp module
Replace with importlib and sys imports to maintain functionality

Addresses #2189 and ovis-hpc/sos#109 