### PR TITLE
fix: correct ILP32 type mismatches for 32-bit ARM cross-compilation

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -401,7 +401,7 @@ uint64_t ldms_set_heap_gn_get(ldms_set_t s)
 	return s->heap->data->gn;
 }
 
-size_t ldms_set_heap_size_get(ldms_set_t s)
+uint64_t ldms_set_heap_size_get(ldms_set_t s)
 {
 	return s->data->heap.size;
 }

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -11506,7 +11506,7 @@ static int qgroup_config_handler(ldmsd_req_ctxt_t reqc)
 						LDMSD_ATTR_ASK_MARK);
 	int rc = 0;
 	uint64_t u64;
-	int64_t s64;
+	long s64;
 
 	if (quota) {
 		u64 = ovis_get_mem_size(quota);

--- a/ldms/src/ldmsd/ldmsd_smplrp.c
+++ b/ldms/src/ldmsd/ldmsd_smplrp.c
@@ -364,7 +364,7 @@ static int p_attr_time_assign(ldmsd_smplrp_t p,
 		SMPLRP_ERROR("%s: attribute '%s' must be a string or a number\n", p->obj.name, name);
 		return EINVAL;
 	}
-	rc = ovis_time_str2us(json_value_cstr(jval), out);
+	{ long _tmp_us; rc = ovis_time_str2us(json_value_cstr(jval), &_tmp_us); *out = _tmp_us; }
 	if (rc) {
 		SMPLRP_ERROR("%s: attribute '%s' has bad time format.\n", p->obj.name, name);
 		return rc;


### PR DESCRIPTION
On ILP32 targets (e.g. armv7), `long` and `size_t` are 32-bit while `int64_t`/`uint64_t` are 64-bit, unlike LP64 where they coincide. Three sites assumed LP64 equivalence and failed to compile:

- ldms/src/core/ldms.c: ldms_set_heap_size_get() was defined as returning `size_t` but declared in the header as `uint64_t`; changed the definition to match.

- ldms/src/ldmsd/ldmsd_smplrp.c: ovis_time_str2us() takes `long *` but was passed an `int64_t *`; introduced a `long` temporary to bridge the types.

- ldms/src/ldmsd/ldmsd_request.c: local variable `s64` was declared `int64_t` and passed to ovis_time_str2us() as `long *`; changed the declaration to `long`.

Tested by cross-compiling for armv7ahf-vfpv4d16 (OpenBMC/Yocto toolchain, gcc 14.2.0) and running the resulting ldmsd binary on an ASPEED AST2600 (ARM Cortex-A7) BMC.