### PR TITLE
Add configuration options for LSOS to store_sos

### DIFF
--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1852,16 +1852,18 @@ class LdmsdCmdParser(Cmd.Cmd):
             print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
             print()
             print(f"{'Statistics per Set Schema':^137}")
-            print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
-            print(f"{' '*4} {'Schema':^20} {'Min (us)':^15} {'Avg (us)':^15} {'Max (us)':^15} {'Min Timestamp':^20} {'Max Timestamp':^20} {'# of Sets':^10} {'Count':^10}")
-            print(f"{'-'*4}-{'-'*20} {'-'*15} {'-'*15} {'-'*15} {'-'*20} {'-'*20} {'-'*10} {'-'*10}")
+            print(f"{' '*4} {'Schema':^32} {'Min (us)':^15} {'Avg (us)':^15} {'Max (us)':^15} "
+                  f"{'Min Timestamp':^14} {'Max Timestamp':^14} {'Sets':^8} {'Count':^10}")
+            print(f"{'-'*4}-{'-'*32} {'-'*15} {'-'*15} {'-'*15} {'-'*14} {'-'*14} {'-'*8} {'-'*10}")
             schema_names = sorted(list(schema_tbl['schema'].keys()))
             for schema in schema_names:
                 stats = schema_tbl['schema'][schema]['stats']
                 if len(stats['set_name']) == 0:
                     continue
-                print(f"{self.__symbols(schema, schema_tbl['stats']):>4}   {schema:>18} {stats['min']:15.4f} {stats['avg']:15.4f} {stats['max']:15.4f} {int(stats['min_ts']):20d} {int(stats['max_ts']):20d} {len(set(stats['set_name'])):10} {stats['count']:10}")
-                print(f"{'='*(4+21+16+16+16+21+21+11+11)}")
+                print(f"{self.__symbols(schema, schema_tbl['stats']):>4} {schema:32} "
+                      f"{stats['min']:15.4f} {stats['avg']:15.4f} {stats['max']:15.4f} "
+                      f"{int(stats['min_ts']):14d} {int(stats['max_ts']):14d} "
+                      f"{len(set(stats['set_name'])):8} {stats['count']:10}")
 
         # Storage policy Table
         if 'strgp_detail' in views or 'histogram' in views:

--- a/ldms/src/store/ldms-store_sos.rst
+++ b/ldms/src/store/ldms-store_sos.rst
@@ -15,19 +15,16 @@ Man page for the LDMS store_sos plugin
 SYNOPSIS
 ========
 
-| Within ldmsd_controller script:
-| ldmsd_controller> load name=store_sos
-| ldmsd_controller> config name=store_sos path=path
-| ldmsd_controller> strgp_add plugin=store_sos [ <attr> = <value> ]
+| load name=NAME plugin=store_sos
 
 DESCRIPTION
 ===========
 
-With LDMS (Lightweight Distributed Metric Service), store plugins for
-the ldmsd (ldms daemon) are configured via the ldmsd_controller. The
-store_sos plugin is a sos store.
+The `store_sos` plugin implements an interface between the *ldmsd* storage
+infrastructure and the Scalable Object Store (SOS).
 
-To build the store_sos, build with the following flag: **--enable_sos**
+To build the store_sos plugin, specify the **--with-sos=PATH** flag where PATH
+is the location of the SOS installaction.
 
 This plugin is multi-instance capable.
 
@@ -35,200 +32,43 @@ STORE_SOS INIT CONFIGURATION ATTRIBUTE SYNTAX
 =============================================
 
 **config**
-   | name=<plugin_name> path=<path>
-   | ldmsd_controller configuration line
+   | name=NAME path=PATH [mode=OCTAL] [backend=BACKEND]
 
-   name=<plugin_name>
-      |
-      | This MUST be store_sos.
+   name=NAME
+      | This is the storage plugin instance name
 
-   path=<path>
-      |
-      | The store will be put into a directory whose root is specified
-        by the path argument. This directory must exist; the store will
-        be created. The full path to the store will be
-        <path>/<container>. The schema(s) determine the schemas of the
-        data base. Container and schema are set when the strgp is added.
+   path=PATH
+      | The store will place `containers` into the directory named PATH.
+      | This directory must exist. The CONTAINER name is specifed when
+      | configing the storage policy.
 
