### PR TITLE
Fix Cython enum and performance hint hush

### DIFF
--- a/ldms/python/ldms.pxd
+++ b/ldms/python/ldms.pxd
@@ -308,7 +308,7 @@ cdef extern from "ldms.h" nogil:
         gid_t gid
 
     # --- xprt connection related --- #
-    cdef enum ldms_xprt_event_type:
+    cpdef enum ldms_xprt_event_type:
         EVENT_CONNECTED     "LDMS_XPRT_EVENT_CONNECTED"
         EVENT_REJECTED      "LDMS_XPRT_EVENT_REJECTED"
         EVENT_ERROR         "LDMS_XPRT_EVENT_ERROR"
@@ -341,7 +341,7 @@ cdef extern from "ldms.h" nogil:
         void * set
         const char *name
     cdef struct ldms_xprt_event:
-        int type
+        ldms_xprt_event_type type
         size_t data_len
         # data, and quota are in union. Cython doesn't care. It just want to
         # know the names of the "fields" it can access in C code.

--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -43,6 +43,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# cython: show_performance_hints=False
+
 from __future__ import print_function
 from cpython cimport PyObject, Py_INCREF, Py_DECREF, PyGILState_Ensure, \
                      PyGILState_Release, PyGILState_STATE, \

--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -515,20 +515,20 @@ def _msg_publish(Ptr x_ptr, name, data, msg_type=None,
     if msg_type is None:
         if _t is dict:
             # JSON
-            msg_type = ldms.LDMS_MSG_JSON
+            msg_type = LDMS_MSG_JSON
         elif _t in (str, bytes):
-            msg_type = ldms.LDMS_MSG_STRING
+            msg_type = LDMS_MSG_STRING
         else:
             raise TypeError(f"Cannot infer msg_type from the type of data ({type(data)})")
     # Avro/Serdes
-    if msg_type == ldms.LDMS_MSG_AVRO_SER:
+    if msg_type == LDMS_MSG_AVRO_SER:
         if not sr_client:
             raise ValueError(f"LDMS_MSG_AVRO_SER requires `sr_client`")
         if not schema_def:
             raise ValueError(f"LDMS_MSG_AVRO_SER requires `schema_def`")
         data = __avro_msg_data(sr_client, schema_def, data)
     # Json
-    if msg_type == ldms.LDMS_MSG_JSON and _t is dict:
+    if msg_type == LDMS_MSG_JSON and _t is dict:
         data = json.dumps(data)
 
     # uid
@@ -1541,10 +1541,10 @@ cdef class XprtEvent(object):
     def __cinit__(self, Ptr ptr):
         cdef ldms_xprt_event_t e = <ldms_xprt_event_t>ptr.c_ptr
         cdef ldms_set_t cset
-        self.type = ldms_xprt_event_type(e.type)
-        if self.type == ldms.LDMS_XPRT_EVENT_SEND_QUOTA_DEPOSITED:
+        self.type = e.type
+        if self.type == LDMS_XPRT_EVENT_SEND_QUOTA_DEPOSITED:
             self.quota = QuotaEventData(e.quota.quota, e.quota.ep_idx, e.quota.rc)
-        elif self.type == ldms.LDMS_XPRT_EVENT_SET_DELETE:
+        elif self.type == LDMS_XPRT_EVENT_SET_DELETE:
             cset = <ldms_set_t>e.set_delete.set
             lset = set_coll.get( ldms_set_id(cset), None )
             self.set_delete = SetDeleteEventData(lset, STR(e.set_delete.name))
@@ -3575,8 +3575,8 @@ cdef class Xprt(object):
     cdef list _threads # cached threads associated to xprt
 
     def __init__(self, name="sock", auth="none", auth_opts=None,
-                       rail_eps = 1, rail_recv_quota = ldms.RAIL_UNLIMITED,
-                       rail_rate_limit = ldms.RAIL_UNLIMITED,
+                       rail_eps = 1, rail_recv_quota = RAIL_UNLIMITED,
+                       rail_rate_limit = RAIL_UNLIMITED,
                        Ptr xprt_ptr=None,
                        rail_recv_limit = None # alias of rail_recv_quota
                        ):
@@ -4015,8 +4015,8 @@ cdef class Xprt(object):
         cdef int64_t q
         q = ldms_xprt_rail_recv_quota_get(self.xprt)
         if q < 0:
-            if q == ldms.LDMS_UNLIMITED:
-                return ldms.LDMS_UNLIMITED
+            if q == LDMS_UNLIMITED:
+                return LDMS_UNLIMITED
             else:
                 err = -q
                 raise RuntimeError(f"ldms_xprt_rail_recv_quota_set() error: {-err}")
@@ -4038,8 +4038,8 @@ cdef class Xprt(object):
 
     def get_send_rate_limit(self):
         cdef int64_t rate = ldms_xprt_rail_send_rate_limit_get(self.xprt)
-        if rate == ldms.LDMS_UNLIMITED:
-            return ldms.LDMS_UNLIMITED
+        if rate == LDMS_UNLIMITED:
+            return LDMS_UNLIMITED
         if rate < 0:
             raise RuntimeError(f"ldms_xprt_rail_send_rate_limit_get() error: {-rate}")
         return rate
@@ -4050,8 +4050,8 @@ cdef class Xprt(object):
 
     def get_recv_rate_limit(self):
         cdef int64_t rate = ldms_xprt_rail_recv_rate_limit_get(self.xprt)
-        if rate == ldms.LDMS_UNLIMITED:
-            return ldms.LDMS_UNLIMITED
+        if rate == LDMS_UNLIMITED:
+            return LDMS_UNLIMITED
         if rate < 0:
             raise RuntimeError(f"ldms_xprt_rail_recv_rate_limit_get() error: {-rate}")
         return rate
@@ -4504,7 +4504,7 @@ cdef class MsgData(object):
             tid = threading.get_ident()
         obj = MsgData(name, src, tid, uid, gid, perm, is_json, data,
                          raw_data,
-                         ldms.ldms_msg_type_e(ev.recv.type))
+                         ldms_msg_type_e(ev.recv.type))
         return obj
 
 cdef int __msg_client_cb(ldms_msg_event_t ev, void *arg) with gil:


### PR DESCRIPTION
- Cython 3.0.x gave UserWarning about enum class not importable from ldms.
  This was caused by accessing the enumeration values with 'ldms.' prefix
  in ldms.pyx. The enum values and enum classes were cimported from
  ldms.pxd and does not need 'ldms.' prefix.

- Also change 'cdef enum ldms_xprt_event_type' to cpdef as we are also
  exporting the enum class to Python.

- Hush Cython performance hint, we have to hold the GIL in the callback as we work with Python objects.