### PR TITLE
Fix various bug in the store time statistics

### DIFF
--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1426,13 +1426,14 @@ class LdmsdCmdParser(Cmd.Cmd):
                     stage_stats['stages'][stage] = prdset['stage_stats'][stage]['avg']
                 else:
                     stage_stats['stages']['prep'] = prep
+            stage_stats['count'] = 1
         else:
             stage_stats['count'] += 1
-            for stage in stage_stats['stage']:
+            for stage in stage_stats['stages']:
                 if stage != "prep":
-                    stage_stats[stage] += (prdset['stage_stats'][stage]['avg'] - stage_stats[stage]) * (weight / stage_stats['count'])
+                    stage_stats['stages'][stage] += (prdset['stage_stats'][stage]['avg'] - stage_stats['stages'][stage]) * (weight / stage_stats['count'])
                 else:
-                    stage_stats['prep'] += (prep - stage_stats['prep']) * (weight / stage_stats['count'])
+                    stage_stats['stages']['prep'] += (prep - stage_stats['stages']['prep']) * (weight / stage_stats['count'])
 
         return stage_stats
 
@@ -1636,20 +1637,30 @@ class LdmsdCmdParser(Cmd.Cmd):
             raise
 
         # Schema Table
-        print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
-        print("   <   Minimum Value          -   Minimum Average value")
-        print("   >   Maximum Value          +   Maximum Average value")
-        print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
-        print(f"{' '*4} {'Schema':^20} {'Min (us)':^15} {'Avg (us)':^15} {'Max (us)':^15} {'Min Timestamp':^20} {'Max Timestamp':^20} {'# of Sets':^10} {'Count':^10}")
-        print(f"{'-'*4}-{'-'*20} {'-'*15} {'-'*15} {'-'*15} {'-'*20} {'-'*20} {'-'*10} {'-'*10}")
-        schema_names = sorted(list(schema_tbl['schema'].keys()))
-        for schema in schema_names:
-            stats = schema_tbl['schema'][schema]['stats']
-            if len(stats['set_name']) == 0:
-                continue
-            print(f"{self.__symbols(schema, schema_tbl['stats']):>4}   {schema:>18} {stats['min']:15.4f} {stats['avg']:15.4f} {stats['max']:15.4f} {int(stats['min_ts']):20d} {int(stats['max_ts']):20d} {len(set(stats['set_name'])):10} {stats['count']:10}")
+        if arg['name'] is None:
+            # If 'name' is given, the schema table will report the same number
+            # as the numbers in the storage policy table for each schema.
+            # Thus, omit the table
+            print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
+            print("   <   Minimum Value          -   Minimum Average value")
+            print("   >   Maximum Value          +   Maximum Average value")
+            print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
+            print()
+            print(f"{'Statistics per Set Schema':^137}")
+            print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
+            print(f"{' '*4} {'Schema':^20} {'Min (us)':^15} {'Avg (us)':^15} {'Max (us)':^15} {'Min Timestamp':^20} {'Max Timestamp':^20} {'# of Sets':^10} {'Count':^10}")
+            print(f"{'-'*4}-{'-'*20} {'-'*15} {'-'*15} {'-'*15} {'-'*20} {'-'*20} {'-'*10} {'-'*10}")
+            schema_names = sorted(list(schema_tbl['schema'].keys()))
+            for schema in schema_names:
+                stats = schema_tbl['schema'][schema]['stats']
+                if len(stats['set_name']) == 0:
+                    continue
+                print(f"{self.__symbols(schema, schema_tbl['stats']):>4}   {schema:>18} {stats['min']:15.4f} {stats['avg']:15.4f} {stats['max']:15.4f} {int(stats['min_ts']):20d} {int(stats['max_ts']):20d} {len(set(stats['set_name'])):10} {stats['count']:10}")
+                print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
 
         # Storage policy Table
+        print()
+        print(f"{'Statistics per Storage Policies and Set Schema':^137}")
         print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
         print(f"{' '*4} {'Storage Policy':^20} {'Min (us)':^15} {'Avg (us)':^15} {'Max (us)':^15} {'Min Timestamp':^20} {'Max Timestamp':^20} {'# of Sets':^10} {'Count':^10}")
         print(f"{'-'*4}-{'-'*20} {'-'*15} {'-'*15} {'-'*15} {'-'*20} {'-'*20} {'-'*10} {'-'*10}")