-STRGP_ADD ATTRIBUTE SYNTAX
-==========================
+   mode=MODE (default is 0660)
+      | An octal number representing the permission bits used when new files
+      | are created for the CONTAINER. See the open(3) system call.
 
-The strgp_add sets the policies being added. This line identifies the
-container and schema for a store.
+   backend=BACKEND (default is "mmos")
+      | The BACKEND specifies the storage strategy that will be used for
+      | objects stored in the CONTAINER. The BACKEND is one of "mmos" or "lsos"
+      | The "mmos" backend is a Memory Mapped Object Store (MMOS). This storage
+      | strategy uses the mmap() system call to map file system memory into the
+      | address space of the `ldmsd`. This strategy is very efficient for solid
+      | state storage devices and local filesystems, but can be very
+      | inefficient for distributed file systems. The "lsos" backend is a Log
+      | Structured Object Store (LSOS) that uses standard read()/write() and
+      | compression to store data in the file system. This strategy is less
+      | efficient for object creation and indexing, but is more efficent for
+      | distributed storage; using typically less than 1/8 of the storage
+      | consumed by MMOS.
 
-**strgp_add**
-   | plugin=store_sos name=<policy_name> schema=<schema>
-     container=<container> [decomposition=<DECOMP_CONFIG_FILE_JSON>]
-   | ldmsd_controller strgp_add line
-
-   plugin=<plugin_name>
-      |
-      | This MUST be store_sos.
-
-   name=<policy_name>
-      |
-      | The policy name for this strgp.
-
-   container=<container>
-      |
-      | The container and schema define the store as described above
-        (see path).
-
-   schema=<schema>
-      |
-      | The container and schema define the store as described above
-        (see path). You can have multiples of the same path and
-        container, but with different schema (which means they will have
-        different metrics) and they will be stored in the same store.
-
-   decomposition=<DECOMP_CONFIG_FILE_JSON>
-      |
-      | Optionally use set-to-row decomposition with the specified
-        configuration file in JSON format. See more about decomposition
-        in :ref:`ldmsd_decomposition(7) <ldmsd_decomposition>`.
-
-USING SOS COMMANDS TO MANAGE PARTITIONS
-=======================================
-
-Some of the basic sos commands are given below. SOS tools will be built
-into XXX. Any commands given with no argument, will return usage info.
-
-**sos_part_query**
-   | <container>
-   | List the partitions defined in a container.
-
-**sos_part_create**
-   | -C <path> [<attr>=<value>] part_name
-   | Create a partition.
-
-   **-C**\ *<path>*
-      |
-      | Path to the container
-
-   **-s**\ *state*
-      |
-      | State of the new partition (case insensitive). Default is
-        OFFLINE. Optional parameter. Valid options are:
-
-   -  PRIMARY: all new allocations go in this partition
-
-   -  ONLINE: objects are accessible, but the partition does not grow
-
-   -  OFFLINE: object references are invalid; the partition may be moved
-      or deleted.
-
-   **part_name**
-      |
-      | Name of the partition
-
-**sos_part_delete**
-   | -C <path> <name>
-   | Delete a partition in a container. The partition must be in the
-     OFFLINE state to be deleted.
-
-   **-C**\ *<path>*
-      |
-      | Path to the container
-
-   **name**
-      |
-      | Name of the parition
-
-**sos_part_modify**
-   | -C <path> [<attr>=<value>] part_name
-   | Modify the state of a partition.
-
-   **-C**\ *<path>*
-      |
-      | Path to the container
-
-   **-s**\ *state*
-      |
-      | State of the new partition (case insensitive). Default is
-        OFFLINE. Optional parameter. Valid options are:
-
-   -  PRIMARY: all new allocations go in this partition
-
-   -  ONLINE: objects are accessible, but the partition does not grow
-
-   -  OFFLINE: object references are invalid; the partition may be moved
-      or deleted.
-
-   **part_name**
-      |
-      | Name of the partition
-
-**sos_part_move**
-   |
-   | Move a partition to another storage location. -C <path> -p
-     <new_path> part_name
-
-   **-C**\ *<path>*
-      |
-      | Path to the container
-
-   **-p**\ *<new_path>*
-      |
-      | The new path.
-
-   **part_name**
-      |
-      | Name of the partition
-
-USING SOS COMMANDS TO LOOK AT DATA IN A PARTITION
-=================================================
-
-sos_cmd can be used to get data from an sos instance. Some relevant
-command options are below. Example usage is in the example section.
-
-**sos_cmd**
-   | -C <path> -l
-   | Print a directory of the schemas.
-
-   **-C**\ *<path>*
-      |
-      | Path to the container
-
-**sos_cmd**
-   | -C <path> -i
-   | Show debug information for the container
-
-   **-C**\ *<path>*
-      |
-      | Path to the container
-
-**sos_cmd**
-   | -C <path> -q -S <schema> -X <index> -V <var1> -V <var2>....
-   | Print data from a container
-
-   **-C**\ *<path>*
-      |
-      | Path to the container
-
-   **-q**
-      Used to query
-
-   **-S**\ *<schema>*
-      |
-      | Schema querying against
-
-   **-X**\ *<index>*
-      |
-      | Variable that is indexed to use in the query.
-
-   **-V**\ *<var>*
-      |
-      | One or more vars to output.
 
 NOTES
 =====
 
