### PR TITLE
Add check for InfiniBand interface link layer

### DIFF
--- a/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
+++ b/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
@@ -459,6 +459,11 @@ static void metrics_tree_refresh()
 				continue;
 			}
 
+			if (ca.ports[j]->link_layer == NULL || ca.ports[j]->link_layer[0] != 'I') {
+				ovis_log(mylog, OVIS_LDEBUG, " metric_tree_refresh() skipping non-InfiniBand link-layer ca %s port %d\n", 
+					ca.ports[j]->ca_name, ca.ports[j]->portnum);
+			}
+
 			snprintf(instance, sizeof(instance), "%s/%s.%d",
 				 conf.producer_name,
 				 ca.ports[j]->ca_name,

--- a/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
+++ b/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
@@ -462,6 +462,7 @@ static void metrics_tree_refresh()
 			if (ca.ports[j]->link_layer == NULL || ca.ports[j]->link_layer[0] != 'I') {
 				ovis_log(mylog, OVIS_LDEBUG, " metric_tree_refresh() skipping non-InfiniBand link-layer ca %s port %d\n", 
 					ca.ports[j]->ca_name, ca.ports[j]->portnum);
+				continue;
 			}
 
 			snprintf(instance, sizeof(instance), "%s/%s.%d",


### PR DESCRIPTION
**\*\*NOTE\*\*:** These code changes have not been tested and therefore should not be merged unless properly reviewed and tested. 

Per issue [#2315](https://github.com/ovis-hpc/ldms/issues/2315) this is a proposed fix. We check to make sure the link layer of the interface to be sampled is configured to InfiniBand or else skip with a debug log message noting as such.

I modeled the check off of the one directly previous in code that checks if the port is active, and only check the first character of the string for the sake of operational efficiency. To my limited knowledge the only value that would appear that starts with 'I' is "InfiniBand."