### PR TITLE
Update dump_cfg to support msg_enable/stream_enable

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -6623,6 +6623,11 @@ static int dump_cfg_handler(ldmsd_req_ctxt_t reqc)
 	}
 	fprintf(fp, "\n");
 
+	if (ldms_msg_is_enabled())
+		fprintf(fp, "msg_enable\n");
+	if (stream_enabled)
+		fprintf(fp, "stream_enable\n");
+
 	/* Daemon name */
 	const char *_name = ldmsd_myname_get();
 	if (_name[0] != '\0') {


### PR DESCRIPTION
Add logic to write msg_enable/stream_enable when writing a LDMSD's configuration to a file with dump_cfg