### PR TITLE
Update dump_cfg to include msg_enable/stream_enable

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -6787,6 +6787,11 @@ static int dump_cfg_handler(ldmsd_req_ctxt_t reqc)
 	}
 	fprintf(fp, "\n");
 
+	if (ldms_msg_is_enabled())
+		fprintf(fp, "msg_enable\n");
+	if (stream_enabled)
+		fprintf(fp, "stream_enable\n");
+
 	/* Daemon name */
 	const char *_name = ldmsd_myname_get();
 	if (_name[0] != '\0') {


### PR DESCRIPTION
Update dump_cfg command to include msg_enable/stream_enable in the ouput file if they are enabled on the LDMSD