### PR TITLE
ldmsd_stream: fix null dereference in stream deliver for non-JSON types

### DIFF
--- a/ldms/src/ldmsd/ldmsd_stream.c
+++ b/ldms/src/ldmsd/ldmsd_stream.c
@@ -299,7 +299,7 @@ void ldmsd_stream_deliver(const char *stream_name, ldmsd_stream_type_t stream_ty
 				break;
 			need_free = 1;
 		}
-		c->c_cb_fn(c, c->c_ctxt, stream_type, data, data_len, json_doc_root(jdoc));
+		c->c_cb_fn(c, c->c_ctxt, stream_type, data, data_len, (jdoc?json_doc_root(jdoc):NULL));
 	}
 
 	if (p_name) {


### PR DESCRIPTION
ldmsd_stream_deliver() only allocates jdoc for JSON-type messages, but passed jdoc to json_doc_root() unconditionally. This caused non-JSON stream messages to fail delivery to subscribers.