### PR TITLE
The test for ipv6 not only checks for AF_INET6 and opens a test socke…

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -111,8 +111,6 @@ static struct {
 } ldms_zap_tbl[16] = {{0}};
 static int ldms_zap_tbl_n = 0;
 
-static int ipv6_enabled;
-
 static char *xprt_event_type_names[] = {
 	[LDMS_XPRT_EVENT_CONNECTED] = "CONNECTED",
 	[LDMS_XPRT_EVENT_REJECTED] = "REJECTED",
@@ -4743,7 +4741,7 @@ int ldms_xprt_listen_by_name(ldms_t x, const char *host, const char *port_no,
 	ai = ai_list;
 	if (ai->ai_family == AF_INET) {
 		struct sockaddr_in *sin = (void*)ai->ai_addr;
-		if (sin->sin_addr.s_addr == INADDR_ANY && ipv6_enabled) {
+		if (sin->sin_addr.s_addr == INADDR_ANY) {
 			/*
 			 * Special ANY address case. `getaddrinfo()` returned
 			 * IPv4 before IPv6. We prefer IP6 for ANY address as it
@@ -4753,8 +4751,13 @@ int ldms_xprt_listen_by_name(ldms_t x, const char *host, const char *port_no,
 			 */
 			_ai = ai; /* save it */
 			for(; ai; ai = ai->ai_next) {
-				if (ai->ai_family == AF_INET6)
+				if (ai->ai_family == AF_INET6) {
+					int test_sock = socket(AF_INET6, SOCK_STREAM, 0);
+					if (test_sock < 0)
+						continue;
+					close(test_sock);
 					break;
+				}
 			}
 			if (!ai)
 				ai = _ai;
@@ -4995,16 +4998,6 @@ static void __attribute__ ((constructor)) cs_init(void)
 	pthread_mutex_init(&xprt_list_lock, 0);
 	pthread_mutex_init(&ldms_zap_list_lock, 0);
 	(void)clock_gettime(CLOCK_REALTIME, &xprt_start);
-
-	/* check if IPv6 is supported */
-	int sd;
-	sd = socket(AF_INET6, SOCK_STREAM, 0);
-	if (sd >= 0) {
-		close(sd);
-		ipv6_enabled = 1;
-	} else {
-		ipv6_enabled = 0;
-	}
 }
 
 static void __attribute__ ((destructor)) cs_term(void)


### PR DESCRIPTION
I am trying to run ldmsd on a system where ipv6 has been disabled on the node,  using the tag: v4.5.3, and it crashes with return code -7.

Via gdb i see **ldms_xprt_listen_by_name()** calls **getaddrinfo**(NULL, "6001", ...), which returns both an **AF_INET** and **AF_INET6**, but the "prefer IPv6 for ANY" logic in ldms_xprt.c selects the **AF_INET6** entry, specifically because it assumes IPv6 works (based on the **ipv6_enabled** flag set by the **cs_init()** constructor's own probe, which doesn't test if a socket can really be created). That address gets passed down to **z_sock_listen()**, which calls **socket(AF_INET6, SOCK_STREAM, 0)**, and in my kubernetes pod, where the k8s worker has a kernel cmdline **ipv6.disable=1**, that call fails with **EAFNOSUPPORT**, returning **ZAP_ERR_RESOURCE (7)**, which propagates all the way up and crashes the daemon.

This patch replaces **ipv6_enabled** with a socket test after choosing AF_INET6.