### PR TITLE
Fix RDMA over IB connect issue

### DIFF
--- a/ldms/src/core/ldms_rail.c
+++ b/ldms/src/core/ldms_rail.c
@@ -655,6 +655,8 @@ void __rail_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 /* These are implemented in ldms_xprt.c */
 void __ldms_xprt_resource_free(struct ldms_xprt *x);
 void __ldms_xprt_conn_msg_init(ldms_t _x, struct ldms_conn_msg *msg);
+void __ldms_rail_ib_conn_msg_init(struct ldms_rail_s *r, int idx,
+		struct ldms_rail_ib_conn_msg_s *m);
 void __ldms_xprt_init(struct ldms_xprt *x, const char *name, int is_active);
 void ldms_zap_auto_cb(zap_ep_t zep, zap_event_t ev);
 
@@ -662,15 +664,31 @@ void ldms_zap_auto_cb(zap_ep_t zep, zap_event_t ev);
 
 static void __ldms_rail_conn_msg_init(struct ldms_rail_s *r, int idx, struct ldms_rail_conn_msg_s *m);
 
-void __rail_conn_msg_ntoh(struct ldms_rail_conn_msg_s *m)
+static int
+__rail_conn_ib_msg_check(zap_ep_t zep, struct ldms_rail_ib_conn_msg_s *mib, int *is_ib)
 {
-	m->conn_type = ntohl(m->conn_type);
-	m->idx = ntohl(m->idx);
-	m->n_eps = ntohl(m->n_eps);
-	m->pid = ntohl(m->pid);
-	m->rail_gn = be64toh(m->rail_gn);
-	m->rate_limit = be64toh(m->rate_limit);
-	m->recv_quota = be64toh(m->recv_quota);
+	if (LDMS_RAIL_IB_CONN_MSG_CONN_TYPE(mib) != LDMS_CONN_TYPE_RAIL)
+		return EINVAL;
+	*is_ib = 1;
+	return 0;
+}
+
+static int
+__rail_conn_msg_check(zap_ep_t zep, void *msg, int msg_len, int *is_ib)
+{
+	struct ldms_rail_conn_msg_s *m = msg;
+	struct ldms_rail_ib_conn_msg_s *mib = msg;
+
+	if (msg_len == sizeof(*mib)) {
+		return __rail_conn_ib_msg_check(zep, mib, is_ib);
+	}
+
+	if (msg_len != sizeof(*m))
+		return EINVAL;
+	if (ntohl(m->conn_type) != LDMS_CONN_TYPE_RAIL)
+		return EINVAL;
+	*is_ib = 0;
+	return 0;
 }
 
 void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
@@ -680,6 +698,8 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 	 * context is the LDMS endpoint in the rail.
 	 */
 	struct ldms_rail_conn_msg_s *m = (void*)ev->data;
+	struct ldms_rail_ib_conn_msg_s *mib = (void*)ev->data;
+	int is_ib;
 	static char rej_msg[64] = "Insufficient resources";
 	struct ldms_rail_conn_msg_s msg;
 	int rc;
@@ -693,6 +713,22 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 	struct ldms_rail_s *r, *lr = NULL;
 	struct ldms_rail_ep_s *rep;
 	struct rbn *rbn;
+
+	int m_n_eps;
+	uint32_t m_idx;
+	int m_pid;
+	uint64_t m_rail_gn;
+	int m_msg_enabled;
+	int64_t m_rate_limit;
+	int64_t m_recv_quota;
+
+	/* some sanity check */
+	rc = __rail_conn_msg_check(zep, ev->data, ev->data_len, &is_ib);
+	if (rc) {
+		/* bad msg */
+		snprintf(rej_msg, sizeof(rej_msg), "Bad msg");
+		goto err_0;
+	}
 
 	rep = ldms_xprt_ctxt_get(lx);
 	if (rep)
@@ -716,11 +752,28 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 		break;
 	}
 
