### PR TITLE
Improve `SET_DELETE` notification path and races with lookup callback

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -855,6 +855,18 @@ int __ldms_xprt_update(ldms_t x, struct ldms_set *set, ldms_update_cb_t cb,
 	if (!xprt)
 		return EINVAL;
 
+	pthread_mutex_lock(&set->lock);
+	if (set->flags & LDMS_SET_F_IO) {
+		pthread_mutex_unlock(&set->lock);
+		return EBUSY;
+	}
+	if (set->flags & LDMS_SET_F_PDEL) {
+		pthread_mutex_unlock(&set->lock);
+		return ENOENT;
+	}
+	set->flags |= LDMS_SET_F_IO;
+	pthread_mutex_unlock(&set->lock);
+
 	pthread_mutex_lock(&xprt->lock);
 	if (!cb) {
 		rc = __ldms_remote_update(xprt, set, sync_update_cb, arg);

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -586,6 +586,8 @@ typedef void (*ldms_lookup_cb_t)(ldms_t t, enum ldms_lookup_status status,
 #define LDMS_SET_F_REMOTE	0x0008
 #define LDMS_SET_F_PUSH_CHANGE	0x0010
 #define LDMS_SET_F_DATA_COPY	0x0020 /* set array data copy on transaction begin */
+#define LDMS_SET_F_IO		0x0040 /* 'on' when there is an outstanding IO: lookup, update */
+#define LDMS_SET_F_PDEL		0x0080 /* 'on' when producer has deleted the set */
 #define LDMS_SET_F_SNAPSHOT	0x10000 /* A read-only light copy of a set, which must not be published or shared with remote clients. */
 #define LDMS_SET_F_PUBLISHED	0x100000 /* Set is in the set tree. */
 #define LDMS_SET_ID_DATA	0x1000000

--- a/ldms/src/core/ldms_rail.c
+++ b/ldms/src/core/ldms_rail.c
@@ -1963,43 +1963,24 @@ size_t format_set_delete_req(struct ldms_request *req, uint64_t xid,
  * Tell the peer that have an RBD for this set that it is being
  * deleted. When they all reply, we can delete the set.
  */
-void __rail_on_set_delete(ldms_t _r, struct ldms_set *s,
+void __xrail_on_set_delete(ldms_t x, struct ldms_set *s,
 			      ldms_set_delete_cb_t cb_fn)
 {
-	assert(XTYPE_IS_RAIL(_r->xtype));
+	/* x is part of rail, not rail itself; This function is implemented here
+	 * instead of ldms_xprt.c because of ldms_rail_ep_s structure access for
+	 * PROFILING feature in rail. */
 
-	ldms_rail_t r = (ldms_rail_t)_r;
 	struct ldms_request *req;
 	struct ldms_context *ctxt;
 	size_t len;
 	struct rbn *rbn;
 	struct xprt_set_coll_entry *ent;
 	__del_tree_ent_t del_ent;
-	int i;
-	ldms_t x;
 	struct ldms_rail_ep_s *rep = NULL;
 	struct ldms_op_ctxt *op_ctxt = NULL;
 
-	x = NULL;
-
-	/* for each x in r */
-	for (i = 0; i < r->n_eps; i++) {
-		x = r->eps[i].ep;
-		pthread_mutex_lock(&x->lock);
-		rbn = rbt_find(&x->set_coll, s);
-		if (rbn)
-			goto found;
-		pthread_mutex_unlock(&x->lock);
-	}
-
-	/* No rbn found in any x in r. Just use the first x to notify with
-	 * ctxt->set_delete.lookup being 0. */
-	x = r->eps[0].ep;
-
-	/* let through */
-
 	pthread_mutex_lock(&x->lock);
- found:
+	rbn = rbt_find(&x->set_coll, s);
 	ctxt = __ldms_alloc_ctxt(x,
 		 sizeof(struct ldms_request) + sizeof(struct ldms_context),
 		 LDMS_CONTEXT_SET_DELETE, cb_fn);

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -839,6 +839,7 @@ static void process_set_delete_request(struct ldms_xprt *x, struct ldms_request 
 	struct ldms_reply reply;
 	struct ldms_set *set;
 	size_t len;
+	int set_io = 0;
 
 	/*
 	 * Always notify the application about peer set delete. If we happened
@@ -848,12 +849,19 @@ static void process_set_delete_request(struct ldms_xprt *x, struct ldms_request 
 	set = __ldms_find_local_set(req->set_delete.inst_name);
 	__ldms_set_tree_unlock();
 	if (set) {
+		pthread_mutex_lock(&set->lock);
+		set->flags |= LDMS_SET_F_PDEL;
+		set_io = set->flags & LDMS_SET_F_IO;
+		pthread_mutex_unlock(&set->lock);
 		if (set->xprt != x) {
 			assert(set->xprt != x);
 			goto reply_1;
 		}
 	}
-	if (x->event_cb) {
+	if (x->event_cb && 0 == set_io) {
+		/*
+		 * Deliver SET_DELETE event if there is no outstanding IO.
+		 */
 		struct ldms_xprt_event event;
 		event.type = LDMS_XPRT_EVENT_SET_DELETE;
 		event.set_delete.set = set;
@@ -2687,9 +2695,19 @@ static void __handle_lookup(ldms_t x, struct ldms_context *ctxt,
 			    zap_event_t ev)
 {
 	int status = 0;
-	if (!ctxt->lu_read.cb)
-		goto ctxt_cleanup;
-	if (ev->status != ZAP_ERR_OK) {
+	int pdel = 0;
+	ldms_set_t set = ctxt->lu_read.s;
+
+	pthread_mutex_lock(&set->lock);
+	set->flags &= ~LDMS_SET_F_IO;
+	pdel = set->flags & LDMS_SET_F_PDEL;
+	pthread_mutex_unlock(&set->lock);
+
+	assert(ctxt->lu_read.cb);
+
+	if (pdel) {
+		status = ENOENT;
+	} else if (ev->status != ZAP_ERR_OK) {
 		status = EREMOTEIO;
 #ifdef DEBUG
 		XPRT_LOG(x, OVIS_LALWAYS, "%s: lookup read error: zap error %d. "
@@ -2697,18 +2715,20 @@ static void __handle_lookup(ldms_t x, struct ldms_context *ctxt,
 			ldms_set_instance_name_get(ctxt->lu_read.s),
 			ev->status, status);
 #endif /* DEBUG */
+	}
+
+	if (status) {
 		/*
 		 * Destroy the set, the ctxt still has a reference on
 		 * it, but that will be dropped when the ctxt is
 		 * freed.
 		 */
-		__ldms_set_delete(ctxt->lu_read.s, 0);
+		__ldms_set_delete(set, 0);
+		set = NULL;
 	} else {
-		ldms_set_publish(ctxt->lu_read.s);
+		ldms_set_publish(set);
 	}
-	ctxt->lu_read.cb((ldms_t)x, status, ctxt->lu_read.more,
-			 ev->status ? NULL : ctxt->lu_read.s,
-			 ctxt->lu_read.cb_arg);
+	ctxt->lu_read.cb((ldms_t)x, status, ctxt->lu_read.more, set, ctxt->lu_read.cb_arg);
 	if (!ctxt->lu_read.more) {
 #ifdef DEBUG
 		assert(x->active_lookup > 0);
@@ -2718,7 +2738,6 @@ static void __handle_lookup(ldms_t x, struct ldms_context *ctxt,
 #endif /* DEBUG */
 	}
 
-ctxt_cleanup:
 	/* each `read` for lookup has its own context */
 	pthread_mutex_lock(&x->lock);
 	__ldms_free_ctxt(x, ctxt);
@@ -2919,7 +2938,7 @@ static void handle_rendezvous_lookup(zap_ep_t zep, zap_event_t ev,
 	lset = __ldms_create_set(inst_name->name, schema_name->name,
 				 ntohl(lu->meta_len), ntohl(lu->data_len),
 				 ntohl(lu->card), ntohl(lu->array_card),
-				 LDMS_SET_F_REMOTE);
+				 LDMS_SET_F_REMOTE|LDMS_SET_F_IO);
 	if (!lset) {
 		rc = errno;
 		goto callback;

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2597,9 +2597,30 @@ static void __handle_update_data(ldms_t x, struct ldms_context *ctxt,
 	struct ldms_data_hdr *data, *prev_data;
 	int flags = 0, upd_curr_idx;
 	void *base;
+	int pdel;
+
+	if (set) {
+		ldms_set_ref_get(set, "__handle_update_data");
+		pthread_mutex_lock(&set->lock);
+		pdel = set->flags & LDMS_SET_F_PDEL;
+		pthread_mutex_unlock(&set->lock);
+	}
 
 	assert(x == ctxt->x);
 	assert(ctxt->update.cb);
+	if (pdel) {
+		/* Deliver update error then deliver SET_DELETE */
+		rc = ENOENT;
+		ctxt->update.cb(x, set, rc, ctxt->update.cb_arg);
+
+		struct ldms_xprt_event event;
+		event.type = LDMS_XPRT_EVENT_SET_DELETE;
+		event.set_delete.set = set;
+		event.set_delete.name = ldms_set_instance_name_get(set);
+		event.data_len = sizeof(ldms_set_t);
+		x->event_cb(x, &event, x->event_cb_arg);
+		goto cleanup;
+	}
 	rc = LDMS_UPD_ERROR(ev->status);
 	if (rc || (set == NULL)) {
 		x->zerrno = rc;
@@ -2607,6 +2628,9 @@ static void __handle_update_data(ldms_t x, struct ldms_context *ctxt,
 		/* READ ERROR */
 		if (!rc)
 			rc = ENOENT;
+		pthread_mutex_lock(&set->lock);
+		set->flags &= ~LDMS_SET_F_IO;
+		pthread_mutex_unlock(&set->lock);
 		ctxt->update.cb(x, set, rc, ctxt->update.cb_arg);
 		goto cleanup;
 	}
@@ -2618,6 +2642,9 @@ static void __handle_update_data(ldms_t x, struct ldms_context *ctxt,
 	if (data != prev_data &&
 			__ldms_data_ts_cmp(prev_data, data) >= 0) {
 		/* special case, no new data */
+		pthread_mutex_lock(&set->lock);
+		set->flags &= ~LDMS_SET_F_IO;
+		pthread_mutex_unlock(&set->lock);
 		ctxt->update.cb(x, set, flags, ctxt->update.cb_arg);
 		goto cleanup;
 	}
@@ -2643,6 +2670,9 @@ static void __handle_update_data(ldms_t x, struct ldms_context *ctxt,
 				&& i == __le32_to_cpu(data->curr_idx)) {
 			/* our update is current. */
 			flags = 0;
+			pthread_mutex_lock(&set->lock);
+			set->flags &= ~LDMS_SET_F_IO;
+			pthread_mutex_unlock(&set->lock);
 		} else {
 			flags = LDMS_UPD_F_MORE;
 		}
@@ -2663,10 +2693,18 @@ static void __handle_update_data(ldms_t x, struct ldms_context *ctxt,
 	/* the updated set is not current */
 	rc = __ldms_remote_update(x, set, ctxt->update.cb,
 			ctxt->update.cb_arg);
-	if (rc)
+	if (rc) {
+		pthread_mutex_lock(&set->lock);
+		set->flags &= ~LDMS_SET_F_IO;
+		pthread_mutex_unlock(&set->lock);
 		ctxt->update.cb(x, set, LDMS_UPD_ERROR(rc), ctxt->update.cb_arg);
+	}
 
 cleanup:
+	if (set) {
+		ldms_set_ref_put(set, "__handle_update_data");
+	}
+
 	zap_put_ep(x->zap_ep, "ldms_xprt:set_update", __func__, __LINE__); /* from __ldms_remote_update() */
 	pthread_mutex_lock(&x->lock);
 	__ldms_free_ctxt(x, ctxt);

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -682,8 +682,9 @@ static void __set_delete_cb(ldms_t xprt, int status, void *cb_arg)
 }
 
 /* implementation in ldms_rail.c */
-void __rail_on_set_delete(ldms_t _r, struct ldms_set *s,
-			      ldms_set_delete_cb_t cb_fn);
+void __xrail_on_set_delete(ldms_t x, struct ldms_set *s, ldms_set_delete_cb_t cb_fn);
+
+size_t format_set_delete_req(struct ldms_request *req, uint64_t xid, const char *inst_name);
 
 void __ldms_dir_del_set(struct ldms_set *set)
 {
@@ -699,20 +700,39 @@ void __ldms_dir_del_set(struct ldms_set *set)
 	 *
 	 * dir_update(set, LDMS_DIR_DEL);
 	 */
-	struct ldms_xprt *x;
-	ldms_t r;
-	pthread_mutex_lock(&xprt_list_lock);
-	LIST_FOREACH(x, &xprt_list, xprt_link) {
-		if (x->remote_dir_xid) {
-			/* NOTE:
-			 * There will be only one `x` in `r` that has
-			 * `x->remote_dir_xid != 0`.
-			 */
-			r = __ldms_xprt_to_rail(x);
-			__rail_on_set_delete(r, set, __set_delete_cb);
-		}
+	struct rbn *rbn;
+	struct ldms_lookup_peer *np;
+	ldms_t *xs;
+	int i, n;
+
+	pthread_mutex_lock(&set->lock);
+	if (rbt_empty(&set->lookup_coll)) {
+		pthread_mutex_unlock(&set->lock);
+		return;
 	}
-	pthread_mutex_unlock(&xprt_list_lock);
+	/*
+	 * Copy-out to avoid set->lock, xprt->lock sequence. This should be
+	 * inexpensive as the size of lookup collection is small.
+	 */
+	xs = malloc(rbt_card(&set->lookup_coll) * sizeof(*xs));
+	if (!xs) {
+		pthread_mutex_unlock(&set->lock);
+		return;
+	}
+	n = 0;
+	RBT_FOREACH(rbn, &set->lookup_coll) {
+		np = container_of(rbn, struct ldms_lookup_peer, rbn);
+		xs[n++] = np->xprt;
+		ldms_xprt_get(np->xprt, "__ldms_dir_del_set:xs");
+	}
+	pthread_mutex_unlock(&set->lock);
+
+	for (i = 0; i < n; i++) {
+		/* NOTE xs[i] is a part of rail, not rail itself */
+		__xrail_on_set_delete(xs[i], set, __set_delete_cb);
+		ldms_xprt_put(np->xprt, "__ldms_dir_del_set:xs");
+	}
+	free(xs);
 }
 
 void __ldms_dir_upd_set(struct ldms_set *set)

--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -220,7 +220,7 @@ void prdcr_hint_tree_update(ldmsd_prdcr_t prdcr, ldmsd_prdcr_set_t prd_set,
 	}
 }
 
-static void prdcr_reset_set(ldmsd_prdcr_t prdcr, ldmsd_prdcr_set_t prd_set)
+void __prdcr_reset_set(ldmsd_prdcr_t prdcr, ldmsd_prdcr_set_t prd_set)
 {
 	prdcr_hint_tree_update(prdcr, prd_set,
 			       &prd_set->updt_hint, UPDT_HINT_TREE_REMOVE);
@@ -238,7 +238,7 @@ static void prdcr_reset_sets(ldmsd_prdcr_t prdcr)
 	struct rbn *rbn;
 	while ((rbn = rbt_min(&prdcr->set_tree))) {
 		prd_set = container_of(rbn, struct ldmsd_prdcr_set, rbn);
-		prdcr_reset_set(prdcr, prd_set);
+		__prdcr_reset_set(prdcr, prd_set);
 	}
 }
 
@@ -421,7 +421,7 @@ static void prdcr_dir_cb_del(ldms_t xprt, ldms_dir_t dir, ldmsd_prdcr_t prdcr)
 			continue;
 		set = container_of(rbn, struct ldmsd_prdcr_set, rbn);
 		assert(set->ref_count);
-		prdcr_reset_set(prdcr, set);
+		__prdcr_reset_set(prdcr, set);
 	}
 }
 
@@ -551,7 +551,7 @@ static void __prdcr_remote_set_delete(ldmsd_prdcr_t prdcr, const char *name)
 			"Deleting %s in the %s state\n",
 			prdcr_set->inst_name, state_str);
 	pthread_mutex_unlock(&prdcr_set->lock);
-	prdcr_reset_set(prdcr, prdcr_set);
+	__prdcr_reset_set(prdcr, prdcr_set);
 }
 
 const char *_conn_state_str[] = {

--- a/ldms/src/ldmsd/ldmsd_updtr.c
+++ b/ldms/src/ldmsd/ldmsd_updtr.c
@@ -510,11 +510,15 @@ out:
 	return rc;
 }
 
+/* implementation in ldmsd_prdcr.c */
+void __prdcr_reset_set(ldmsd_prdcr_t prdcr, ldmsd_prdcr_set_t prd_set);
+
 void __ldmsd_prdset_lookup_cb(ldms_t xprt, enum ldms_lookup_status status,
 					int more, ldms_set_t set, void *arg)
 {
 	ldmsd_prdcr_set_t prd_set = arg;
 	int ready = 0;
+	int delete = 0;
 	int flags;
 	pthread_mutex_lock(&prd_set->lock);
 	if (status != LDMS_LOOKUP_OK) {
@@ -534,11 +538,17 @@ void __ldmsd_prdset_lookup_cb(ldms_t xprt, enum ldms_lookup_status status,
 				  "It is likely that there are multiple "
 				  "producers providing a set with the same instance name.\n",
 				  prd_set->prdcr->obj.name, prd_set->inst_name, set);
+		} else if (status == ENOENT) {
+			ovis_log(updtr_log, OVIS_LERROR,
+				  "prdcr %s: The set '%s' (%p) no longer exists.\n",
+				  prd_set->prdcr->obj.name, prd_set->inst_name, set);
+			delete = 1;
 		} else {
 			ovis_log(updtr_log, OVIS_LERROR,
 				  "prdcr %s: Error %d in lookup callback of set '%s' (%p)\n",
 				  prd_set->prdcr->obj.name,
 				  status, prd_set->inst_name, set);
+			delete = 1;
 		}
 		prd_set->state = LDMSD_PRDCR_SET_STATE_START;
 		goto out;
@@ -568,6 +578,8 @@ out:
 	pthread_mutex_unlock(&prd_set->lock);
 	if (ready)
 		ldmsd_prd_set_updtr_task_update(prd_set);
+	if (delete)
+		__prdcr_reset_set(prd_set->prdcr, prd_set);
 	ldmsd_prdcr_set_ref_put(prd_set); /* The ref is taken before calling lookup */
 	return;
 }


### PR DESCRIPTION
This PR contains commits address the following issues related to `SET_DELETE`:
- `SET_DELETE` notification performance,
- `SET_DELETE` notification race with lookup callback (application may get `SET_DELETE` of the set it is looking up before lookup completion),
  - Also delete `prd_set` for lookup failure,
- `ldms_xprt_update()` could be issued to the set that `SET_DELETE` was already notified. A commit of this PR guards such case. Plus, it also guards issuing another update on top of an outstanding update.

For convenience, the following is a list of commit messages describing the issues / solutions in a bit more details:

    1) Address SET_DELETE notification
    ----------------------------------

    When a set was deleted, LDMS went through all transports and send
    `SET_DELETE` notification to the transports that register for DIR
    updates. L1 aggregators usually connect to a lot of compute nodes (e.g.
    10K nodes). When a big job (e.g. 10K nodes job) ended, the `SET_DELETE`
    notification loop will cost O(N^2) iterations on the aggregator.

    This patch iterates through `set->lookup_coll` transport list instead of
    the big global transport list to addess the issue. All of the transports
    looked up the set will get the notification so that they know that the
    set is going away.


    2) Delete `prd_set` on certain lookup errors
    --------------------------------------------

    `prd_set` should be deleted when encountering `ENOENT` error. The set
    can be deleted while the lookup was in process. Other unhandling errors
    should result in `prd_set` deletion as well. The know exceptions
    `ENOMEM` and `EEXIST` would leave the `prd_set` alone for a retry.


    3) Address SET_DELETE & lookup_cb race
    --------------------------------------

    `SET_DELETE` notification and `lookup_cb()` can race as follows:

    - `agg` looks up a set.
    - `samp` sends `zap_share`, `agg` xprt is added into the
      `set->lookup_coll`.
    - `agg` recv `zap_share`, then it does `zap_read`.
    - at the same time, `samp` deletes the set and send `SET_DELETE` to
      `agg`.
    - `SET_DELETE` *can* arrive before read completion. In such case, `agg`
      will receive `SET_DELETE` notification of the set it does not know it
      has as the set was being looked up.

    This patch adds two new set flags: `LDMS_SET_F_IO` and
    `LDMS_SET_F_PDEL`. The IO flag is turned on when the set has an on-going
    IO operation (e.g. lookingup, updating). The PDEL flag is turned on when
    the set is known to be deleted on the producer (when `SET_DELETE`
    notification is received). Then, we can use IO and PDEL in conjunction
    with the receive notification or completion to determine what event(s)
    to deliver to the application as follows:

    - On receiving `SET_DELETE`: turn on PDEL flag, and:
      - If IO flag was on: don't deliver the `SET_DELETE` to the
        application. IO completion event will determine what to deliver
        later.
      - If IO flag was off: deliver `SET_DELETE` to the application.
    - On lookup read completion:
      - If PDEL is on, deliver lookup failure with ENOENT instead.


    4) `SET_DELETE`, outstanding IO and the update path
    ---------------------------------------------------

    - Use `IO` set flag on update as well. New update call shall result in
      an error if there is an outstanding `IO` on the set.
    - If `PDEL` set flag is on, the remote set has been deleted. The
      `update` call should synchronously fail.
    - Deliver `SET_DELETE` as last event. It is guaranteed to not deliver
      any more set events after `SET_DELETE`.