### PR TITLE
removing jinja2 from docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,6 @@ sphinxcontrib-spelling
 sphinx-rtd-theme>=1.0.0
 sphinx-copybutton
 docutils
-Jinja2<3.1
 markupsafe==2.0.1
 sphinx_immaterial
 pydantic


### PR DESCRIPTION
Jinja2 is not needed for the LDMS documentation build, so it has been removed to resolve the security warning in Github.