-	__rail_conn_msg_ntoh(m);
+	if (is_ib) {
+		m_n_eps = LDMS_RAIL_IB_CONN_MSG_N_EPS(mib);
+		m_idx = LDMS_RAIL_IB_CONN_MSG_IDX(mib);
+		m_pid = ntohl(mib->pid);
+		m_rail_gn = be64toh(mib->rail_gn);
+		m_msg_enabled = LDMS_RAIL_IB_CONN_MSG_MSG_ENABLED(mib);
+		m_recv_quota = be64toh(mib->recv_quota);
+		m_rate_limit = be64toh(mib->rate_limit);
+	} else {
+		m_n_eps = ntohl(m->n_eps);
+		m_idx = ntohl(m->idx);
+		m_pid = ntohl(m->pid);
+		m_rail_gn = be64toh(m->rail_gn);
+		m_msg_enabled = !!m->msg_enabled;
+		m_recv_quota = be64toh(m->recv_quota);
+		m_rate_limit = be64toh(m->rate_limit);
+	}
+
 
 	rail_id.ip4_addr = peer_addr.sin.sin_addr.s_addr;
-	rail_id.pid = m->pid;
-	rail_id.rail_gn = m->rail_gn;
+	rail_id.pid = m_pid;
+	rail_id.rail_gn = m_rail_gn;
 	pthread_mutex_lock(&__rail_mutex);
 	rbn = rbt_find(&__passive_rail_rbt, &rail_id);
 	if (!rbn) {
@@ -747,7 +800,7 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 			cb = lx->event_cb;
 			cb_arg = lx->event_cb_arg;
 		}
