### PR TITLE
Catch non-positive sampling interval in ldmsd

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -1058,6 +1058,11 @@ int ldmsd_sampler_start(const char *cfg_name, const char *interval, const char *
 	if (rc)
 		goto out;
 
+	if (sample_interval <= 0) {
+		rc = EINVAL;
+		goto out;
+	}
+
 	samp->sample_interval_us = sample_interval;
 	if (offset) {
 		rc = ovis_time_str2us(offset, &sample_offset);


### PR DESCRIPTION
The sampling interval should only be positive.