### PR TITLE
Fix ldms set delete

### DIFF
--- a/ldms/python/ldms.pxd
+++ b/ldms/python/ldms.pxd
@@ -955,6 +955,7 @@ cdef extern from "ldms.h" nogil:
     char *ldms_msg_client_stats_str()
 
     void ldms_set_ref_dump(ldms_set_t set, const char *name, FILE *f)
+    void ldms_set_deleting_dump(FILE *f)
 
 cdef extern from "ldms_msg_chan.h":
     cdef enum ldms_msg_chan_state_e:

--- a/ldms/python/ldms.pxd
+++ b/ldms/python/ldms.pxd
@@ -954,6 +954,8 @@ cdef extern from "ldms.h" nogil:
     char *ldms_msg_client_stats_tq_to_str(ldms_msg_client_stats_tq_s *tq)
     char *ldms_msg_client_stats_str()
 
+    void ldms_set_ref_dump(ldms_set_t set, const char *name, FILE *f)
+
 cdef extern from "ldms_msg_chan.h":
     cdef enum ldms_msg_chan_state_e:
         LDMS_MSG_CHAN_DISCONNECTED

--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -51,6 +51,7 @@ from cpython cimport PyObject, Py_INCREF, Py_DECREF, PyGILState_Ensure, \
 
 from libc.stdint cimport *
 from libc.stdlib cimport calloc, malloc, free, realloc
+from libc.stdio cimport *
 from posix.unistd cimport geteuid, getegid
 from collections import namedtuple
 import datetime as dt
@@ -3461,6 +3462,11 @@ cdef class Set(object):
         rc = ldms_xprt_cancel_push(self.rbd)
         if rc: # synchronous error
             raise RuntimeError(f"ldms_xprt_cancel_push() error: {rc}")
+
+    def ref_dump(self):
+        b = BYTES(self.name)
+        cdef char *name = b
+        ldms_set_ref_dump(self.rbd, name, stdout)
 
 cdef void __xprt_free_cb(void* p) with gil:
     cdef Xprt x = <Xprt>p

--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -5141,3 +5141,7 @@ def msg_enable():
 def msg_is_enabled():
     """Return True if the LDMS Message Service is enabled"""
     return ldms_msg_is_enabled()
+
+def set_deleting_dump():
+    """(DEBUG) Dump sets in the set deleting list to stdout"""
+    ldms_set_deleting_dump(stdout)