--  The configuration lines do not allow specification of the partition,
-   that is done automatically (by default this is the epoch timestamp).
+-  The configuration files do not specify partition names. This is done
+   automatically and is an epoch timestamp. See the *time* command.
 
--  Management of partitions is done outside of LDMS (e.g., cron script
-   that calls creation of new partitions and changes from PRIMARY to
-   ACTIVE).
+-  Management of partitions is done outside of *ldmsd*. See the *sos-part*
+   command.
 
 BUGS
 ====
@@ -238,110 +78,88 @@ No known bugs.
 EXAMPLES
 ========
 
-Configuring store_sos:
-----------------------
+Simple store_sos Configuration
+------------------------------
+
+This will store metric set data with the schema `meminfo` into the container
+/var/tmp/ldms. The example below are the relevant lines in the **ldmsd**
+configuration file.
 
 ::
 
-   ldmsd_controller> load name=store_sos
-   ldmsd_controller> config name=store_sos path=/XXX/storedir
-   ldmsd_controller> strgp_add name=sos_mem_policy plugin=store_sos container=sos schema=meminfo
+   load name=ss1 plugin=store_sos
+   config name=ss1 path=/var/tmp
+   strgp_add name=strgp_sos plugin=ss1 container=ldms schema=meminfo
+   strgp_start name=strgp_sos plugin=ss1 container=ldms schema=meminfo
 
-Querying a container's partitions:
+Store with Two Backends
+------------------------
+
+This will store metric set data as described in decomp.conf to two different
+containers: one using the MMOS backend and another using the LSOS backend.
+
+You can compare the performance of these two backends using the
+`store_time_stats` command.
+
+The relevant lines from a configuration file are as follows::
+
+    load name=mmos plugin=store_sos
+    config name=mmos path=/var/tmp/mmos backend=mmos mode=0777
+
+    load name=lsos plugin=store_sos
+    config name=lsos path=/var/tmp/lsos backend=lsos mode=0777
+
+    strgp_add name=lsos plugin=lsos container=ldms \
+       decomposition=/opt/ovis/etc/decomp.json regex=.*
+    strgp_prdcr_add name=lsos regex=.* \
+       strgp_start name=lsos
+
+    strgp_add name=mmos plugin=mmos container=ldms \
+	decomposition=/opt/ovis/etc/decomp.json regex=.*
+    strgp_prdcr_add name=mmos regex=.*
+
+    strgp_start name=mmos
+    strgp_start name=lmos
+
+Examine Storage Plugin Performance
 ----------------------------------
 
-::
+The ldmsd_controller *store_time_stats* command can be used to evaluate plugin performance::
 
