### PR TITLE
Change ldms_xprt_event_type to cdef enum

### DIFF
--- a/ldms/python/ldms.pxd
+++ b/ldms/python/ldms.pxd
@@ -308,7 +308,7 @@ cdef extern from "ldms.h" nogil:
         gid_t gid
 
     # --- xprt connection related --- #
-    cpdef enum ldms_xprt_event_type:
+    cdef enum ldms_xprt_event_type:
         EVENT_CONNECTED     "LDMS_XPRT_EVENT_CONNECTED"
         EVENT_REJECTED      "LDMS_XPRT_EVENT_REJECTED"
         EVENT_ERROR         "LDMS_XPRT_EVENT_ERROR"


### PR DESCRIPTION
The enum is only used internally in C-level contexts. No Python code references the type by name; users access event types via the individual module-level values (EVENT_CONNECTED, etc.). cpdef causes a Cython warning at import
time that breaks tests relying on a clean interactive prompt.