### PR TITLE
Fix dstat clock tick option documentation.

### DIFF
--- a/ldms/src/sampler/dstat/ldms-sampler_dstat.rst
+++ b/ldms/src/sampler/dstat/ldms-sampler_dstat.rst
@@ -29,7 +29,7 @@ CONFIGURATION ATTRIBUTE SYNTAX
 
 **config**
    | name=<plugin_name> component_id=<comp_id> [io=<bool>] [stat=<bool>]
-     [statm=<bool>] [mmalloc=<bool>] [fd=<bool>] [fdtypes=<bool>]
+     [sc_clk_tck=<bool>] [statm=<bool>] [mmalloc=<bool>] [fd=<bool>] [fdtypes=<bool>]
      set=<set_name>
    | configuration line
 
@@ -72,7 +72,7 @@ CONFIGURATION ATTRIBUTE SYNTAX
       |
       | Include the metrics from /proc/self/stat.
 
-   tick=<bool>
+   sc_clk_tck=<bool>
       |
       | Include the sc_clk_tck from :ref:`sysconf(3) <sysconf>` as a metric.
 


### PR DESCRIPTION
There existed an issue in the documentation where the option for enabling clock tick was said to be `tick=<bool>` when it should have been `sc_clk_tck=<bool>`. The option was also not included in the `CONFIGURATION ATTRIBUTE SYNTAX`  top section in `config` for the basic quick-reference configuration options.