### PR TITLE
fix file descriptor leak in b4.5

### DIFF
--- a/ldms/python/ldmsd/ldmsd_util.py
+++ b/ldms/python/ldmsd/ldmsd_util.py
@@ -530,6 +530,8 @@ class LDMSD_Controller(object):
                           close_fds = True,
                           shell = True
                           )
+        # close the slave fd
+        os.close(_sfd)
         if self.term_immediately:
             return
         time.sleep(0.5)


### PR DESCRIPTION
We never close the slave descriptor in this code path. This translates into resource leaks.