-   $ sos_part /NVME/0/SOS_ROOT/Test
-    Partition Name       RefCount Status           Size     Modified         Accessed         Path
-    -------------------- -------- ---------------- -------- ---------------- ---------------- ----------------
-         00000000               3 ONLINE                 1M 2015/08/25 13:49 2015/08/25 13:51 /SOS_STAGING/Test
-         00000001               3 ONLINE                 2M 2015/08/25 11:54 2015/08/25 13:51 /NVME/0/SOS_ROOT/Test
-         00000002               3 ONLINE                 2M 2015/08/25 11:39 2015/08/25 13:51 /NVME/0/SOS_ROOT/Test
-         00000003               3 ONLINE PRIMARY         2M 2015/08/25 11:39 2015/08/25 13:51 /NVME/0/SOS_ROOT/Test
+  ldmsd_controller -a munge -p 10002
+  Welcome to the LDMSD control processor
+  sock:localhost:10002> store_time_stats
+  =========================================================================================================================================
+  <   Minimum Value          -   Minimum Average value
+  >   Maximum Value          +   Maximum Average value
+  =========================================================================================================================================
+  Schema           Min (us)        Avg (us)        Max (us)        Min Timestamp        Max Timestamp     # of Sets    Count
+  ------------------------- --------------- --------------- --------------- -------------------- -------------------- ---------- ----------
+      file_importer.fi.helm          1.2800          3.3632          9.9840           1775162441           1775163540          1        699
+  <-   file_importer.fi.smart2          1.0240          2.1149          7.1680           1775162271           1775164051          1        696
+  >+           perfevent2          5.3760        228.9463      37693.9520           1775162903           1775162207          1      13992
+  =========================================================================================================================================
+  Storage Policy       Min (us)        Avg (us)        Max (us)        Min Timestamp        Max Timestamp     # of Sets    Count
+  ------------------------- --------------- --------------- --------------- -------------------- -------------------- ---------- ----------
+  <>+  csv                         1.0240        239.4822      37693.9520           1775162271           1775162207          3       5129
+  ------------------ --------------- --------------- --------------- -------------------- -------------------- ---------- ----------
+       lsos                        1.0240        230.7347      34880.5120           1775162331           1775162204          3       5129
+  ------------------ --------------- --------------- --------------- -------------------- -------------------- ---------- ----------
+    -  mmos                        1.0240        155.0978      26222.0800           1775164071           1775163461          3       5129
+   ------------------ --------------- --------------- --------------- -------------------- -------------------- ---------- ----------
 
-Looking at a container's directory:
------------------------------------
+  Number of store operations per second: 6.4863
+  Percentages of each stage:
+  commit         :   84.53%
+  queue          :   10.40%
+  decomp         :    4.34%
+  prep           :    0.52%
+  wait           :    0.22%
 
-Variables that are options for -X in the sos_cmd will have indexed = 1
-
-::
-
-   $ sos_cmd -C /NVME/0/LDMS -l
-   schema :
-       name      : aries_nic_mmr
-       schema_sz : 1944
-       obj_sz    : 192
-       id        : 129
-       -attribute : timestamp
-           type          : TIMESTAMP
-           idx           : 0
-           indexed       : 1
-           offset        : 8
-       -attribute : comp_time
-           type          : UINT64
-           idx           : 1
-           indexed       : 1
-           offset        : 16
-       -attribute : job_time
-           type          : UINT64
-           idx           : 2
-           indexed       : 1
-           offset        : 24
-       -attribute : component_id
-           type          : UINT64
-           idx           : 3
-           indexed       : 0
-           offset        : 32
-       -attribute : job_id
-           type          : UINT64
-           idx           : 4
-           indexed       : 0
-           offset        : 40
-       -attribute : AR_NIC_NETMON_ORB_EVENT_CNTR_REQ_PKTS
-           type          : UINT64
-           idx           : 5
-           indexed       : 0
-           offset        : 48
-       -attribute : AR_NIC_NETMON_ORB_EVENT_CNTR_REQ_FLITS
-           type          : UINT64
-           idx           : 6
-           indexed       : 0
-           offset        : 56
-       -attribute : AR_NIC_NETMON_ORB_EVENT_CNTR_REQ_STALLED
-           type          : UINT64
-           idx           : 7
-           indexed       : 0
-           offset        : 64
-     ...
-
-Looking at variable values in a container:
-------------------------------------------
-
-::
-
-   $ sos_cmd -C /NVME/0/LDMS -q -S aries_nic_mmr -X timestamp -V timestamp -V AR_NIC_NETMON_ORB_EVENT_CNTR_REQ_PKTS
-   timestamp                        AR_NIC_NETMON_ORB_EVENT_CNTR_REQ_PKTS
-   -------------------------------- ------------------
-                  1447449560.003480         1642207034
-                  1447449630.002155         1642213993
-                  1447449630.003115           88703749
-                  1447449630.003673           74768272
-                  1447449640.002818           74768367
-                  1447449640.003201           88703844
-                  1447449640.003249         1642214024
-                  1447449650.002885           74768402
-                  1447449650.003263         1642214059
-                  1447449650.003325           88703874
-                  1447449660.002954           74768511
-                  1447449660.003308         1642214174
-                  1447449660.003444           88703993
-                  1447449670.003015           74768547
-                  1447449670.003361         1642214205
-                  1447449670.003601           88704024
-                  1447449680.003081           74768582
 
 SEE ALSO
 ========
 