-		r = (void*)ldms_xprt_rail_new(xprt_name, m->n_eps,
+		r = (void*)ldms_xprt_rail_new(xprt_name, m_n_eps,
 				recv_quota, rate_limit, auth_name, auth_av_list);
 		if (!r) {
 			snprintf(rej_msg, sizeof(rej_msg), "passive rail create error: %d", errno);
@@ -757,12 +810,12 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 
 		r->xtype = LDMS_XTYPE_PASSIVE_RAIL;
 		r->state = LDMS_RAIL_EP_ACCEPTING;
-		r->send_quota = m->recv_quota;
-		r->send_rate_limit = m->rate_limit;
+		r->send_quota = m_recv_quota;
+		r->send_rate_limit = m_rate_limit;
 		r->event_cb = cb;
 		r->event_cb_arg = cb_arg;
 		r->rail_id = rail_id;
-		r->peer_msg_enabled = m->msg_enabled;
+		r->peer_msg_enabled = m_msg_enabled;
 		rbn_init(&r->rbn, &r->rail_id);
 		rbt_ins(&__passive_rail_rbt, &r->rbn);
 		ref_get(&r->ref, "__passive_rail_rbt");
@@ -773,23 +826,23 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 	pthread_mutex_unlock(&__rail_mutex);
 
 	/* some sanity check */
-	if (m->n_eps != r->n_eps) {
+	if (m_n_eps != r->n_eps) {
 		snprintf(rej_msg, sizeof(rej_msg),
 			"bad request, expecting rail of %d eps, but got %d",
-			r->n_eps, m->n_eps);
+			r->n_eps, m_n_eps);
 		goto err_0;
 	}
-	if (m->idx >= r->n_eps) {
+	if (m_idx >= r->n_eps) {
 		snprintf(rej_msg, sizeof(rej_msg),
 			"bad ep_idx %d (should be in 0..%d range)",
-			m->idx, r->n_eps-1);
+			m_idx, r->n_eps-1);
 		goto err_0;
 	}
 	pthread_mutex_lock(&r->mutex);
-	if (r->eps[m->idx].ep) {
+	if (r->eps[m_idx].ep) {
 		snprintf(rej_msg, sizeof(rej_msg),
 			"bad ep_idx %d, the endpoint already existed",
-			m->idx);
+			m_idx);
 		pthread_mutex_unlock(&r->mutex);
 		goto err_0;
 	}
@@ -824,16 +877,16 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 
 	/* interpose */
 	_x->event_cb = __rail_cb;
-	_x->event_cb_arg = &r->eps[m->idx];
-	r->eps[m->idx].ep = _x;
-	r->eps[m->idx].state = LDMS_RAIL_EP_ACCEPTING;
-	r->eps[m->idx].send_quota = r->send_quota;
-	r->eps[m->idx].rate_quota.quota = r->send_rate_limit;
-	r->eps[m->idx].rate_quota.rate   = r->send_rate_limit;
-	r->eps[m->idx].rate_quota.ts.tv_sec  = 0;
-	r->eps[m->idx].rate_quota.ts.tv_nsec = 0;
-	r->eps[m->idx].remote_is_rail = 1;
-	ldms_xprt_ctxt_set(_x, &r->eps[m->idx], NULL);
+	_x->event_cb_arg = &r->eps[m_idx];
+	r->eps[m_idx].ep = _x;
+	r->eps[m_idx].state = LDMS_RAIL_EP_ACCEPTING;
+	r->eps[m_idx].send_quota = r->send_quota;
+	r->eps[m_idx].rate_quota.quota = r->send_rate_limit;
+	r->eps[m_idx].rate_quota.rate   = r->send_rate_limit;
+	r->eps[m_idx].rate_quota.ts.tv_sec  = 0;
+	r->eps[m_idx].rate_quota.ts.tv_nsec = 0;
+	r->eps[m_idx].remote_is_rail = 1;
+	ldms_xprt_ctxt_set(_x, &r->eps[m_idx], NULL);
 	pthread_mutex_unlock(&r->mutex);
 
 	ldms_xprt_get(_x, "zap_uctxt");
@@ -848,13 +901,15 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 	rc = ldms_xprt_auth_bind(_x, auth);
 	if (rc)
 		goto err_2;
-	__ldms_rail_conn_msg_init(r, m->idx, &msg);
+	__ldms_rail_conn_msg_init(r, m_idx, &msg);
 
 	/* Take a 'connect' reference. Dropped in ldms_xprt_close() */
 	ldms_xprt_get(_x, "connect");
 
+	/* Unlike rdma_connect(), rdma_accept() can take 196 bytes.
+	 * Our `msg` is a lot less than that. */
 	ref_get(&r->ref, "ldms_accepting");
-	zerr = zap_accept2(zep, ldms_zap_auto_cb, (void*)&msg, sizeof(msg), m->idx);
+	zerr = zap_accept2(zep, ldms_zap_auto_cb, (void*)&msg, sizeof(msg), m_idx);
 	if (zerr) {
 		RAIL_LOG("ERROR: %d accepting connection from %s.\n", zerr, name);
 		goto err_3;
@@ -869,8 +924,8 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
  err_1:
 	pthread_mutex_lock(&r->mutex);
 	r->connecting_eps--;
-	r->eps[m->idx].ep = NULL;
-	r->eps[m->idx].state = LDMS_RAIL_EP_ERROR;
+	r->eps[m_idx].ep = NULL;
+	r->eps[m_idx].state = LDMS_RAIL_EP_ERROR;
 	pthread_mutex_unlock(&r->mutex);
 	zap_set_ucontext(_x->zap_ep, NULL);
 	ldms_xprt_put(_x, "zap_uctxt");	/* context reference */
@@ -893,20 +948,54 @@ static void __ldms_rail_conn_msg_init(struct ldms_rail_s *r, int idx, struct ldm
 	m->msg_enabled = htonl(ldms_msg_enabled);
 }
 
+void __ldms_rail_ib_conn_msg_init(struct ldms_rail_s *r, int idx,
+				  struct ldms_rail_ib_conn_msg_s *m)
+{
+	/* a convenient routine to construct conn_msg for rail */
+	assert(r->eps[idx].ep);
+	__ldms_xprt_conn_msg_init(r->eps[idx].ep, (void*)m);
+
+	LDMS_RAIL_IB_CONN_MSG_SET_CONN_TYPE(m, LDMS_CONN_TYPE_RAIL);
+	LDMS_RAIL_IB_CONN_MSG_SET_MSG_ENABLED(m, !!ldms_msg_enabled);
+
+	m->rate_limit = htobe64(r->recv_rate_limit);
+	m->recv_quota = htobe64(r->recv_quota);
+
+	LDMS_RAIL_IB_CONN_MSG_SET_N_EPS(m, r->n_eps);
+	LDMS_RAIL_IB_CONN_MSG_SET_IDX(m, idx);
+
+	m->pid = htonl(getpid());
+	m->rail_gn = htobe64(r->rail_id.rail_gn);
+}
+
 static int __rail_ep_connect(ldms_t x, struct sockaddr *sa, socklen_t sa_len,
 			ldms_event_cb_t cb, void *cb_arg)
 {
 	int rc;
-	struct ldms_rail_conn_msg_s msg;
+	union {
+		struct ldms_rail_conn_msg_s msg;
+		struct ldms_rail_ib_conn_msg_s ib_msg;
+	} data;
+	int data_len;
 	struct ldms_rail_ep_s *rep = cb_arg;
+
+	enum zap_link_type lt;
+
 	ldms_rail_t r = rep->rail;
 
-	__ldms_rail_conn_msg_init(r, rep->idx, &msg);
+	lt = zap_ep_link_type(x->zap_ep, sa, sa_len);
+	if (lt == ZAP_LINK_RDMA_IB) {
+		__ldms_rail_ib_conn_msg_init(r, rep->idx, &data.ib_msg);
+		data_len = sizeof(data.ib_msg);
+	} else {
+		__ldms_rail_conn_msg_init(r, rep->idx, &data.msg);
+		data_len = sizeof(data.msg);
+	}
 
 	x->event_cb = cb;
 	x->event_cb_arg = cb_arg;
 	ldms_xprt_get(x, "connect");
-	rc = zap_connect2(x->zap_ep, sa, sa_len, (void*)&msg, sizeof(msg), rep->idx);
+	rc = zap_connect2(x->zap_ep, sa, sa_len, (void*)&data, data_len, rep->idx);
 	return rc;
 }
 

--- a/ldms/src/core/ldms_rail.h
+++ b/ldms/src/core/ldms_rail.h
@@ -95,6 +95,60 @@ struct ldms_rail_conn_msg_s {
 };
 #pragma pack(pop)
 
+/* For IB link */
+#pragma pack(push,1)
+#define LDMS_RAIL_IB_BITS_MSG_ENABLED_MASK 0x01 /* 0b00000001 */
+#define LDMS_RAIL_IB_BITS_CONN_TYPE_MASK   0x0e /* 0b00001110*/
+#define LDMS_RAIL_IB_BITS_HI_N_EPS_MASK    0x30 /* 0b00110000*/
+#define LDMS_RAIL_IB_BITS_HI_IDX_MASK      0xc0 /* 0b11000000*/
+struct ldms_rail_ib_conn_msg_s {
+	/* Compatible to existing LDMS connect message */
+	struct ldms_version ver; /* 4 */
+	char auth_name[LDMS_AUTH_NAME_MAX + 1]; /* 16 */
+	/* -------- */
+	uint64_t rail_gn;
+	int64_t recv_quota; /* receive limits in bytes */
+	int64_t rate_limit;  /* send/recv rate limits in bytes/sec */
+	int pid;
+	uint8_t n_eps_low; /* low byte of n_eps */
+	uint8_t idx_low;   /* low byte of idx */
+	uint8_t bits; /* bits[(low) msg_enabled[1], conn_type[3], n_eps[2], idx[2] (high)] */
+};
+
+#define LDMS_RAIL_IB_CONN_MSG_CONN_TYPE(m) \
+	(((m)->bits&LDMS_RAIL_IB_BITS_CONN_TYPE_MASK) >> 1)
+
+#define LDMS_RAIL_IB_CONN_MSG_SET_CONN_TYPE(m, v) \
+	(m)->bits = ((m)->bits & ~LDMS_RAIL_IB_BITS_CONN_TYPE_MASK) \
+	| (((v)<<1)&LDMS_RAIL_IB_BITS_CONN_TYPE_MASK)
+
+#define LDMS_RAIL_IB_CONN_MSG_MSG_ENABLED(m) \
+	(((m)->bits&LDMS_RAIL_IB_BITS_MSG_ENABLED_MASK))
+
+#define LDMS_RAIL_IB_CONN_MSG_SET_MSG_ENABLED(m, v) \
+	(m)->bits = ((m)->bits & ~LDMS_RAIL_IB_BITS_MSG_ENABLED_MASK) \
+	| (((v))&LDMS_RAIL_IB_BITS_MSG_ENABLED_MASK)
+
+#define LDMS_RAIL_IB_CONN_MSG_N_EPS(m) \
+	( (m)->n_eps_low + ( ((m)->bits & LDMS_RAIL_IB_BITS_HI_N_EPS_MASK) << 4 ) )
+
+#define LDMS_RAIL_IB_CONN_MSG_SET_N_EPS(m, v) do { \
+	(m)->n_eps_low = (v)&0xff; \
+	(m)->bits = ((m)->bits & ~LDMS_RAIL_IB_BITS_HI_N_EPS_MASK) \
+	| (((v)>>4)&LDMS_RAIL_IB_BITS_HI_N_EPS_MASK); \
+} while(0)
+
+#define LDMS_RAIL_IB_CONN_MSG_IDX(m) \
+	( (m)->idx_low + ( ((m)->bits & LDMS_RAIL_IB_BITS_HI_IDX_MASK) << 2 ) )
+
+#define LDMS_RAIL_IB_CONN_MSG_SET_IDX(m, v) do { \
+	(m)->idx_low = (v)&0xff; \
+	(m)->bits = ((m)->bits & ~LDMS_RAIL_IB_BITS_HI_IDX_MASK) \
+	| (((v)>>2)&LDMS_RAIL_IB_BITS_HI_IDX_MASK); \
+} while(0)
+
+#pragma pack(pop)
+
 typedef enum ldms_rail_ep_state_e {
 	LDMS_RAIL_EP_INIT = 0,
 	LDMS_RAIL_EP_LISTENING,

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -3259,10 +3259,9 @@ static void ldms_zap_cb(zap_ep_t zep, zap_event_t ev)
 			zap_reject(zep, rej_msg, strlen(rej_msg)+1);
 			break;
 		}
-		struct ldms_conn_msg2 *m = (void*)ev->data;
 		if (x->event_cb == __rail_cb &&
-				ev->data_len >= sizeof(struct ldms_conn_msg2) &&
-				m->conn_type == htonl(LDMS_CONN_TYPE_RAIL)) { /* rail ep */
+				ev->data_len >= sizeof(struct ldms_conn_msg2)) {
+			/* rail ep */
 			__rail_zap_handle_conn_req(zep, ev);
 		} else {
 			ldms_zap_handle_conn_req(zep);

--- a/ldms/test/minimal/env.sh
+++ b/ldms/test/minimal/env.sh
@@ -1,0 +1,4 @@
+export HOSTNAME
+export LDMS_XPRT=rdma
+export LDMS_PORT=9411
+export LDMS_HOST=blake09-ib0

--- a/ldms/test/minimal/pub.py
+++ b/ldms/test/minimal/pub.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+import os
+
+from ovis_ldms import ldms
+
+HOST = os.environ.get("LDMS_HOST", "localhost")
+PORT = os.environ.get("LDMS_PORT", "9411")
+XPRT = os.environ.get("LDMS_XPRT", "sock")
+
+ldms.init(16*1024*1024)
+x = ldms.Xprt(XPRT, "none")
+x.connect(host=HOST, port=PORT)
+x.msg_publish("foo", "bar")

--- a/ldms/test/minimal/samp.conf
+++ b/ldms/test/minimal/samp.conf
@@ -1,0 +1,7 @@
+msg_enable
+
+listen xprt=${LDMS_XPRT} port=${LDMS_PORT} host=${LDMS_HOST}
+
+load name=meminfo
+config name=meminfo producer=${HOSTNAME} instance=${HOSTNAME}/meminfo
+start name=meminfo interval=1s

--- a/ldms/test/minimal/sub.py
+++ b/ldms/test/minimal/sub.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import os
+import time
+
+from ovis_ldms import ldms
+
+HOST = os.environ.get("LDMS_HOST", "localhost")
+PORT = os.environ.get("LDMS_PORT", "9411")
+XPRT = os.environ.get("LDMS_XPRT", "sock")
+
+ldms.init(16*1024*1024)
+x = ldms.Xprt(XPRT, "none")
+x.connect(host=HOST, port=PORT)
+
+mc = ldms.MsgClient("foo", is_regex=False)
+x.msg_subscribe("foo", is_regex=False)
+
+t = time.time()
+t_fin = t + 5 # 5 sec in the future
+
+while t < t_fin:
+    m = mc.get_data()
+    if m:
+        break
+    time.sleep(0.1)
+    t = time.time()
+
+if m:
+    print(f"data: {m.data}")
+else:
+    raise RuntimeError("no data")

--- a/lib/src/zap/rdma/zap_rdma.c
+++ b/lib/src/zap/rdma/zap_rdma.c
@@ -2797,6 +2797,217 @@ zap_err_t z_rdma_io_thread_ep_release(zap_io_thread_t t, zap_ep_t ep)
 	return 0;
 }
 
+#if 0
+
+/* get link type using rdma_resolve_addr() */
+static enum zap_link_type
+z_rdma_ep_link_type(zap_ep_t ep, struct sockaddr *sa_dst, size_t sa_len)
+{
+	int rc;
+	struct rdma_event_channel *ch;
+	struct rdma_cm_id *cm_id;
+	struct rdma_cm_event *ev;
+	enum zap_link_type lt = ZAP_LINK_ERROR;
+
+	ch = rdma_create_event_channel();
+	if (!ch)
+		goto out;
+	rc = rdma_create_id(ch, &cm_id, NULL, RDMA_PS_TCP);
+	if (rc)
+		goto err_1; /* errno has been set */
+	rc = rdma_resolve_addr(cm_id, NULL, sa_dst, 2000);
+	if (rc)
+		goto err_2;
+	rc = rdma_get_cm_event(ch, &ev); /* blocking */
+	if (rc)
+		goto err_2;
+	if (ev->event == RDMA_CM_EVENT_ADDR_RESOLVED) {
+		switch (ev->id->verbs->device->transport_type) {
+		case IBV_TRANSPORT_IB:
+			lt = ZAP_LINK_RDMA_IB;
+			break;
+		case IBV_TRANSPORT_IWARP:
+			lt = ZAP_LINK_RDMA_IW;
+			break;
+		default:
+			errno = ENOTSUP;
+			break;
+		}
+	} else {
+		errno = ev->status;
+	}
+	rdma_ack_cm_event(ev);
+
+	/* let through for cleaning up */
+ err_2:
+	rdma_destroy_id(cm_id);
+ err_1:
+	rdma_destroy_event_channel(ch);
+ out:
+	return lt;
+}
+
+#else
+/* get link type using Linux rtnetlink (same as `ip route get`)
+ * and /sys/class/infiniband/... */
+
+/* from <net/if.h> */
+extern char *if_indextoname (unsigned int __ifindex, char *__ifname) __THROW;
+
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+
+#include <linux/if_arp.h>
+
+static int z_rdma_ep_iface(zap_ep_t ep,
+			   struct sockaddr *sa_dst, size_t sa_len,
+			   char *out, int out_len)
+{
+	int sd;
+	struct {
+		struct nlmsghdr nl;
+		struct rtmsg    rt;
+		char            buf[512];
+	} req;
+	char reply[4096];
+	int len;
+
+	struct rtattr *rta;
+	union {
+		struct sockaddr sa;
+		struct sockaddr_in sin;
+		struct sockaddr_in6 sin6;
+	} *dst;
+	struct nlmsghdr *nh;
+	int addr_len;
+	char *addr;
+	int rc;
+
+	dst = (void*)sa_dst;
+
+	/* only support AF_INET	and AF_INET6 for now */
+	switch (dst->sa.sa_family) {
+	case AF_INET:
+		addr_len = sizeof(dst->sin.sin_addr.s_addr);
+		addr = (char*)&dst->sin.sin_addr.s_addr;
+		break;
+	case AF_INET6:
+		addr_len = sizeof(dst->sin6.sin6_addr);
+		addr = (char*)&dst->sin6.sin6_addr;
+		break;
+	default:
+		rc = errno = ENOTSUP;
+		goto out;
+	}
+
+	sd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+	if (sd < 0) {
+		rc = errno;
+		goto out;
+	}
+
+	/* make netlink route request */
+	memset(&req, 0, sizeof(req));
+	req.nl.nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg));
+	req.nl.nlmsg_flags = NLM_F_REQUEST;
+	req.nl.nlmsg_type = RTM_GETROUTE;
+	req.rt.rtm_family = sa_dst->sa_family;
+	req.rt.rtm_table = RT_TABLE_MAIN;
+	req.rt.rtm_dst_len = addr_len;
+
+	rta = ((void*)&req) + NLMSG_ALIGN(req.nl.nlmsg_len);
+	rta->rta_type = RTA_DST;
+	rta->rta_len = RTA_LENGTH(addr_len);
+	memcpy(RTA_DATA(rta), addr, addr_len);
+	req.nl.nlmsg_len = NLMSG_ALIGN(req.nl.nlmsg_len) + RTA_ALIGN(rta->rta_len);
+
+	/* submit the request to Linux kernel */
+	len = send(sd, &req, req.nl.nlmsg_len, 0);
+	if (len < req.nl.nlmsg_len) {
+		rc = errno;
+		goto err_1;
+	}
+
+	/* Get the answer back */
+	len = recv(sd, reply, sizeof(reply), 0);
+
+	if (len < 0) {
+		rc = errno;
+		goto err_1;
+	}
+
+	nh = (struct nlmsghdr *)reply;
+
+	rc = ENOENT;
+
+	/* Go through attributes to get the interface */
+	for (; NLMSG_OK(nh, len); nh = NLMSG_NEXT(nh, len)) {
+		struct rtmsg *rt = (struct rtmsg *)NLMSG_DATA(nh);
+		struct rtattr *attr = (struct rtattr *)RTM_RTA(rt);
+		int attr_len = RTM_PAYLOAD(nh);
+
+		for (; RTA_OK(attr, attr_len); attr = RTA_NEXT(attr, attr_len)) {
+			if (attr->rta_type != RTA_OIF)
+				continue;
+			int if_idx = *(int *)RTA_DATA(attr);
+			char if_name[512];
+			if_indextoname(if_idx, if_name);
+			len = snprintf(out, out_len, "%s", if_name);
+			if (len >= out_len) {
+				rc = ENOSPC;
+			} else {
+				rc = 0;
+			}
+			break;
+		}
+	}
+
+	if (rc)
+		errno = rc;
+
+ err_1:
+	close(sd);
+ out:
+	return rc;
+}
+
+static enum zap_link_type
+z_rdma_ep_link_type(zap_ep_t ep, struct sockaddr *sa_dst, size_t sa_len)
+{
+	enum zap_link_type lt = ZAP_LINK_ERROR;
+	int rc, len;
+	int fd;
+	int arp_type;
+	char iface[128];
+	char buf[4096];
+
+	rc = z_rdma_ep_iface(ep, sa_dst, sa_len, iface, sizeof(iface));
+	if (rc)
+		goto out;
+	snprintf(buf, sizeof(buf), "/sys/class/net/%s/type", iface);
+	fd = open(buf, O_RDONLY);
+	if (fd < 0)
+		goto out;
+	len = read(fd, buf, sizeof(buf));
+	close(fd);
+	if (len < 0)
+		goto out;
+	arp_type = atoi(buf);
+	switch (arp_type) {
+	case ARPHRD_INFINIBAND:
+		lt = ZAP_LINK_RDMA_IB;
+		break;
+	case ARPHRD_ETHER:
+		lt = ZAP_LINK_RDMA_IW;
+		break;
+	default:
+		errno = ENOTSUP;
+	}
+ out:
+	return lt;
+}
+#endif
+
 static int init_complete = 0;
 
 static int init_once()