--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -230,10 +230,35 @@ static struct rbt __id_tree = {
 
 static pthread_mutex_t __set_tree_lock = PTHREAD_MUTEX_INITIALIZER;
 
+static int del_comparator(void *a, const void *b)
+{
+	const struct ldms_set_del_key *_a = a;
+	const struct ldms_set_del_key *_b = b;
+
+	if (_a->time > _b->time)
+		return 1;
+	if (_a->time < _b->time)
+		return -1;
+	if (_a->gn > _b->gn)
+		return 1;
+	if (_a->gn < _b->gn)
+		return -1;
+	return 0;
+}
+
+static uint64_t __del_gn = 0;
+
 static struct rbt __del_tree = {
 	.root = NULL,
-	.comparator = id_comparator
-};
+	.comparator = del_comparator
+}; /* protected by __del_tree_lock*/
+
+static int del_set_count = 0;
+
+/* Also protected by __del_tree_lock */
+#ifdef LDMS_SET_DEBUG
+static LIST_HEAD(, ldms_set) del_set_list = LIST_HEAD_INITIALIZER(&del_set_list);
+#endif
 
 int ldms_set_count()
 {
@@ -242,10 +267,10 @@ int ldms_set_count()
 
 int ldms_set_deleting_count()
 {
-	return __del_tree.card;
+	return del_set_count;
 }
 
-static pthread_mutex_t __del_tree_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t __del_tree_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
 void __ldms_gn_inc(struct ldms_set *set, ldms_mdesc_t desc)
 {
@@ -927,8 +952,19 @@ static void __destroy_set_no_lock(void *v)
 	struct ldms_set *set = v;
 	struct ldms_xprt *x = set->xprt;
 	struct ldms_context *ctxt;
+	struct ldms_lookup_peer *lp;
+	struct ldms_push_peer *pp;
+	struct rbn *rbn;
 
 	SETDEBUG("set: %p\n", set);
+
+	__sync_fetch_and_add(&del_set_count, -1, __ATOMIC_SEQ_CST);
+
+#ifdef LDMS_SET_DEBUG
+	pthread_mutex_lock(&__del_tree_lock);
+	LIST_REMOVE(set, del_entry);
+	pthread_mutex_unlock(&__del_tree_lock);
+#endif
 
 	if (x) {
 		/*
@@ -952,8 +988,6 @@ static void __destroy_set_no_lock(void *v)
 					ctxt->req_notify.s = NULL;
 				break;
 			case LDMS_CONTEXT_SET_DELETE:
-				if (ctxt->set_delete.s == set)
-					ctxt->set_delete.s = NULL;
 				break;
 			default:
 				break;
@@ -962,7 +996,70 @@ static void __destroy_set_no_lock(void *v)
 		pthread_mutex_unlock(&x->lock);
 	}
 
-	rbt_del(&__del_tree, &set->del_node);
+	/* no need to lock the set; no one has a reference to us */
+	while ((rbn = rbt_min(&set->push_coll))) {
+		pp = container_of(rbn, struct ldms_push_peer, rbn);
+		if (!pp->xprt)
+			goto free_pp;
+		x = pp->xprt;
+		pthread_mutex_lock(&x->lock);
+		TAILQ_FOREACH(ctxt, &x->ctxt_list, link) {
+			switch (ctxt->type) {
+				case LDMS_CONTEXT_LOOKUP_READ:
+					if (ctxt->lu_read.s == set)
+						ctxt->lu_read.s = NULL;
+					break;
+				case LDMS_CONTEXT_UPDATE:
+				case LDMS_CONTEXT_UPDATE_META:
+					if (ctxt->update.s == set)
+						ctxt->update.s = NULL;
+					break;
+				case LDMS_CONTEXT_REQ_NOTIFY:
+					if (ctxt->req_notify.s == set)
+						ctxt->req_notify.s = NULL;
+					break;
+				default:
+					break;
+			}
+		}
+		pthread_mutex_unlock(&x->lock);
+		ldms_xprt_put(x, "push_peer");
+	free_pp:
+		free(pp);
+	}
+
+	while ((rbn = rbt_min(&set->lookup_coll))) {
+		rbt_del(&set->lookup_coll, rbn);
+		lp = container_of(rbn, struct ldms_lookup_peer, rbn);
+		if (!lp->xprt)
+			goto free_lp;
+		x = lp->xprt;
+		pthread_mutex_lock(&x->lock);
+		TAILQ_FOREACH(ctxt, &x->ctxt_list, link) {
+			switch (ctxt->type) {
+				case LDMS_CONTEXT_LOOKUP_READ:
+					if (ctxt->lu_read.s == set)
+						ctxt->lu_read.s = NULL;
+					break;
+				case LDMS_CONTEXT_UPDATE:
+				case LDMS_CONTEXT_UPDATE_META:
+					if (ctxt->update.s == set)
+						ctxt->update.s = NULL;
+					break;
+				case LDMS_CONTEXT_REQ_NOTIFY:
+					if (ctxt->req_notify.s == set)
+						ctxt->req_notify.s = NULL;
+					break;
+				default:
+					break;
+			}
+		}
+		pthread_mutex_unlock(&x->lock);
+		ldms_xprt_put(x, "lookup_peer");
+	free_lp:
+		free(lp);
+	}
+
 	mm_free(set->meta);
 	__ldms_set_info_delete(&set->local_info);
 	__ldms_set_info_delete(&set->remote_info);
@@ -975,9 +1072,7 @@ static void __destroy_set_no_lock(void *v)
 static void __destroy_set(void *v)
 {
 	SETDEBUG("set: %p\n", v);
-	pthread_mutex_lock(&__del_tree_lock);
 	__destroy_set_no_lock(v);
-	pthread_mutex_unlock(&__del_tree_lock);
 }
 
 void __ldms_set_delete(ldms_set_t s, int notify)
@@ -1003,15 +1098,14 @@ void __ldms_set_delete(ldms_set_t s, int notify)
 
 	SETDEBUG("set: %p proceed ...\n", s);
 
-	/* NOTE: We will clean up the push and lookup collections
-	 *       when we destroy the set. While we wait for the
-	 *       SET_DELETE replies from the peers, we iterate
-	 *       through the collections to check if there are any peers
-	 *       that are connected or not.
-	 *
-	 *       If no peers are connected, the set will be destroyed
-	 *       regardless of its reference count. See delete_proc().
-	 */
+	__sync_add_and_fetch(&del_set_count, 1, __ATOMIC_SEQ_CST);
+
+#ifdef LDMS_SET_DEBUG
+	pthread_mutex_lock(&__del_tree_lock);
+	LIST_INSERT_HEAD(&del_set_list, s, del_entry);
+	pthread_mutex_unlock(&__del_tree_lock);
+#endif
+
 	pthread_mutex_lock(&s->lock);
 	x = s->xprt;
 	s->xprt = NULL;
@@ -1019,16 +1113,16 @@ void __ldms_set_delete(ldms_set_t s, int notify)
 	if (x)
 		ldms_xprt_put(x, "lu_set");
 
-	SETDEBUG("set: %p inserting into __del_tree\n", s);
-	/* Add the set to the delete tree with the current timestamp */
 	s->del_time = time(NULL);
-	rbn_init(&s->del_node, &s->del_time);
-	pthread_mutex_lock(&__del_tree_lock);
-	rbt_ins(&__del_tree, &s->del_node);
-	pthread_mutex_unlock(&__del_tree_lock);
 
 	if (notify) {
-		/* Notify downstream transports about the set deletion. */
+		/* Notify downstream transports about the set deletion.
+		 * Each SET_DELETE notification has __del_tree_ent associated
+		 * with it. Think of __del_tree_ent as TIMED SET REF -- a set
+		 * reference that will be dropped on either delete timeout (see
+		 * ldms.c:delete_proc()) or when peer acknowledge SET_DELETE
+		 * (see ldms_xprt.c:__set_delete_cb()).
+		 */
 		__ldms_dir_del_set(s);
 	}
 
@@ -1838,7 +1932,6 @@ ldms_set_t ldms_set_create(const char *instance_name,
 	/* value_off is the offset from the beginning of data header */
 	value_off = roundup(sizeof(*data_base), 8);
 	metric_idx = 0;
-	size_t vd_size = 0;
 	STAILQ_FOREACH(md, &schema->metric_list, entry) {
 		/* Add descriptor to dictionary */
 		meta->dict[metric_idx] = __cpu_to_le32(ldms_off_(meta, vd));
@@ -1852,7 +1945,6 @@ ldms_set_t ldms_set_create(const char *instance_name,
 		/* Advance to next descriptor */
 		metric_idx++;
 		vd = (struct ldms_value_desc *)((char *)vd + md->meta_sz);
-		vd_size += md->meta_sz;
 	}
 
 	/*
@@ -4139,19 +4231,79 @@ int ldms_mval_parse_scalar(ldms_mval_t v, enum ldms_value_type vt, const char *s
 	return 0;
 }
 
+__del_tree_ent_t __del_tree_ent_alloc(ldms_set_t set, uint64_t del_time)
+{
+	__del_tree_ent_t ent;
+	ent = malloc(sizeof(*ent));
+	if (!ent)
+		return NULL;
+	ref_get(&set->ref, "__del_tree_ent");
+	ent->set = set;
+	ent->del.time = del_time;
+	ent->del.gn = __atomic_fetch_add(&__del_gn, 1, __ATOMIC_SEQ_CST);
+	rbn_init(&ent->rbn, &ent->del);
+	ent->in_tree = 0; /* for debugging */
+	SETDEBUG("del_ent alloc: (%lu, %lu)\n", ent->del.time, ent->del.gn);
+	return ent;
+}
+
+void __del_tree_ent_free(__del_tree_ent_t ent)
+{
+	SETDEBUG("del_ent free: (%lu, %lu)\n", ent->del.time, ent->del.gn);
+	assert(0 == ent->in_tree);
+	ref_put(&ent->set->ref, "__del_tree_ent");
+	free(ent);
+}
+
+void __del_tree_ent_ins(__del_tree_ent_t ent)
+{
+	SETDEBUG("del_ent ins: (%lu, %lu)\n", ent->del.time, ent->del.gn);
+	assert(0 == ent->in_tree);
+	pthread_mutex_lock(&__del_tree_lock);
+	ent->in_tree = 1;
+	rbt_ins(&__del_tree, &ent->rbn);
+	pthread_mutex_unlock(&__del_tree_lock);
+}
+
+void __del_tree_ent_del_nolock(__del_tree_ent_t ent)
+{
+	SETDEBUG("del_ent del: (%lu, %lu)\n", ent->del.time, ent->del.gn);
+	assert(1 == ent->in_tree);
+	ent->in_tree = 0;
+	rbt_del(&__del_tree, &ent->rbn);
+}
+
+__del_tree_ent_t __del_tree_ent_rm(struct ldms_set_del_key *key)
+{
+	__del_tree_ent_t ent;
+	struct rbn *rbn;
+	pthread_mutex_lock(&__del_tree_lock);
+	rbn = rbt_find(&__del_tree, key);
+	if (!rbn) {
+		errno = ENOENT;
+		ent = NULL;
+	} else {
+		ent = container_of(rbn, struct __del_tree_ent_s, rbn);
+		__del_tree_ent_del_nolock(ent);
+	}
+	pthread_mutex_unlock(&__del_tree_lock);
+	return ent;
+}
+
+#ifndef LDMS_SET_DEBUG
 #define DELETE_TIMEOUT	(60)	/* 1 minute */
 #define DELETE_CHECK	(15)
+#else
+#define DELETE_TIMEOUT	(5)	/* 5 sec; make it quick for debugging */
+#define DELETE_CHECK	(5)
+#endif
 
 extern int ldms_xprt_connected(struct ldms_xprt *x);
 static void *delete_proc(void *arg)
 {
-	struct rbn *rbn, *prev_rbn, *xrbn;
-	struct ldms_set *set;
-	struct ldms_lookup_peer *lp;
-	struct ldms_push_peer *pp;
+	struct rbn *rbn;
 	time_t dur;
-	ldms_t x;
-	struct ldms_context *ctxt;
+	__del_tree_ent_t del_ent;
 	char *to = getenv("LDMS_DELETE_TIMEOUT");
 	int timeout = (to ? atoi(to) : DELETE_TIMEOUT);
 	if (timeout <= DELETE_CHECK)
@@ -4160,139 +4312,18 @@ static void *delete_proc(void *arg)
 	do {
 		/*
 		 * Iterate through the tree from oldest to
-		 * newest. Delete any set older than the threshold
+		 * newest. Drop any DEL ENTRY older than the threshold.
 		 */
 		pthread_mutex_lock(&__del_tree_lock);
-		rbn = rbt_max(&__del_tree);
-		while (rbn) {
-			prev_rbn = rbn_pred(rbn);
-			set = container_of(rbn, struct ldms_set, del_node);
-			dur = time(NULL) - set->del_time;
+		while ((rbn = rbt_min(&__del_tree))) {
+			del_ent = container_of(rbn, struct __del_tree_ent_s, rbn);
+			dur = time(NULL) - del_ent->del.time;
 			if (dur < timeout)
 				break;
-
-			/*
-			 * Look for a connected push/lookup peer.
-			 * If there is a connected peer, we skip the set
-			 * and wait for the SET_DELETE reply from the connected peers.
-			 *
-			 * This prevents the race between the SET_DELETE timeout
-			 * and the SET_DELETE reply.
-			 */
-			pthread_mutex_lock(&set->lock);
-			xrbn = rbt_min(&set->lookup_coll);
-			while (xrbn) {
-				lp = container_of(xrbn, struct ldms_lookup_peer, rbn);
-				if (ldms_xprt_connected(lp->xprt)) {
-					/*
-					 * A push peer is connected... skip the set.
-					 */
-					pthread_mutex_unlock(&set->lock);
-					goto next;
-				}
-				xrbn = rbn_succ(xrbn);
-			}
-			xrbn = rbt_min(&set->push_coll);
-			while (xrbn) {
-				pp = container_of(xrbn, struct ldms_push_peer, rbn);
-				if (ldms_xprt_connected(pp->xprt)) {
-					/*
-					 * A lookup peer is connected ... skip the set.
-					 */
-					pthread_mutex_unlock(&set->lock);
-					goto next;
-				}
-			}
-			pthread_mutex_unlock(&set->lock);
-
-			/*
-			 * Since all peers have disconnected, the push and lookup
-			 * collections should be empty at this point.
-			 *
-			 * Below logic is for a corner case and makes sure
-			 * that we are not leaking and leaving the transport dangling.
-			 */
-			/* Clean up the push peer collection */
-			while ((rbn = rbt_min(&set->push_coll))) {
-				rbt_del(&set->push_coll, rbn);
-				pp = container_of(rbn, struct ldms_push_peer, rbn);
-				if (!pp->xprt)
-					goto free_pp;
-				x = pp->xprt;
-				pthread_mutex_lock(&x->lock);
-				TAILQ_FOREACH(ctxt, &x->ctxt_list, link) {
-					switch (ctxt->type) {
-					case LDMS_CONTEXT_LOOKUP_READ:
-						if (ctxt->lu_read.s == set)
-							ctxt->lu_read.s = NULL;
-						break;
-					case LDMS_CONTEXT_UPDATE:
-					case LDMS_CONTEXT_UPDATE_META:
-						if (ctxt->update.s == set)
-							ctxt->update.s = NULL;
-						break;
-					case LDMS_CONTEXT_REQ_NOTIFY:
-						if (ctxt->req_notify.s == set)
-							ctxt->req_notify.s = NULL;
-						break;
-					case LDMS_CONTEXT_SET_DELETE:
-						if (ctxt->set_delete.s == set)
-							ctxt->set_delete.s = NULL;
-						break;
-					default:
-						break;
-					}
-				}
-				pthread_mutex_unlock(&x->lock);
-				ldms_xprt_put(x, "push_peer");
-			free_pp:
-				free(pp);
-			}
-
-			/*
-			 * Clean up the lookup peer collection and
-			 * remove set from the transport's set collection.
-			 */
-			while ((rbn = rbt_min(&set->lookup_coll))) {
-				rbt_del(&set->lookup_coll, rbn);
-				lp = container_of(rbn, struct ldms_lookup_peer, rbn);
-				if (!lp->xprt)
-					goto free_lp;
-				x = lp->xprt;
-				pthread_mutex_lock(&x->lock);
-				TAILQ_FOREACH(ctxt, &x->ctxt_list, link) {
-					switch (ctxt->type) {
-					case LDMS_CONTEXT_LOOKUP_READ:
-						if (ctxt->lu_read.s == set)
-							ctxt->lu_read.s = NULL;
-						break;
-					case LDMS_CONTEXT_UPDATE:
-					case LDMS_CONTEXT_UPDATE_META:
-						if (ctxt->update.s == set)
-							ctxt->update.s = NULL;
-						break;
-					case LDMS_CONTEXT_REQ_NOTIFY:
-						if (ctxt->req_notify.s == set)
-							ctxt->req_notify.s = NULL;
-						break;
-					case LDMS_CONTEXT_SET_DELETE:
-						if (ctxt->set_delete.s == set)
-							ctxt->set_delete.s = NULL;
-						break;
-					default:
-						break;
-					}
-				}
-				pthread_mutex_unlock(&x->lock);
-				ldms_xprt_put(x, "lookup_peer");
-			free_lp:
-				free(lp);
-			}
-
-			__destroy_set_no_lock(set);
-		next:
-			rbn = prev_rbn;
-			fflush(stderr);
+			SETDEBUG("dur: %lu\n", dur);
+			SETDEBUG("timeout: %d\n", timeout);
+			__del_tree_ent_del_nolock(del_ent);
+			__del_tree_ent_free(del_ent);
 		}
 		pthread_mutex_unlock(&__del_tree_lock);
 		sleep(DELETE_CHECK);
@@ -6299,4 +6330,22 @@ const char *ldms_msg_event_type_sym(enum ldms_msg_event_type t)
 void ldms_set_ref_dump(ldms_set_t set, const char *name, FILE *f)
 {
 	ref_dump(&set->ref, name, f);
+}
+
+void ldms_set_deleting_dump(FILE *f)
+{
+#ifdef LDMS_SET_DEBUG
+	ldms_set_t set;
+	if (!f)
+		f = stdout;
+	pthread_mutex_lock(&__del_tree_lock);
+	fprintf(f, "-------- ldms_set_deleting_dump BEGIN --------\n");
+	LIST_FOREACH(set, &del_set_list, del_entry) {
+		ldms_set_ref_dump(set, ldms_set_instance_name_get(set), f);
+	}
+	fprintf(f, "-------- ldms_set_deleting_dump END --------\n");
+	pthread_mutex_unlock(&__del_tree_lock);
+#else
+	fprintf(f, "ERROR: ldms library does not compile with -DLDMS_SET_DEBUG\n");
+#endif
 }

--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -927,6 +927,9 @@ static void __destroy_set_no_lock(void *v)
 	struct ldms_set *set = v;
 	struct ldms_xprt *x = set->xprt;
 	struct ldms_context *ctxt;
+
+	SETDEBUG("set: %p\n", set);
+
 	if (x) {
 		/*
 		 * Check if there any transports referencing this set
@@ -971,6 +974,7 @@ static void __destroy_set_no_lock(void *v)
 
 static void __destroy_set(void *v)
 {
+	SETDEBUG("set: %p\n", v);
 	pthread_mutex_lock(&__del_tree_lock);
 	__destroy_set_no_lock(v);
 	pthread_mutex_unlock(&__del_tree_lock);
@@ -980,6 +984,8 @@ void __ldms_set_delete(ldms_set_t s, int notify)
 {
 	ldms_t x;
 	struct ldms_set *__set;
+
+	SETDEBUG("set: %p\n", s);
 
 	__ldms_set_tree_lock();
 	__set = __ldms_set_by_id(s->set_id);
@@ -994,6 +1000,8 @@ void __ldms_set_delete(ldms_set_t s, int notify)
 	rbt_del(&__set_tree, &s->rb_node);
 	rbt_del(&__id_tree, &s->id_node);
 	__ldms_set_tree_unlock();
+
+	SETDEBUG("set: %p proceed ...\n", s);
 
 	/* NOTE: We will clean up the push and lookup collections
 	 *       when we destroy the set. While we wait for the
@@ -1011,6 +1019,7 @@ void __ldms_set_delete(ldms_set_t s, int notify)
 	if (x)
 		ldms_xprt_put(x, "lu_set");
 
+	SETDEBUG("set: %p inserting into __del_tree\n", s);
 	/* Add the set to the delete tree with the current timestamp */
 	s->del_time = time(NULL);
 	rbn_init(&s->del_node, &s->del_time);
@@ -1907,6 +1916,8 @@ ldms_set_t ldms_set_create(const char *instance_name,
 				&((uint8_t *)set->data)[schema->data_sz]);
 	}
 	__init_rec_array(set, schema);
+	SETDEBUG("set: %p\n", set);
+	SETDEBUG("set->ref.free_fn: %p\n", set->ref.free_fn);
 	return set;
 }
 
@@ -6283,4 +6294,9 @@ const char *ldms_msg_event_type_sym(enum ldms_msg_event_type t)
 	if (t < sizeof(tbl) / sizeof(tbl[0]))
 		return tbl[t];
 	assert(NULL=="Invalid ldms_msg_event type");
+}
+
+void ldms_set_ref_dump(ldms_set_t set, const char *name, FILE *f)
+{
+	ref_dump(&set->ref, name, f);
 }

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -4719,6 +4719,7 @@ static inline double ldms_timespec_diff_s(struct timespec *start, struct timespe
 void dump_addrinfo_list(struct addrinfo *ai_list, const char *fn_name, int line);
 
 void ldms_set_ref_dump(ldms_set_t set, const char *name, FILE *f);
+void ldms_set_deleting_dump(FILE *f);
 
 #ifdef __cplusplus
 }

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -4718,6 +4718,8 @@ static inline double ldms_timespec_diff_s(struct timespec *start, struct timespe
 #include <netdb.h>
 void dump_addrinfo_list(struct addrinfo *ai_list, const char *fn_name, int line);
 
+void ldms_set_ref_dump(ldms_set_t set, const char *name, FILE *f);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ldms/src/core/ldms_private.h
+++ b/ldms/src/core/ldms_private.h
@@ -66,6 +66,12 @@
 #define HEAP_OFFSET(grained_ref) ( (grained_ref) * LDMS_LIST_GRAIN )
 #define HEAP_REF(offset) ( (offset) / LDMS_LIST_GRAIN )
 
+#ifdef LDMS_SET_DEBUG
+#define SETDEBUG(FMT, ... ) \
+	ovis_log(NULL, OVIS_LALWAYS, "%s():%d " FMT ,  __func__, __LINE__, ## __VA_ARGS__)
+#else
+#define SETDEBUG(FMT, ... )  /* no-op */
+#endif
 
 typedef struct ldms_mdef_s {
 	char *name;

--- a/ldms/src/core/ldms_private.h
+++ b/ldms/src/core/ldms_private.h
@@ -131,14 +131,14 @@ struct ldms_set {
 	struct ref_s ref;
 	unsigned long flags;
 	uint64_t set_id;	/* unique identifier for a set in this daemon */
-	uint64_t del_time;	/* Unix timestamp when set was deleted */
+	uint64_t del_time;      /* Unix timestamp when set was deleted */
 	struct ldms_set_hdr *meta;
 	struct ldms_data_hdr *data; /* points to current entry of data array */
 	struct ldms_set_info_list local_info;
 	struct ldms_set_info_list remote_info; /*set info from the lookup operation */
 	struct rbn rb_node;	/* Indexed by instance name */
 	struct rbn id_node;	/* Indexed by set_id */
-	struct rbn del_node;	/* Indexed by timestamp */
+	LIST_ENTRY(ldms_set) del_entry; /* for del_set_list */
 	pthread_mutex_t lock;
 	int curr_idx;
 	struct ldms_data_hdr *data_array;
@@ -237,6 +237,7 @@ struct ldms_data_hdr *__ldms_set_array_get(struct ldms_set *s, int idx)
 	return __set_array_get(s, idx);
 }
 
+typedef enum ldms_context_type ldms_context_type_t;
 struct ldms_context *__ldms_alloc_ctxt(struct ldms_xprt *x, size_t sz, ldms_context_type_t type, ...);
 void __ldms_free_ctxt(struct ldms_xprt *x, struct ldms_context *ctxt);
 
@@ -257,4 +258,16 @@ void __ldms_set_delete(ldms_set_t s, int notify);
 ldms_t __ldms_xprt_new_with_auth(const char *xprt_name,
 			       const char *auth_name,
 			       struct attr_value_list *auth_av_list);
+
+typedef struct __del_tree_ent_s {
+	struct rbn rbn;
+	struct ldms_set_del_key del;
+	ldms_set_t set;
+	int in_tree; /* for debugging */
+} * __del_tree_ent_t;
+
+__del_tree_ent_t __del_tree_ent_alloc(ldms_set_t set, uint64_t del_time);
+void __del_tree_ent_free(__del_tree_ent_t ent);
+void __del_tree_ent_ins(__del_tree_ent_t ent);
+__del_tree_ent_t __del_tree_ent_rm(struct ldms_set_del_key *key);
 #endif

--- a/ldms/src/core/ldms_rail.c
+++ b/ldms/src/core/ldms_rail.c
@@ -1974,6 +1974,7 @@ void __rail_on_set_delete(ldms_t _r, struct ldms_set *s,
 	size_t len;
 	struct rbn *rbn;
 	struct xprt_set_coll_entry *ent;
+	__del_tree_ent_t del_ent;
 	int i;
 	ldms_t x;
 	struct ldms_rail_ep_s *rep = NULL;
@@ -1999,12 +2000,9 @@ void __rail_on_set_delete(ldms_t _r, struct ldms_set *s,
 
 	pthread_mutex_lock(&x->lock);
  found:
-	ctxt = __ldms_alloc_ctxt
-		(x,
+	ctxt = __ldms_alloc_ctxt(x,
 		 sizeof(struct ldms_request) + sizeof(struct ldms_context),
-		 LDMS_CONTEXT_SET_DELETE,
-		 s,
-		 cb_fn);
+		 LDMS_CONTEXT_SET_DELETE, cb_fn);
 	if (!ctxt) {
 		ovis_log(xlog, OVIS_LCRIT, "%s:%s:%d Memory allocation failure\n",
 				__FILE__, __func__, __LINE__);
@@ -2017,6 +2015,23 @@ void __rail_on_set_delete(ldms_t _r, struct ldms_set *s,
 		rbt_del(&x->set_coll, rbn);
 		ent = container_of(rbn, struct xprt_set_coll_entry, rbn);
 		free(ent);
+		ref_put(&s->ref, "xprt_set_coll");
+
+		assert(s->del_time);
+		del_ent = __del_tree_ent_alloc(s, s->del_time);
+		if (del_ent) {
+			/* del_ent took set reference. The reference is put in
+			 * __del_tree_ent_free(), which is guaranteed to happen
+			 * only once on either DEL TIMEOUT or when peer replied
+			 * the DEL event.
+			 */
+			__del_tree_ent_ins(del_ent);
+			ctxt->set_delete.del_key = del_ent->del;
+		} else {
+			ctxt->set_delete.del_key.time = 0;
+			ctxt->set_delete.del_key.gn = 0;
+			ovis_log(xlog, OVIS_LERROR, "__del_tree_ent_alloc() failed: ENOMEM\n");
+		}
 	} else {
 		/* We won't put ref on receiving reply. */
 		ctxt->set_delete.lookup = 0;

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -418,8 +418,7 @@ struct ldms_context *__ldms_alloc_ctxt(struct ldms_xprt *x, size_t sz,
 		ctxt->dir.cb_arg = va_arg(ap, void *);
 		break;
 	case LDMS_CONTEXT_SET_DELETE:
-		ctxt->set_delete.s = va_arg(ap, ldms_set_t);
-		ref_get(&ctxt->set_delete.s->ref, "__ldms_alloc_ctxt");
+		/* ctxt->set_delete.del_key will be set later by caller */
 		ctxt->set_delete.cb = va_arg(ap, ldms_set_delete_cb_t);
 		ctxt->set_delete.cb_arg = ctxt;
 		break;
@@ -464,8 +463,6 @@ void __ldms_free_ctxt(struct ldms_xprt *x, struct ldms_context *ctxt)
 		break;
 	case LDMS_CONTEXT_SET_DELETE:
 		e = &x->stats.ops[LDMS_XPRT_OP_SET_DELETE];
-		if (ctxt->set_delete.s)
-			ref_put(&ctxt->set_delete.s->ref, "__ldms_alloc_ctxt");
 		break;
 	case LDMS_CONTEXT_DIR:
 		break;
@@ -644,12 +641,26 @@ void __ldms_dir_add_set(struct ldms_set *set)
 	dir_update(set, LDMS_DIR_ADD);
 }
 
-static void __set_delete_cb(ldms_t xprt, int status, ldms_set_t rbd, void *cb_arg)
+static void __set_delete_cb(ldms_t xprt, int status, void *cb_arg)
 {
 	struct ldms_context *ctxt = cb_arg;
-	struct ldms_set *set = ctxt->set_delete.s;
+	struct ldms_set *set;
 	struct rbn *rbn;
 	struct ldms_lookup_peer *lp;
+	__del_tree_ent_t del_ent;
+
+	SETDEBUG("peer reply, del_ent: (%lu, %lu)\n", ctxt->set_delete.del_key.time, ctxt->set_delete.del_key.gn);
+	if (0 == ctxt->set_delete.lookup) {
+		SETDEBUG("lookup is 0\n");
+		return;
+	}
+
+	del_ent = __del_tree_ent_rm(&ctxt->set_delete.del_key);
+	if (!del_ent) {
+		/* DEL TIMEOUT occur before we get this reply */
+		return;
+	}
+	set = del_ent->set;
 
 	pthread_mutex_lock(&set->lock);
 	rbn = rbt_find(&set->lookup_coll, xprt);
@@ -666,14 +677,8 @@ static void __set_delete_cb(ldms_t xprt, int status, ldms_set_t rbd, void *cb_ar
 		pthread_mutex_unlock(&set->lock);
 	}
 
-	/* If the set was successfully looked up, it will be be put into
-	 * `x->set_coll` and a reference taken. So, we have to put back the
-	 * reference only in this case. If the set was not in the `x->set_coll`,
-	 * the `ctxt->set_delete.lookup` will be 0 and we must not put the
-	 * reference we have not taken. */
-	if (ctxt->set_delete.lookup) {
-		ref_put(&set->ref, "xprt_set_coll");
-	}
+	SETDEBUG("freeing del_ent: (%lu, %lu)\n", del_ent->del.time, del_ent->del.gn);
+	__del_tree_ent_free(del_ent);
 }
 
 /* implementation in ldms_rail.c */
@@ -865,7 +870,7 @@ void process_set_delete_reply(struct ldms_xprt *x, struct ldms_reply *reply,
 		timespec_ntoh(&reply->set_del.recv_ts);
 		memcpy(&ctxt->op_ctxt->set_del_profile.recv_ts, &reply->set_del.recv_ts, sizeof(struct timespec));
 	}
-	ctxt->set_delete.cb(x, reply->hdr.rc, ctxt->set_delete.s, ctxt->set_delete.cb_arg);
+	ctxt->set_delete.cb(x, reply->hdr.rc, ctxt->set_delete.cb_arg);
 	pthread_mutex_lock(&x->lock);
 	__ldms_free_ctxt(x, ctxt);
 	pthread_mutex_unlock(&x->lock);

--- a/ldms/src/core/ldms_xprt.h
+++ b/ldms/src/core/ldms_xprt.h
@@ -74,7 +74,7 @@
  * cb_arg The cb_arg parameter to the ldsm_xprt_set_delete
  *        function
  */
-typedef void (*ldms_set_delete_cb_t)(ldms_t xprt, int status, ldms_set_t set, void *cb_arg);
+typedef void (*ldms_set_delete_cb_t)(ldms_t xprt, int status, void *cb_arg);
 
 /**
  * If set in the push_flags, the set changes will be automatically
@@ -381,6 +381,11 @@ typedef enum ldms_context_type {
 	LDMS_CONTEXT_SET_DELETE,
 } ldms_context_type_t;
 
+struct ldms_set_del_key {
+	uint64_t time;	/* Unix timestamp when set was deleted */
+	uint64_t gn;    /* __del_gn when set was deleted */
+};
+
 struct ldms_context {
 	sem_t sem;
 	sem_t *sem_p;
@@ -419,10 +424,10 @@ struct ldms_context {
 			void *cb_arg;
 		} req_notify;
 		struct {
-			ldms_set_t s;
 			ldms_set_delete_cb_t cb;
 			void *cb_arg;
 			int lookup;
+			struct ldms_set_del_key del_key;
 		} set_delete;
 	};
 	struct timespec start;


### PR DESCRIPTION
    Fix ldms_set delete

    Issues:

    1) `delete_proc()`, the thread that periodically woke up to clean up the
       sets in `__del_tree` process sets from the rear. When a new set was
       inserted into `__del_tree`, the old entries won't be processed.

    2) `delete_proc()` skipped sets that had outstanding transports
       referring to the sets (e.g. by lookup or by push). Even though this
       prevented use-after-free when peer replied to the SET_DELETE
       notification, it could look like a leak if (for any reasons) the peer
       took so long to response -- especially in the case that we have a lot
       of sets coming and going regularly.

    3) `delete_proc()` did not honor set references. It freed the set
       memory directly. If (for any reasons) a part of the process still
       held a reference to the said set, when that part of the program "put"
       the set reference, it will be a use-after-free.

    Issues 1 + 2 in a frequent set coming / going (e.g. a lot of 1-min jobs)
    could make the `__del_tree` grew indefinitely.

    This patch solved the issues by:

    a) Modifying `__del_tree` to hold DEL entries that referred to the sets.

    b) `delete_proc()` process entries from the front.

    c) the DEL reply handler (__set_delete_cb()) does not assume the
       existence of the DEL entry. It will lookup the entry from the
       `__del_tree` first. If lookup failed, this became a no-op. If it was
       a success, the entry is removed and freed (set reference drop).

    d) Set references are honored. The set memory will only be truely freed
       when the last reference to that set is dropped.

    If LDMS library is compiled with `-DLDMS_SET_DEBUG` and `-D_REF_TRACK_,
    the application can also dump a list of sets that were "deleted"
    (`ldms_set_delete()` is called) but still hanging around (got at least a
    refence on them).