-:ref:`ldms(7) <ldms>`, :ref:`store_csv(7) <store_csv>`, :ref:`ldmsd_decomposition(7) <ldmsd_decomposition>`
+   :ref:`ldmsd(7) <ldmsd>`
+   :ref:`lmsd_decomposition(7) <ldmsd_decomposition>`
+   :ref:`sos-part(7) <sos-part>`

--- a/ldms/src/store/store_sos.c
+++ b/ldms/src/store/store_sos.c
@@ -114,7 +114,10 @@ typedef struct store_sos_s {
 	ovis_log_t log;
 	LIST_HEAD(sos_inst_list, sos_instance) inst_list;
 	char root_path[PATH_MAX]; /**< store root path */
-	time_t timeout;		  /* Default is forever */
+	time_t timeout;		/* Default is forever */
+	int mode;		/* mode mask for files in the container */
+	sos_perm_t backend;	/* backend storage strategy (MMAP | LSOS) */
+
 } *store_sos_t;
 
 /*
@@ -126,22 +129,22 @@ struct sos_instance {
 	char *container;
 	char *schema_name;
 	char *path; /**< <root_path>/<container> */
+	int mode;	/* mode mask for files in the container */
+	sos_perm_t backend;	/* backend storage strategy (MMAP | LSOS) */
 	sos_handle_t sos_handle; /**< sos handle */
 	sos_schema_t sos_schema;
-	int store_flags;
 	enum store_sos_mode {
 		STORE_SOS_M_NOT_SUPPORTED = -1,
 		STORE_SOS_M_BASIC = 0,
 		STORE_SOS_M_LISTS,
 		STORE_SOS_M_LAST
-	} mode;
+	} decomp_mode;
 	union {
 		struct sos_single_list_records slist;
 		struct sos_lists_of_records lrec;
 		struct sos_list_ctxt lists;
 	} ctxt;
 	pthread_mutex_t lock; /**< lock at metric store level */
-
 	int job_id_idx;
 	int comp_id_idx;
 	sos_attr_t ts_attr;
@@ -417,66 +420,6 @@ static sos_handle_t __create_handle(const char *path, sos_t sos)
 	return h;
 }
 