@@ -2865,6 +3076,7 @@ zap_err_t zap_transport_get(zap_t *pz, zap_mem_info_fn_t mem_info_fn)
 	z->io_thread_cancel = z_rdma_io_thread_cancel;
 	z->io_thread_ep_assign = z_rdma_io_thread_ep_assign;
 	z->io_thread_ep_release = z_rdma_io_thread_ep_release;
+	z->ep_link_type = z_rdma_ep_link_type;
 
 	*pz = z;
 	return ZAP_ERR_OK;

--- a/lib/src/zap/zap.c
+++ b/lib/src/zap/zap.c
@@ -356,6 +356,7 @@ zap_t zap_get(const char *name, zap_mem_info_fn_t mem_info_fn)
 
 	pthread_mutex_lock(&zap_list_lock);
 	zent->zap = z;
+	z->type = zent->type;
 	LIST_INSERT_HEAD(&zap_list, z, zap_link);
 	pthread_mutex_unlock(&zap_list_lock);
 
@@ -1127,6 +1128,37 @@ void zap_ep_thread_id_set(zap_ep_t ep, pid_t tid)
 uint64_t zap_ep_sq_sz(zap_ep_t ep)
 {
 	return ep->sq_sz;
+}
+
+static enum zap_link_type
+zap_ep_link_type_default(zap_ep_t ep, struct sockaddr *sa_dst, size_t sa_len)
+{
+	switch (ep->z->type) {
+	case ZAP_SOCK:
+		return ZAP_LINK_SOCK;
+	case ZAP_UGNI:
+		return ZAP_LINK_UGNI;
+	case ZAP_FABRIC:
+		return ZAP_LINK_FABRIC;
+	/* ZAP_RDMA implements ep_link_type() interface */
+	default:
+		errno = EINVAL;
+		return ZAP_LINK_ERROR;
+	}
+}
+
+enum zap_link_type
+zap_ep_link_type(zap_ep_t ep, struct sockaddr *sa_dst, size_t sa_len)
+{
+	/* Note: add zap.ep_link_type() interface in the future if needed. */
+	zap_t z = ep->z;
+	if (!z) {
+		errno = EINVAL;
+		return ZAP_LINK_ERROR;
+	}
+	if (z->ep_link_type)
+		return z->ep_link_type(ep, sa_dst, sa_len);
+	return zap_ep_link_type_default(ep, sa_dst, sa_len);
 }
 
 static int zap_initialized = 0;

