### PR TITLE
Fix ldms_xprt_listen() for IPv6

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -114,8 +114,6 @@ static struct {
 } ldms_zap_tbl[16] = {{0}};
 static int ldms_zap_tbl_n = 0;
 
-static int ipv6_enabled;
-
 static char *xprt_event_type_names[] = {
 	[LDMS_XPRT_EVENT_CONNECTED] = "CONNECTED",
 	[LDMS_XPRT_EVENT_REJECTED] = "REJECTED",
@@ -4867,7 +4865,7 @@ int ldms_xprt_listen_by_name(ldms_t x, const char *host, const char *port_no,
 	ai = ai_list;
 	if (ai->ai_family == AF_INET) {
 		struct sockaddr_in *sin = (void*)ai->ai_addr;
-		if (sin->sin_addr.s_addr == INADDR_ANY && ipv6_enabled) {
+		if (sin->sin_addr.s_addr == INADDR_ANY) {
 			/*
 			 * Special ANY address case. `getaddrinfo()` returned
 			 * IPv4 before IPv6. We prefer IP6 for ANY address as it
@@ -4877,8 +4875,13 @@ int ldms_xprt_listen_by_name(ldms_t x, const char *host, const char *port_no,
 			 */
 			_ai = ai; /* save it */
 			for(; ai; ai = ai->ai_next) {
-				if (ai->ai_family == AF_INET6)
+				if (ai->ai_family == AF_INET6) {
+					int test_sock = socket(AF_INET6, SOCK_STREAM, 0);
+					if (test_sock < 0)
+						continue;
+					close(test_sock);
 					break;
+				}
 			}
 			if (!ai)
 				ai = _ai;
@@ -5156,16 +5159,6 @@ static void __attribute__ ((constructor)) cs_init(void)
 	pthread_mutex_init(&xprt_list_lock, 0);
 	pthread_mutex_init(&ldms_zap_list_lock, 0);
 	(void)clock_gettime(CLOCK_REALTIME, &xprt_start);
-
-	/* check if IPv6 is supported */
-	int sd;
-	sd = socket(AF_INET6, SOCK_STREAM, 0);
-	if (sd >= 0) {
-		close(sd);
-		ipv6_enabled = 1;
-	} else {
-		ipv6_enabled = 0;
-	}
 
 	for (op_e = 0; op_e < LDMS_XPRT_OP_COUNT; op_e++) {
 		ovis_histogram_init(&xprt_op_hist[op_e].hist, 0, 0,


### PR DESCRIPTION
We should check IPv6 support every time for ldms_xprt_listen(). Evidently from @jstile-lbl k8s environment, `cs_init()` successfully create an IPv6 socket, but then later `z_sock_listen()` failed to create an IPv6 socket with the same parameter.

This is a port to main branch from @jstile-lbl PR #2380 on b4.5 branch.