### PR TITLE
Catch non-positive sampling interval in ldmsd

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -1040,6 +1040,11 @@ int ldmsd_sampler_start(char *cfg_name, char *interval, char *offset,
 	if (rc)
 		goto out;
 
+	if (sample_interval <= 0) {
+		rc = EINVAL;
+		goto out;
+	}
+
 	samp->sample_interval_us = sample_interval;
 	if (offset) {
 		rc = ovis_time_str2us(offset, &sample_offset);


### PR DESCRIPTION
The sampling interval should only be positive.