@@ -1659,30 +1670,47 @@ class LdmsdCmdParser(Cmd.Cmd):
             if 0 == len(stats['set_name']):
                 continue
             print(f"{self.__symbols(strgp, strgp_tbl['stats']):>5}  {strgp:18} {stats['min']:15.4f} {stats['avg']:15.4f} {stats['max']:15.4f} {int(stats['min_ts']):20d} {int(stats['max_ts']):20d} {len(set(stats['set_name'])):10} {stats['count']:10}")
+            print(f"   {' '*2}{'-'*20} {'-'*15} {'-'*15} {'-'*15} {'-'*20} {'-'*20} {'-'*10} {'-'*10}")
             schemas = sorted(list(strgp_tbl['strgp'][strgp]['schema'].keys()))
             for schema in schemas:
                 sch_stats = strgp_tbl['strgp'][strgp]['schema'][schema]['stats']
-                if sch_stats['start_ts'] is None:
+                if sch_stats['count'] == 0:
                     continue
-                print(f"   {' '*2}{'-'*20} {'-'*15} {'-'*15} {'-'*15} {'-'*20} {'-'*20} {'-'*10} {'-'*10}")
-                print(f"   {self.__symbols(schema, strgp_tbl['strgp'][strgp]['stats']):>5} {schema:16} {sch_stats['min']:15.4f} {sch_stats['avg']:15.4f} " \
+                print(f"   {self.__symbols(schema, strgp_tbl['strgp'][strgp]['stats']):>5} {schema:>16} {sch_stats['min']:15.4f} {sch_stats['avg']:15.4f} " \
                       f"{sch_stats['max']:15.4f} {int(sch_stats['min_ts']):20d} {int(sch_stats['max_ts']):20d} " \
                       f"{len(set(sch_stats['set_name'])):10} {sch_stats['count']:10}")
-            print(f"{' '*5}  {'-'*18} {'-'*15} {'-'*15} {'-'*15} {'-'*20} {'-'*20} {'-'*10} {'-'*10}")
+            print(f"{' '*5}{'='*20} {'='*15} {'='*15} {'='*15} {'='*20} {'='*20} {'='*10} {'='*10}")
 
         print()
-        print(f"Number of store operations per second: {num_op_per_sec:0.4f}")
-
-        print("Percentages of each stage:", end = "")
+        print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
+        print(f"Number of store operations per second:              {num_op_per_sec:7.2f}")
+        print(f"The averaged duration of each store operation (us): {stage_tbl['total_time']:7.2f}")
+        print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
+        print()
+        print("Breakdown of Storage Operation (Percentage and Average)", end = "")
         if stage_tbl['total_time'] == 0:
             print(" N/A")
             print(" -- No sets have been stored")
         else:
+            def __get_stage_name(n):
+                if n == "queue":
+                    return "in_worker_queue"
+                elif n == "wait":
+                    return "wait_for_worker"
+                elif n == "prep":
+                    return "misc"
+                elif n == "commit":
+                    return "store/commit"
+                elif n == "decomp":
+                    return "decomposition"
+                else:
+                    return n
             print()
             sorted_stages = sorted(stage_tbl['stages'].items(), key=lambda x: x[1], reverse=True)
             for stage, value in sorted_stages:
                 pct = value/stage_tbl['total_time']*100
-                print(f"   {stage:15}: {pct:>7.2f}%")
+                print(f"   {__get_stage_name(stage):16}: {pct:>7.2f}%          {value:>7.2f} us")
+
 
     def complete_store_time_stats(self, text, line, begidx, endidx):
         return self.__complete_attr_list('store_time_stats', text)

--- a/ldms/src/ldmsd/ldmsd_event_strg.c
+++ b/ldms/src/ldmsd/ldmsd_event_strg.c
@@ -112,7 +112,6 @@ extern ovis_log_t store_log;
  */
 struct store_event_ctxt {
 	ldms_set_t snapshot; /* Set Snapshot */
-	ldmsd_strgp_t strgp; /* TODO: Remove this */
 	ldmsd_strgp_ref_t strgp_ref;
 	ldmsd_row_list_t row_list;
 	int row_count;
@@ -162,7 +161,7 @@ struct store_event_ctxt *store_event_ctxt_new(ldmsd_strgp_ref_t strgp_ref, ldms_
 	 */
 	ldms_set_snapshot_get(snapshot, "store_event_ctxt_new");
 	ctxt->snapshot = snapshot;
-	ctxt->strgp = ldmsd_strgp_get(strgp_ref->strgp, "store_event_ctxt_new"); /* TODO: I need to carefully thing about this. It isn't clear to me that taking strgp reference is correct here. */
+	ldmsd_strgp_get(strgp_ref->strgp, "store_event_ctxt_new");
 	ctxt->strgp_ref = strgp_ref;
 	if (strgp_ref->strgp->decomp) {
 		ctxt->type = STORE_T_DECOMP;
@@ -414,6 +413,7 @@ void strg_worker_release(struct strg_worker *w)
 void storage_worker_actor(struct ovis_event_s *ev)
 {
 	int rc;
+	struct timespec start, end;
 	struct store_event_ctxt *event_ctxt = ev->param.ctxt;
 	ldmsd_strgp_ref_t strgp_ref = event_ctxt->strgp_ref;
 	ldmsd_strgp_t strgp = strgp_ref->strgp;
@@ -421,9 +421,12 @@ void storage_worker_actor(struct ovis_event_s *ev)
 	ldmsd_row_list_t row_list = event_ctxt->row_list;
 	int row_count = event_ctxt->row_count;
 	struct ldmsd_stat *queue_stat = &(strgp_ref->store_stages_stat.queue_stat);
+	struct ldmsd_stat *commit_stat = &(strgp_ref->store_stages_stat.commit_stat);
 
-	clock_gettime(CLOCK_REALTIME, &queue_stat->end); /* start is the end timestamp of the event being queued */
+	clock_gettime(CLOCK_REALTIME, &start); /* start is the end timestamp of the event being queued */
+	queue_stat->end = start;
 	ldmsd_stat_update(queue_stat, &event_ctxt->post_ts, &queue_stat->end);
+
 	if (event_ctxt->type == STORE_T_LEGACY) {
 		strgp->store->api->store((ldmsd_plug_handle_t)strgp->store,
 					 strgp->store_handle, set,
@@ -449,11 +452,14 @@ void storage_worker_actor(struct ovis_event_s *ev)
 	}
 	strg_worker_release(event_ctxt->w);
 
-	clock_gettime(CLOCK_REALTIME, &strgp_ref->store_stat.end);
-	strgp_ref->store_stages_stat.commit_stat.end = strgp_ref->store_stat.end;
+	clock_gettime(CLOCK_REALTIME, &end);
+	strgp_ref->store_stat.end = commit_stat->end = end;
 	ldmsd_stat_update(&strgp_ref->store_stages_stat.commit_stat,
-			&queue_stat->end, &strgp_ref->store_stat.end);
-	ldmsd_stat_update(&strgp_ref->store_stat, &event_ctxt->start_ts, &strgp_ref->store_stat.end);
+				&start, &end);
+	/* event_ctxt->start_ts is the very begining in strgp_update_fn() */
+	ldmsd_stat_update(&strgp_ref->store_stat,
+				&event_ctxt->start_ts, &end);
+
 	store_event_ctxt_free(event_ctxt);
 	free(row_list);
 	free(ev);
@@ -475,6 +481,7 @@ int store_event_post(struct store_event_ctxt *ctxt)
 	struct strg_worker *w;
 	ldmsd_strgp_ref_t strgp_ref = ctxt->strgp_ref;
 	struct timespec wait_start, wait_end;
+	struct ldmsd_stat *worker_wait_stat = &(strgp_ref->store_stages_stat.worker_wait_stat);
 
 	ovis_log(store_log, OVIS_LDEBUG, "store_post(%p, %p).\n", ctxt, ctxt->snapshot);
 
@@ -483,7 +490,8 @@ int store_event_post(struct store_event_ctxt *ctxt)
 	w = strg_worker_acquire();
 	ctxt->w = w;
 	clock_gettime(CLOCK_REALTIME, &wait_end);
-	ldmsd_stat_update(&strgp_ref->store_stages_stat.worker_wait_stat, &wait_start, &wait_end);
+	ldmsd_stat_update(worker_wait_stat, &wait_start, &wait_end);
+
 	if (!w) {
 		rc = errno;
 		return rc;
@@ -507,13 +515,15 @@ int store_event_post(struct store_event_ctxt *ctxt)
 	 * Therefore, the order of events posted on a worker is preserved.
 	 */
 	ovis_log(store_log, OVIS_LDEBUG, "Post store_event %p to worker %p\n", ev, w);
-	clock_gettime(CLOCK_REALTIME, &ctxt->post_ts);
 
+	clock_gettime(CLOCK_REALTIME, &ctxt->post_ts);
 	ldmsd_stat_update(&strgp_ref->store_stages_stat.io_thread_stat,
 				  &ctxt->start_ts, &ctxt->post_ts);
-	strgp_ref->store_stages_stat.io_thread_stat.end = ctxt->post_ts;
+
+	/* Enqueue the store event to the storage worker */
 	rc = ovis_scheduler_event_add(w->worker, ev);
 	if (rc) {
+		free(ev);
 		ovis_log(store_log, OVIS_LERROR, "Failed to post a store event " \
 						 "on a storage worker. Error %d\n", rc);
 	}

--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -1904,9 +1904,12 @@ void ldmsd_prdcr_set_stats_reset(ldmsd_prdcr_set_t prdset, struct timespec *now,
 	if (flags & LDMSD_PRDSET_STATS_F_STORE) {
 		LIST_FOREACH(strgp_ref, &prdset->strgp_list, entry) {
 			ldmsd_stat_reset(&strgp_ref->store_stat, now);
-			/* TODO: why don't we reset the store_stages_stat???
-			 * If we should do this, call ldmsd_strgp_ref_stats_init().
-			 */
+			/* Reset each store stage statistics */
+			ldmsd_stat_reset(&strgp_ref->store_stages_stat.commit_stat, now);
+			ldmsd_stat_reset(&strgp_ref->store_stages_stat.decomp_stat, now);
+			ldmsd_stat_reset(&strgp_ref->store_stages_stat.io_thread_stat, now);
+			ldmsd_stat_reset(&strgp_ref->store_stages_stat.queue_stat, now);
+			ldmsd_stat_reset(&strgp_ref->store_stages_stat.worker_wait_stat, now);
 		}
 	}
 
@@ -1914,22 +1917,4 @@ void ldmsd_prdcr_set_stats_reset(ldmsd_prdcr_set_t prdset, struct timespec *now,
 		ldmsd_stat_reset(&prdset->updt_stat, now);
 		prdset->oversampled_cnt = prdset->skipped_upd_cnt = 0;
 	}
-}
-
-void ldmsd_strgp_ref_stats_init(ldmsd_strgp_ref_t strgp_ref, struct timespec *ts)
-{
-	struct timespec start;
-
-	if (ts == NULL) {
-		clock_gettime(CLOCK_REALTIME, &start);
-	} else {
-		start = *ts;
-	}
-	strgp_ref->store_stat.start = start;
-
-	strgp_ref->store_stages_stat.io_thread_stat.start = start;
-	strgp_ref->store_stages_stat.decomp_stat.start = start;
-	strgp_ref->store_stages_stat.worker_wait_stat.start = start;
-	strgp_ref->store_stages_stat.queue_stat.start = start;
-	strgp_ref->store_stages_stat.commit_stat.start = start;
 }

--- a/ldms/src/ldmsd/ldmsd_strgp.c
+++ b/ldms/src/ldmsd/ldmsd_strgp.c
@@ -181,8 +181,26 @@ extern struct store_event_ctxt *store_event_ctxt_new(ldmsd_strgp_ref_t strgp_ref
                                                      ldmsd_row_list_t row_list, int row_count,
                                                      struct timespec start
 );
+
 extern int store_event_post(struct store_event_ctxt *ctxt);
-extern void ldmsd_strgp_ref_stats_init(ldmsd_strgp_ref_t strgp_ref, struct timespec *ts);
+
+void ldmsd_strgp_ref_stats_init(ldmsd_strgp_ref_t strgp_ref, struct timespec *ts)
+{
+	struct timespec start;
+
+	if (ts == NULL) {
+		clock_gettime(CLOCK_REALTIME, &start);
+	} else {
+		start = *ts;
+	}
+	strgp_ref->store_stat.start = start;
+
+	strgp_ref->store_stages_stat.io_thread_stat.start = start;
+	strgp_ref->store_stages_stat.decomp_stat.start = start;
+	strgp_ref->store_stages_stat.worker_wait_stat.start = start;
+	strgp_ref->store_stages_stat.queue_stat.start = start;
+	strgp_ref->store_stages_stat.commit_stat.start = start;
+}
 
 /* protected by strgp lock */
 static void strgp_update_fn(ldmsd_strgp_t strgp, ldmsd_prdcr_set_t prd_set, ldms_set_t set_snapshot, void *ctxt)
@@ -194,9 +212,11 @@ static void strgp_update_fn(ldmsd_strgp_t strgp, ldmsd_prdcr_set_t prd_set, ldms
 	struct store_event_ctxt *event_ctxt;
 	int row_count;
 	int rc;
-	struct timespec start, end;
-	struct ldmsd_stat *decomp_stat;
 	ldmsd_strgp_ref_t strgp_ref = (ldmsd_strgp_ref_t)ctxt;
+
+	struct timespec start, end, ts;
+	struct ldmsd_stat *decomp_stat;
+	struct ldmsd_stat *io_thread_stat = &(strgp_ref->store_stages_stat.io_thread_stat);
 
 	clock_gettime(CLOCK_REALTIME, &start);
 	if (strgp_ref->store_stat.start.tv_sec == 0) {
@@ -205,45 +225,61 @@ static void strgp_update_fn(ldmsd_strgp_t strgp, ldmsd_prdcr_set_t prd_set, ldms
 	}
 
 	if (strgp->decomp_path) {
+		decomp_stat = &(strgp_ref->store_stages_stat.decomp_stat);
+
 		if (!strgp->decomp) {
 			strgp->state = LDMSD_STRGP_STATE_STOPPED;
-			goto free;
+			goto end_decomp;
 		}
 		row_list = malloc(sizeof(*row_list));
 		if (!row_list) {
 			ovis_log(store_log, OVIS_LCRIT, "Memory allocation failure.\n");
-			goto free;
+			goto end_decomp;
 		}
 		TAILQ_INIT(row_list);
 		rc = strgp->decomp->decompose(strgp, set_snapshot, row_list, &row_count, &strgp_ref->decomp_ctxt);
 		if (rc) {
 			ovis_log(store_log, OVIS_LERROR, "strgp decompose error: %d\n", rc);
-			goto free;
+			goto end_decomp;
 		}
-		decomp_stat = &(strgp_ref->store_stages_stat.decomp_stat);
-		clock_gettime(CLOCK_REALTIME, &decomp_stat->end);
-		ldmsd_stat_update(&strgp_ref->store_stages_stat.decomp_stat, &start, &decomp_stat->end);
+
 		if (TAILQ_EMPTY(row_list)) {
-			goto free;
+			goto end_decomp;
+		}
+
+	end_decomp:
+		clock_gettime(CLOCK_REALTIME, &ts);
+		ldmsd_stat_update(decomp_stat, &start, &ts);
+
+		if (!strgp->decomp || !row_list || rc || TAILQ_EMPTY(row_list)) {
+			/* Handle any errors in this decomp path */
+			goto err;
 		}
 	} else {
 		if (!strgp->store_handle) {
 			strgp->state = LDMSD_STRGP_STATE_STOPPED;
-			goto free;
+			goto err;
 		}
 	}
 
 	event_ctxt = store_event_ctxt_new(strgp_ref, set_snapshot, prd_set, row_list, row_count, start);
 	if (!event_ctxt) {
 		ovis_log(store_log, OVIS_LCRIT, "Memory allocation failure.\n");
-		goto free;
+		goto err;
 	}
-	(void) store_event_post(event_ctxt);
+
+	rc = store_event_post(event_ctxt);
+	if (rc)
+		goto err;
 	return;
 
-free:
+err:
 	free(row_list);
+
 	clock_gettime(CLOCK_REALTIME, &end);
+	io_thread_stat->end = end;
+	ldmsd_stat_update(io_thread_stat, &start, &end);
+
 	strgp_ref->store_stat.end = end;
 	ldmsd_stat_update(&strgp_ref->store_stat, &start, &end);
 	return;


### PR DESCRIPTION
The patch fixes the following bugs:

 - Bugs in calculating the store time statistics when an error occurs in strgp_update_fn(), including failing to post storage events to a storage worker queue
 - Bugs in the logic that calculate and report the statistics for each schema per storage policies
 - Show averaged value of each stage in the breakdown section besides the percentages as percentages can be misleading. A motivation is that the commit percentage reduces overtime and the percentage of storage events in the queue increases. At the first glance, this could make reader think that ldmsd has spent more time in idling in worker queues. However, the averaged values of each stage reduce after the inital phase of storing. ldmsd takes less time in the commit procedure than when it initially starts. The averaged values compliment the percentages