### PR TITLE
Fix LDMS Connect over Infiniband RDMA

### DIFF
--- a/ldms/src/core/ldms_rail.h
+++ b/ldms/src/core/ldms_rail.h
@@ -72,25 +72,28 @@ struct ldms_rail_id_s {
 	uint64_t rail_gn;
 };
 
+/*
+ * NOTE: Keep this under 51 bytes due to ZAP_RDMA_CONN_DATA_MAX limit.
+ */
 struct ldms_rail_conn_msg_s {
 	/* Compatible to existing LDMS connect message */
 	struct ldms_version ver;
 	char auth_name[LDMS_AUTH_NAME_MAX + 1];
 	/* -------- */
 
-	enum ldms_conn_type conn_type;
-
 	/* The rail part */
 
-	int64_t rate_limit;  /* send/recv rate limits in bytes/sec */
+	uint32_t conn_type:3;
+	uint32_t msg_enabled:1; /* 0 if peer does not enable message service */
+	uint32_t n_eps:12; /* number of endpoints */
+	uint32_t idx:12; /* endpoint index in the rail */
+	uint32_t pad:4;
+
+	int32_t rate_limit;  /* send/recv rate limits in bytes/sec */
 	int64_t recv_quota; /* receive limits in bytes */
 
-	int n_eps; /* number of endpoints */
-	uint32_t idx; /* endpoint index in the rail */
 	int pid;
 	uint64_t rail_gn;
-
-	int msg_enabled; /* 0 if peer does not enable message service */
 
 };
 #pragma pack(pop)

--- a/lib/src/zap/rdma/zap_rdma.h
+++ b/lib/src/zap/rdma/zap_rdma.h
@@ -58,8 +58,8 @@
 #define SQ_DEPTH 4
 #define RQ_DEPTH 4
 #define RQ_BUF_SZ 2048
-#define SQ_SGE 1
-#define RQ_SGE 1
+#define SQ_SGE 2
+#define RQ_SGE 2
 
 /* number of buffers in a pool */
 #define Z_RDMA_POOL_SZ 256
@@ -167,10 +167,22 @@ struct z_rdma_conn_data {
 };
 #pragma pack(pop)
 
-#define RDMA_CONN_DATA_MAX (196)
+/* RDMA_CONN_DATA_MAX being 56 is limited by RDMA_PS_TCP on IB. IWarp don't have
+ * this limit. `rdma_connect(3)` man page also mentioned this limitation on IB.
+ *
+ * linux/drivers/infiniband/core/cm.c:cm_validate_req_param() was the one
+ * invaliding the private_data_len (from the rdma_connect() > cma_connect_ib() >
+ * ib_send_cm_req() > cm_validate_req_param() call chain).
+ *
+ * The IB_CM_REQ_PRIVATE_DATA_SIZE is actually 92 bytes, but since we use TCP
+ * addressing, the private data was offset by 36 bytes for `struct cma_hdr`
+ * containing cma version, src and dst addresses; hence the 92 - 36 = 56 usable
+ * private data length.
+ */
+#define RDMA_CONN_DATA_MAX (56)
 #define ZAP_RDMA_CONN_DATA_MAX (RDMA_CONN_DATA_MAX - sizeof(struct z_rdma_conn_data))
 
-#define RDMA_ACCEPT_DATA_MAX (196)
+#define RDMA_ACCEPT_DATA_MAX (56)
 #define ZAP_RDMA_ACCEPT_DATA_MAX RDMA_ACCEPT_DATA_MAX
 
 struct z_rdma_epoll_ctxt {


### PR DESCRIPTION
`rmda_connect()` on Infiniband has 56 bytes private user data length limit. This patch changes our RDMA_CONN_DATA_MAX to 56 with a note to prevent future modification. This patch also modify rail connect message to fit the smaller message size requirement.