--- a/lib/src/zap/zap.h
+++ b/lib/src/zap/zap.h
@@ -102,6 +102,19 @@ enum zap_type {
 	ZAP_LAST,
 };
 
+enum zap_link_type {
+	ZAP_LINK_ERROR = 0x0,
+
+	ZAP_LINK_SOCK = 0x1,
+
+	ZAP_LINK_RDMA_IB = 0x10000,
+	ZAP_LINK_RDMA_IW,
+
+	ZAP_LINK_UGNI = 0x20000,
+
+	ZAP_LINK_FABRIC = 0x30000,
+};
+
 typedef enum zap_event_type {
 	/*! An incoming connect request is ready to be accepted or rejected. */
 	ZAP_EVENT_CONNECT_REQUEST = 1,
@@ -995,5 +1008,16 @@ pid_t zap_ep_thread_id_get(zap_ep_t ep);
  * \return The send queue depth
  */
 uint64_t zap_ep_sq_sz(zap_ep_t ep);
+
+/**
+ * Given \c ep and destination address \c sa_dst, determine the link type.
+ *
+ * \param ep zap endpoint handle
+ * \param sa_dst Address of the destination
+ * \param sa_len The length of \c sa_dst
+ *
+ * \return link_type
+ */
+enum zap_link_type zap_ep_link_type(zap_ep_t ep, struct sockaddr *sa_dst, size_t sa_len);
 
 #endif

--- a/lib/src/zap/zap_priv.h
+++ b/lib/src/zap/zap_priv.h
@@ -195,6 +195,7 @@ struct zap_io_thread_pool_s {
 };
 
 struct zap {
+	enum zap_type type;
 	char name[ZAP_MAX_TRANSPORT_NAME_LEN];
 	int max_msg;		/* max send message size */
 
@@ -350,9 +351,16 @@ struct zap {
 	/** Thread pool handles. */
 	struct zap_io_thread_pool_s _thr_pool[ZAP_IO_THREAD_POOL_MAX];
 
-	/** Number of threads */
-	//int _n_threads;
-
+	/**
+	 * Given \c ep and destination address \c sa_dst, determine the link type.
+	 *
+	 * \param ep zap endpoint handle
+	 * \param sa_dst Address of the destination
+	 * \param sa_len The length of \c sa_dst
+	 *
+	 * \return link_type
+	 */
+	enum zap_link_type (*ep_link_type)(zap_ep_t ep, struct sockaddr *sa_dst, size_t sa_len);
 };
 
 static inline zap_err_t


### PR DESCRIPTION
`rdma_connect()` on Infiniband only supports 56 bytes of private data. With 5 bytes of `zap_rdma` message header, we only have 51 bytes left for LDMS connect data. The new LDMS connect message (Rail) is larger than 51 bytes, breaking the RDMA transport over Infiniband.

Simply reducing the connect message size across all transports will break 4.5.1 LDMS compatibility. To circumvent this, this patch does the following:

1) Add `zap_ep_link_type()` so that LDMS can determine if it is running
   on Infiniband.

   1.1) `zap_ep_link_type()` requires a destination address to determine
        the interface (otherwise, we don't know which interface to use).

   1.2) For RDMA, there are 2 implementations: a) using
        `rdma_resolve_addr()`, b) using Linux Netlink Route request and
	information from /sys/class/net/<DEV>/type. From sniff-testing,
	we don't see any differences in time for both of the methods.
	The one enabled in this patch is b) Linux Netlink Route request.

2) LDMS connect uses existing connect message if the link is not
   Infiniband. If it is an Infiniband, LDMS uses a short message version
   of the connect message.

   2.1) The limitation on the short message version is that the number
        of endpoints in a rail bundle must not exceed 1023.

3) The passive side of LDMS understands both short and normal connect
   message, and can setup the connection accordingly.