### PR TITLE
Fix papi_sampler SIGSEGV down inside libpapi

### DIFF
--- a/ldms/src/sampler/papi/papi_sampler.c
+++ b/ldms/src/sampler/papi/papi_sampler.c
@@ -836,6 +836,8 @@ static int stream_recv_cb(ldms_msg_event_t ev, void *ctxt)
 		return EINVAL;
 	}
 
+	PAPI_register_thread();
+
 	event = json_attr_find(ev->recv.json, "event");
 	if (!event) {
 		ovis_log(mylog, OVIS_LERROR, "'event' attribute missing\n");


### PR DESCRIPTION
`PAPI_register_thread(3)` manpage claimed that the call is *usually* not necessary as PAPI implicitly detects. However, our `PAPI_event_name_to_code()` call in papi_sampler from an LDMS IO thread yields SIGSEGV from inside libpapi. In particular, `_papi_hwi_my_thread->tls_papi_event_code = -1` in `_papi_hwi_set_papi_event_code()` subsequent call inside libpapi caused SIGSEGV because `_papi_hwi_my_thread` is `NULL` -- indicating that the `_papi_hwi_my_thread` per-thread variable is not initialized. The variable can be initialize by calling `PAPI_register_thread()`.