-/* caller must hold cfg_lock */
-static sos_handle_t __create_container(struct sos_instance *si)
-{
-	int rc = 0;
-	sos_t sos;
-	time_t t;
-	char part_name[16];	/* Unix timestamp as string */
-	sos_part_t part;
-	sos_handle_t h;
-	const char *path = si->path;
-
-	rc = sos_container_new(path, 0660);
-	if (rc) {
-		LOG_(si, OVIS_LERROR, "Error %d creating the container at '%s'\n",
-		       rc, path);
-		goto err_0;
-	}
-	sos = sos_container_open(path, SOS_PERM_RW);
-	if (!sos) {
-		LOG_(si, OVIS_LERROR, "Error %d opening the container at '%s'\n",
-		       errno, path);
-		goto err_0;
-	}
-	/*
-	 * Create the first partition. All other partitions and
-	 * rollover are handled with the SOS partition commands
-	 */
-	t = time(NULL);
-	sprintf(part_name, "%d", (unsigned int)t);
-	rc = sos_part_create(sos, part_name, path);
-	if (rc) {
-		LOG_(si, OVIS_LERROR, "Error %d creating the partition '%s' in '%s'\n",
-		       rc, part_name, path);
-		goto err_1;
-	}
-	part = sos_part_find(sos, part_name);
-	if (!part) {
-		LOG_(si, OVIS_LERROR, "Newly created partition was not found\n");
-		goto err_1;
-	}
-	rc = sos_part_state_set(part, SOS_PART_STATE_PRIMARY);
-	if (rc) {
-		LOG_(si, OVIS_LERROR, "New partition could not be made primary\n");
-		goto err_2;
-	}
-	sos_part_put(part);
-	h = __create_handle(path, sos);
-	if (!h)
-		goto err_1;
-	return h;
- err_2:
-	sos_part_put(part);
- err_1:
-	sos_container_close(sos, SOS_COMMIT_ASYNC);
- err_0:
-	if (rc)
-		errno = rc;
-	return NULL;
-}
-
 static void close_container(sos_handle_t h)
 {
 	assert(h->ref_count == 0);
@@ -519,27 +462,85 @@ static sos_handle_t __find_container(const char *path)
 static sos_handle_t get_container(struct sos_instance *si)
 {
 	sos_handle_t h = NULL;
-	const char *path = si->path;
 	sos_t sos;
+	sos_part_t part;
+	sos_part_iter_t iter = NULL;
+	time_t t;
+	int rc;
+	char part_name[32];	/* Unix timestamp as string */
+	const char *path = si->path;
 
 	pthread_mutex_lock(&cfg_lock);
 	h = __find_container(path);
 	if (h)
-		goto out;
-	/* See if the container exists, but has not been opened yet. */
-	sos = sos_container_open(path, SOS_PERM_RW);
-	if (sos) {
-		/* Create a new handle and add it for this SOS */
-		h = __create_handle(path, sos);
-		if (!h) {
-			sos_container_close(sos, SOS_COMMIT_ASYNC);
-			errno = ENOMEM;
-		}
-		goto out;
+		goto err_0;
+	/* Open/create the container */
+	sos = sos_container_open(path,
+		SOS_PERM_CREAT | SOS_PERM_RW | si->backend,
+		si->mode);
+	if (!sos) {
+		LOG_(si, OVIS_LERROR,
+			"Error %d opening the container at '%s'\n",
+			errno, path);
+		goto err_0;
 	}
-	/* the container does not exist, must create it */
-	h = __create_container(si);
- out:
+	/* Make certain the primary partion exists and is a timestamp */
+	iter = sos_part_iter_new(sos);
+	if (!iter) {
+		LOG_(si, OVIS_LERROR,
+			"Error %d creating partition iterator for container at '%s'\n",
+			errno, path);
+		goto err_0;
+	}
+	for (part = sos_part_first(iter); part; part = sos_part_next(iter)) {
+		/* Skip non-primary partitions*/
+		sos_part_state_t state = sos_part_state(part);
+		if (state != SOS_PART_STATE_PRIMARY)
+			continue;
+
+		const char *name = sos_part_name(part);
+		/* If the primary is the 'default' partition, create another
+		 * one with a 'timestamp' like name. */
+		if (0 != strcmp(name, "default"))
+			break;
+	}
+	if (part)
+		goto out;
+	/*
+	 * Create the first partition. All other partitions and
+	 * rollover are handled with the SOS partition commands
+	 */
+	t = time(NULL);
+	sprintf(part_name, "%u", (unsigned int)t);
+	rc = sos_part_create(sos, part_name, path);
+	if (rc) {
+		LOG_(si, OVIS_LERROR,
+			"Error %d creating the partition '%s' in '%s'\n",
+			rc, part_name, path);
+		goto err_0;
+	}
+	part = sos_part_find(sos, part_name);
+	if (!part) {
+		LOG_(si, OVIS_LERROR,
+			"Newly created partition was not found\n");
+		goto err_0;
+	}
+	rc = sos_part_state_set(part, SOS_PART_STATE_PRIMARY);
+	if (rc) {
+		LOG_(si, OVIS_LERROR,
+			"New partition could not be made primary\n");
+		goto err_0;
+	}
+out:
+	h = __create_handle(path, sos);
+	if (!h) {
+		LOG_(si, OVIS_LERROR,
+			"Memory allocation failure for path '%s'.\n",
+			path);
+	}
+	sos_part_put(part);
+	sos_part_iter_free(iter);
+err_0:
 	pthread_mutex_unlock(&cfg_lock);
 	return h;
 }
@@ -555,6 +556,8 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 	int len;
 	char *value;
 
+	pthread_mutex_lock(&ss->cfg_lock);
+
 	value = av_value(avl, "timeout");
 	if (value)
 		ss->timeout = strtol(value, NULL, 0);
@@ -564,12 +567,10 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 		LOG_(ss, OVIS_LERROR,
 		     "%s[%d]: The 'path' configuration option is required.\n",
 		     __func__, __LINE__);
-		return EINVAL;
-	}
-	pthread_mutex_lock(&ss->cfg_lock);
-	if (0 == strcmp(value, ss->root_path))
-		/* Ignore the call if the root_path is unchanged */
+		rc = EINVAL;
 		goto out;
+	}
+
 	len = strlen(value);
 	if (len >= PATH_MAX) {
 		LOG_(ss, OVIS_LERROR,
@@ -578,10 +579,40 @@ static int config(ldmsd_plug_handle_t handle, struct attr_value_list *kwl, struc
 		rc = ENAMETOOLONG;
 		goto out;
 	}
-	strcpy(ss->root_path, value);
+	strcpy(ss->root_path, strdup(value));
+
+	value = av_value(avl, "mode");
+	if (value) {
+		ss->mode = strtol(value, NULL, 0);
+		if (!ss->mode || ss->mode < 0 || ss->mode > 0777) {
+			LOG_(ss, OVIS_LERROR,
+			     "%s[%d]: Invalid permissions '%s'. Must be an octal value between 0600 and 777.\n",
+			     __func__, __LINE__, value);
+			rc = EINVAL;
+			goto out;
+		}
+	} else {
+		ss->mode = 0660;
+	}
+	value = av_value(avl, "backend");
+	if (value) {
+		if (0 == strcasecmp(value, "mmos")) {
+			ss->backend = SOS_BE_MMOS;
+		} else if (0 == strcasecmp(value, "lsos")) {
+			ss->backend = SOS_BE_LSOS;
+		} else {
+			LOG_(ss, OVIS_LERROR,
+			     "%s[%d]: Invalid backend '%s'. Valid values are 'mmos' and 'lsos'.\n",
+			     __func__, __LINE__, value);
+			rc = EINVAL;
+			goto out;
+		}
+	} else {
+		ss->backend = SOS_BE_MMOS;
+	}
 
 	/* Run through all open containers and close them. They will
-	 * get re-opened when store() is next called
+	 * get re-opened when store()/commit() is next called.
 	 */
 	rc = ENOMEM;
 	LIST_FOREACH(si, &ss->inst_list, entry) {
@@ -636,6 +667,8 @@ open_store(ldmsd_plug_handle_t handle, const char *container, const char *schema
 		goto out;
 	si->log = ss->log;
 	rbt_init(&si->schema_rbt, row_schema_rbn_cmp);
+	si->mode = ss->mode;
+	si->backend = ss->backend;
 	si->container = strdup(container);
 	if (!si->container)
 		goto err1;
@@ -915,7 +948,7 @@ _open_store(struct sos_instance *si, ldms_set_t set,
 	if (rc)
 		return rc;
 
-	/* Check if the container is already open */
+	/* Open/create the container */
 	si->sos_handle = get_container(si);
 	if (!si->sos_handle)
 		return errno;
@@ -1246,7 +1279,7 @@ __store_lists(struct sos_instance *si, ldms_set_t set,
 		goto err;
 	}
 	/*
-	 * store_sos doesn't store the data if one of the list is empty.
+	 * store_sos doesn't store the data if one of the lists is empty.
 	 */
 	for (i = 0; i < si->ctxt.lists.num_lists; i++) {
 		mid = si->ctxt.lists.list[i].list_mid;
@@ -1502,7 +1535,10 @@ static int init_store_instance(ldmsd_plug_handle_t handle, ldmsd_strgp_t strgp)
 		rc = errno;
 		goto err_0;
 	}
+	si->log = ss->log;
 	rbt_init(&si->schema_rbt, row_schema_rbn_cmp);
+	si->mode = ss->mode;
+	si->backend = ss->backend;
 	len = asprintf(&si->path, "%s/%s", ss->root_path, strgp->container);
 	if (len < 0) {
 		rc = errno;
@@ -1662,7 +1698,7 @@ commit_rows(ldmsd_plug_handle_t handle, ldmsd_strgp_t strgp,
 	sos_attr_t sos_attr;
 	int i, esz, array_len, count;
 
-	if (!strgp->store_handle) {
+	if (!strgp->store_handle) { /* protected by strgp->lock */
 		rc = init_store_instance(handle, strgp);
 		if (rc)
 			goto out;


### PR DESCRIPTION
Plugin configuration options were added to store_sos to allow for the specification of the LSOS backend in the ldmsd configuration file. Previously, this had to be done with an environment variable.

The ldmsd_controller output for the store_time_stats has also been improved to make the output more readable.