### PR TITLE
Fix `dispatch-container-bake` not being triggered

### DIFF
--- a/.github/workflows/dispatch-container-bake.yaml
+++ b/.github/workflows/dispatch-container-bake.yaml
@@ -3,6 +3,9 @@ name: Dispatch Container Bake
 on:
   release:
     types: [ released ]
+  workflow_run:
+    workflows: [ "Create Release" ]
+    types: [ completed ]
 
 jobs:
   dispatch-container-bake:


### PR DESCRIPTION
Github forbids a workflow to trigger another workflow to prevent infinite workflow triger loop. Hence, the release produced by "Create Release" workflow does not trigger "Dispatch Container Bake" workflow.

This patch adds "workflow_run" event to "Dispatch Contaeinr Bake" workflow so that Github run this workflow after "Create Release" completion. This should now cover both manual release via web interface and workflow-triggered release via tag creation.