### PR TITLE
Remove erraneous logic that gets the end of store time

### DIFF
--- a/ldms/src/ldmsd/ldmsd_strgp.c
+++ b/ldms/src/ldmsd/ldmsd_strgp.c
@@ -239,9 +239,6 @@ static void strgp_update_fn(ldmsd_strgp_t strgp, ldmsd_prdcr_set_t prd_set, ldms
 		goto free;
 	}
 	(void) store_event_post(event_ctxt);
-	clock_gettime(CLOCK_REALTIME, &end);
-	strgp_ref->store_stat.end = end;
-	ldmsd_stat_update(&strgp_ref->store_stat, &start, &end);
 	return;
 
 free:


### PR DESCRIPTION
The errorneous code causes the number of store operations (number of processed store events) to be doubled. This leads to inaccurate rate of number of store operations reported by store_time_stats.